### PR TITLE
Track whether MemberInfos are primitive types explicitly

### DIFF
--- a/src/Microsoft.Fx.Portability.MetadataReader/MemberDependency.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MemberDependency.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Fx.Portability.Analyzer
         private string _definedInAssemblyIdentity;
         private string _memberDocId;
         private string _typeDocId;
+        private bool _isPrimitive;
 
         /// <summary>
         /// This represents the assembly that is calling the member
@@ -29,6 +30,19 @@ namespace Microsoft.Fx.Portability.Analyzer
             set
             {
                 _definedInAssemblyIdentity = value;
+                _hashComputed = false;
+            }
+        }
+
+        /// <summary>
+        /// This indicates whether or not the dependency is a primitive type
+        /// </summary>
+        public bool IsPrimitive
+        {
+            get { return _isPrimitive; }
+            set
+            {
+                _isPrimitive = value;
                 _hashComputed = false;
             }
         }
@@ -66,14 +80,15 @@ namespace Microsoft.Fx.Portability.Analyzer
 
             return StringComparer.Ordinal.Equals(MemberDocId, other.MemberDocId) &&
                     StringComparer.Ordinal.Equals(DefinedInAssemblyIdentity, other.DefinedInAssemblyIdentity) &&
-                    CallingAssembly.Equals(other.CallingAssembly);
+                    CallingAssembly.Equals(other.CallingAssembly) &&
+                    IsPrimitive == other.IsPrimitive;
         }
 
         public override int GetHashCode()
         {
             if (!_hashComputed)
             {
-                _hashCode = ((DefinedInAssemblyIdentity ?? string.Empty) + (MemberDocId ?? string.Empty)).GetHashCode() ^ CallingAssembly.GetHashCode();
+                _hashCode = ((DefinedInAssemblyIdentity ?? string.Empty) + (MemberDocId ?? string.Empty) + IsPrimitive.ToString()).GetHashCode() ^ CallingAssembly.GetHashCode();
                 _hashComputed = true;
             }
             return _hashCode;

--- a/src/Microsoft.Fx.Portability.MetadataReader/ReflectionMetadataDependencyInfo.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/ReflectionMetadataDependencyInfo.cs
@@ -69,6 +69,11 @@ namespace Microsoft.Fx.Portability.Analyzer
                             DefinedInAssemblyIdentity = dependencies.DefinedInAssemblyIdentity
                         };
 
+                        if (m.DefinedInAssemblyIdentity == null && !dependencies.IsPrimitive)
+                        {
+                            throw new InvalidOperationException("All non-primitive types should be defined in an assembly");
+                        }
+
                         // Add this memberinfo
                         var newassembly = new HashSet<AssemblyInfo> { dependencies.CallingAssembly };
 

--- a/src/Microsoft.Fx.Portability/Analysis/AnalysisEngine.cs
+++ b/src/Microsoft.Fx.Portability/Analysis/AnalysisEngine.cs
@@ -132,7 +132,11 @@ namespace Microsoft.Fx.Portability.Analysis
 
         private bool MemberIsInFramework(MemberInfo dep)
         {
-            return _catalog.IsFrameworkAssembly(GetAssemblyIdentityWithoutCultureAndVersion(dep.DefinedInAssemblyIdentity)) && _catalog.IsFrameworkMember(dep.MemberDocId);
+            // A null 'DefinedInAssemblyIdentity is indicative of a primitive
+            // type, which should always be considered within the Framework.
+            // For non-primitive types, consult the catalog to determine whether the
+            // assembly and API in question are part of the Framework.
+            return (dep.DefinedInAssemblyIdentity == null) || (_catalog.IsFrameworkAssembly(GetAssemblyIdentityWithoutCultureAndVersion(dep.DefinedInAssemblyIdentity)) && _catalog.IsFrameworkMember(dep.MemberDocId));
         }
 
         /// <summary>


### PR DESCRIPTION
Using the metadata reader, primitive types were often (always?) returned without containing-assembly information. That caused our current scheme of using '_assemblyInfoForPrimitives' to not work. The 'defined in assembly' field would end up null, leading to argument null exceptions later.

This change removes that field and, instead, adds an explicit bool to MemberDependency and MemberInfo to track whether a type is primitive. The analysis engine is then updated to consider that field before looking at DefinedInAssembly (which will be null for primitives).

Fixes Microsoft/dotnet-apiport#42
