### PR TITLE
Add check for op_Implicit and op_Explicit specialname

### DIFF
--- a/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfo.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfo.cs
@@ -258,12 +258,13 @@ namespace Microsoft.Fx.Portability.Analyzer
                 // Only required parameters should be listed explicitly
                 Debug.Assert(MethodSignature.ParameterTypes.Count() >= MethodSignature.RequiredParameterCount, "More parameters were required than are available");
                 sb.Append(string.Join(",", MethodSignature.ParameterTypes.Select(m => m.ToString()).ToArray(), 0, MethodSignature.RequiredParameterCount));
-                
+
                 // If the method is a varargs method, it should add an '__arglist' parameter
                 if (MethodSignature.Header.CallingConvention.HasFlag(SignatureCallingConvention.VarArgs))
                 {
                     sb.Append(",__arglist");
                 }
+
                 sb.Append(")");
             }
             else if (Kind == MemberKind.Method && MethodSignature.Header.CallingConvention.HasFlag(SignatureCallingConvention.VarArgs))
@@ -272,7 +273,11 @@ namespace Microsoft.Fx.Portability.Analyzer
                 sb.Append("(__arglist)");
             }
 
-            if (string.Equals(Name, "op_Implicit", StringComparison.Ordinal) || string.Equals(Name, "op_Explicit", StringComparison.Ordinal))
+            // Technically, we want to verify that these are marked as a special name along with the names op_Implicit or op_Explicit.  However, 
+            // since we are just using member references, we don't have enought information to know if it is.  For now, we will assume that it is 
+            // a special name if it only has one input parameter
+            if (MethodSignature.ParameterTypes.Length == 1 &&
+                (string.Equals(Name, "op_Implicit", StringComparison.Ordinal) || string.Equals(Name, "op_Explicit", StringComparison.Ordinal)))
             {
                 sb.Append("~");
                 sb.Append(MethodSignature.ReturnType);

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -80,6 +80,23 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             CompareSpecificDependency(TestAssembly.OpImplicit, expected);
         }
 
+        [Fact]
+        public void OpImplicitMethod()
+        {
+            // This is case where we mark it as a special name when it really isn't. Don't have the info to fix with just member refs
+            const string expected = "M:Microsoft.Fx.Portability.MetadataReader.Tests.OpImplicit_Method`1.op_Implicit(`0)~System.Int32";
+
+            CompareSpecificDependency(TestAssembly.OpImplicitMethod, expected);
+        }
+
+        [Fact]
+        public void OpImplicitMethod2Parameter()
+        {
+            const string expected = "M:Microsoft.Fx.Portability.MetadataReader.Tests.OpImplicit_Method_2Parameter`1.op_Implicit(`0,`0)";
+
+            CompareSpecificDependency(TestAssembly.OpImplicitMethod2Parameter, expected);
+        }
+
         [Fact(Skip = "Requires an updated version of System.Reflection.Metadata")]
         public void OpExplicit()
         {

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
@@ -85,6 +85,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReflectionMetadataInfoTests.cs" />
     <Compile Include="TestAssembly.cs" />
+    <EmbeddedResource Include="Tests\OpImplicitMethod2Parameter.cs" />
+    <EmbeddedResource Include="Tests\OpImplicitMethod.cs" />
     <EmbeddedResource Include="Tests\Arglist.cs" />
     <EmbeddedResource Include="Tests\modopt.dll" />
     <EmbeddedResource Include="Tests\modopt.il" />

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/TestAssembly.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/TestAssembly.cs
@@ -168,6 +168,24 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             }
         }
 
+        public static string OpImplicitMethod
+        {
+            get
+            {
+                var text = GetText("OpImplicitMethod.cs");
+                return new TestAssembly("OpImplicitMethod", text, new[] { s_mscorlib }).AssemblyPath;
+            }
+        }
+
+        public static string OpImplicitMethod2Parameter
+        {
+            get
+            {
+                var text = GetText("OpImplicitMethod2Parameter.cs");
+                return new TestAssembly("OpImplicitMethod2Parameter", text, new[] { s_mscorlib }).AssemblyPath;
+            }
+        }
+
         public static string OpExplicit
         {
             get

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Tests/OpImplicitMethod.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Tests/OpImplicitMethod.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Fx.Portability.MetadataReader.Tests
+{
+    internal class OpImplicit_Method
+    {
+        private static void Main(string[] args)
+        {
+            var method = new OpImplicit_Method<int>();
+
+            method.op_Implicit(1);
+        }
+    }
+
+    internal struct OpImplicit_Method<T>
+    {
+        public int op_Implicit(T other)
+        {
+            return 0;
+        }
+    }
+}

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Tests/OpImplicitMethod2Parameter.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Tests/OpImplicitMethod2Parameter.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Fx.Portability.MetadataReader.Tests
+{
+    internal class OpImplicit_Method_2Parameter
+    {
+        private static void Main(string[] args)
+        {
+            var method = new OpImplicit_Method_2Parameter<int>();
+
+            method.op_Implicit(1, 2);
+        }
+    }
+
+    internal struct OpImplicit_Method_2Parameter<T>
+    {
+        public int op_Implicit(T arg1, T arg2)
+        {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
This adds a heuristic to determine if op_Implicit and op_Explicit are
special names by determining how many parameters they have and
restricting it to be a special name if it only has one input parameter

Fixes #51
