### PR TITLE
Fix Microsoft.Fx.Portability.Tests to use the latest dnx versions of xunit

### DIFF
--- a/tests/Microsoft.Fx.Portability.Tests/project.json
+++ b/tests/Microsoft.Fx.Portability.Tests/project.json
@@ -5,11 +5,11 @@
   "dependencies": {
     "NSubstitute": "1.8.1.0",
     "Microsoft.Fx.Portability": "",
-    "xunit": "2.0.0-aspnet-beta5-*",
-    "xunit.runner.aspnet": "2.0.0-aspnet-beta5-*"
+    "xunit": "2.1.0-*",
+    "xunit.runner.dnx": "2.1.0-*"
   },
   "commands": {
-    "test": "xunit.runner.aspnet"
+    "test": "xunit.runner.dnx"
   },
   "frameworks": {
     "dnx451": {


### PR DESCRIPTION
The key is that we need to be using xunit.runner.dnx now (once we do that, the latest xunit bits 'just work').
