### PR TITLE
 Get file version of assembly

### DIFF
--- a/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Fx.Portability.Analyzer
             _assemblyLocation = assemblyPath;
 
             MemberDependency = new List<MemberDependency>();
-            CallingAssembly = _reader.GetAssemblyInfo();
+            CallingAssembly = _reader.GetAssemblyInfo(assemblyPath);
 
             // Get assembly info
             var assemblyDefinition = _reader.GetAssemblyDefinition();

--- a/src/Microsoft.Fx.Portability.MetadataReader/MetadataReaderExtensions.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MetadataReaderExtensions.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Fx.Portability.ObjectModel;
 using System;
+using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Security.Cryptography;
 
@@ -10,13 +11,15 @@ namespace Microsoft.Fx.Portability
 {
     internal static class MetadataReaderExtensions
     {
-        public static AssemblyInfo GetAssemblyInfo(this MetadataReader metadataReader)
+        public static AssemblyInfo GetAssemblyInfo(this MetadataReader metadataReader, string filePath)
         {
-            // TODO: Find FileVersion and TFM of assembly
+            var fileInfo = FileVersionInfo.GetVersionInfo(filePath);
+
+            // TODO: Find TFM of assembly
             return new AssemblyInfo
             {
                 AssemblyIdentity = metadataReader.FormatAssemblyInfo(metadataReader.GetAssemblyDefinition()),
-                FileVersion = string.Empty,
+                FileVersion = fileInfo.FileVersion ?? string.Empty,
                 TargetFrameworkMoniker = string.Empty
             };
         }


### PR DESCRIPTION
This uses System.Diagnostics.FileVersionInfo.GetVersionInfo to get the file version of the assembly.  This is equivalent to finding the custom attribute and is much easier.
