### PR TITLE
Support __arglist parameters

### DIFF
--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -42,6 +42,15 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             CompareSpecificDependency(TestAssembly.ModsFromIL, expected2);
         }
 
+        [Fact]
+        public void Arglist()
+        {
+            const string expected = "M:TestClass.ArglistMethod(System.Int32,__arglist)";
+            const string expected2 = "M:TestClass.ArglistMethod2(__arglist)";
+            CompareSpecificDependency(TestAssembly.Arglist, expected);
+            CompareSpecificDependency(TestAssembly.Arglist, expected2);
+        }
+
         [Fact(Skip = "Requires an updated version of System.Reflection.Metadata")]
         public void GenericWithGenericMember()
         {

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReflectionMetadataInfoTests.cs" />
     <Compile Include="TestAssembly.cs" />
+    <EmbeddedResource Include="Tests\Arglist.cs" />
     <EmbeddedResource Include="Tests\modopt.dll" />
     <EmbeddedResource Include="Tests\modopt.il" />
     <EmbeddedResource Include="Tests\NestedGenericTypes.cs" />

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/TestAssembly.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/TestAssembly.cs
@@ -78,6 +78,15 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
 
         public string AssemblyPath { get { return _path; } }
 
+        public static string Arglist
+        {
+            get
+            {
+                var text = GetText("Arglist.cs");
+                return new TestAssembly("Arglist", text, new[] { s_mscorlib }).AssemblyPath;
+            }
+        }
+
         public static string EmptyProject
         {
             get

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Tests/Arglist.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Tests/Arglist.cs
@@ -1,0 +1,16 @@
+﻿public class TestClass
+{
+    public static void ArglistMethod(int i, __arglist)
+    {
+    }
+
+    public static void ArglistMethod2(__arglist)
+    {
+    }
+
+    public static void Main(string[] args)
+    {
+        ArglistMethod(5, __arglist(1, 2, 3));
+        ArglistMethod2(__arglist());
+    }
+}


### PR DESCRIPTION
Change our formatting of method DocIDs to only list required parameters explicitly and to use __arglist for any optional parameters. Also adds a regression test for this case.

Fixes Microsoft/dotnet-apiport#70
