### PR TITLE
Enable target mapper map verification

### DIFF
--- a/src/Microsoft.Fx.Portability-net45/Microsoft.Fx.Portability-net45.csproj
+++ b/src/Microsoft.Fx.Portability-net45/Microsoft.Fx.Portability-net45.csproj
@@ -48,9 +48,10 @@
     <Compile Include="..\Microsoft.Fx.Portability\**\*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\Microsoft.Fx.Portability\Targets.xsd">
+    <EmbeddedResource Include="..\Microsoft.Fx.Portability\Targets.xsd">
       <Link>Targets.xsd</Link>
-    </None>
+      <LogicalName>Targets.xsd</LogicalName>
+    </EmbeddedResource>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Fx.Portability/TargetMapper.cs
+++ b/src/Microsoft.Fx.Portability/TargetMapper.cs
@@ -90,10 +90,10 @@ namespace Microsoft.Fx.Portability
             {
                 var doc = XDocument.Load(XmlReader.Create(stream));
 
-#if DESKTOP && HAS_RESOURCES
-               // Validate against schema
+#if DESKTOP
+                // Validate against schema
                 var schemas = new XmlSchemaSet();
-                schemas.Add(null, XmlReader.Create(typeof(TargetMapper).Assembly.GetManifestResourceStream(typeof(TargetMapper), "Targets.xsd")));
+                schemas.Add(null, XmlReader.Create(typeof(TargetMapper).Assembly.GetManifestResourceStream("Targets.xsd")));
                 doc.Validate(schemas, (s, e) => { throw new TargetMapperException(e.Message, e.Exception); });
 #endif
 

--- a/src/Microsoft.Fx.Portability/project.json
+++ b/src/Microsoft.Fx.Portability/project.json
@@ -9,6 +9,9 @@
     "Resources\\LocalizedStrings.Designer.cs",
     "Resources\\LocalizedStrings.resx"
   ],
+  "resource": [
+    "Targets.xsd"
+  ],
   "scripts": {
     "prebuild": [
       "powershell -NoProfile -ExecutionPolicy unrestricted -file %project:Directory%\\..\\..\\CreateLocalizedStrings.ps1 %project:Directory%\\Resources"

--- a/tests/Microsoft.Fx.Portability.Tests/TargetMapTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/TargetMapTests.cs
@@ -319,7 +319,6 @@ namespace Microsoft.Fx.Portability.Tests
             Assert.True(false, "Expected exception was not thrown");
         }
 
-#if HAS_RESOURCES
         [Fact]
         public void XmlNotInSchema()
         {
@@ -342,7 +341,6 @@ namespace Microsoft.Fx.Portability.Tests
 
             Assert.True(false, "Expected exception was not thrown");
         }
-#endif
 
         [Fact]
         public void XmlGetAlias()


### PR DESCRIPTION
The way that DNX handles resources is different than previous
csproj projects. This enables Targets.xsd to be included as a
resource to be used for validation of TargetMap.xml files.
