### PR TITLE
Add offline execution via Microsoft.Fx.Portability.Offline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ rcf
 *.swp
 .vs
 project.lock.json
+src/Microsoft.Fx.Portability.Offline/data/

--- a/Documentation/BreakingChanges/! Template.md
+++ b/Documentation/BreakingChanges/! Template.md
@@ -1,0 +1,34 @@
+## ID: Breaking Change Title
+
+### Scope
+Major
+
+### Version Introduced
+4.5
+
+### Version Reverted
+4.6
+
+### Change Description
+Description goes here.
+
+- [ ] Quirked
+- [ ] Build-time break
+- [ ] Source analyzer available
+
+### Recommended Action
+Suggested steps if user is affected (such as work arounds or code fixes) go here.
+
+### Affected APIs
+* Not detectable via API analysis
+
+[More information](LinkForMoreInformation)
+
+<!--
+    ### Original Bug
+    Bug link goes here
+    ### Notes
+    Source analyzer status: Not usefully detectable with an analyzer
+-->
+
+

--- a/Documentation/BreakingChanges/001- SoapFormatter cannot deserialize Hashtable and sim.md
+++ b/Documentation/BreakingChanges/001- SoapFormatter cannot deserialize Hashtable and sim.md
@@ -1,0 +1,34 @@
+## 1: SoapFormatter cannot deserialize Hashtable and similar ordered collection objects
+
+### Scope
+Minor
+
+### Version Introduced
+4.5
+
+### Change Description
+The SoapFormatter does not guarantee that objects serialized under one .NET Framework version will successfully deserialize under a different version. Specifically, some ordered collections (like Hashtable) added members between 4.0 and 4.5 such that objects of these types cannot deserialize with .NET 4.0 if they were serialzied with .NET 4.5.  
+Note that if the serialized data is both serialized and deserialized with the same .NET Framework version, no issue will occur.
+
+- [ ] Quirked
+- [ ] Build-time break
+- [ ] Source analyzer available
+
+### Recommended Action
+SoapFormatter serialization should be replaced with BinaryFormatter serialization or NetDataContractSerialization to be resilient to .NET Framework changes.
+
+### Affected APIs
+* M:System.Runtime.Serialization.Formatters.Soap.SoapFormatter.Serialize(System.IO.Stream,System.Object)
+* M:System.Runtime.Serialization.Formatters.Soap.SoapFormatter.Serialize(System.IO.Stream,System.Object,System.Runtime.Remoting.Messaging.Header[])
+* M:System.Runtime.Serialization.Formatters.Soap.SoapFormatter.Deserialize(System.IO.Stream)
+* M:System.Runtime.Serialization.Formatters.Soap.SoapFormatter.Deserialize(System.IO.Stream,System.Runtime.Remoting.Messaging.HeaderHandler)
+
+[More information](https://msdn.microsoft.com/en-us/library/hh367887\(v=vs.110\).aspx#core)
+
+<!--
+    ### Notes
+    Somewhat expensive to detect given the need to figure out the returned type.
+    Source analyzer status: Pri 1, NOT DONE
+-->
+
+

--- a/Documentation/BreakingChanges/003- WPF DataTemplate elements are now visible to UIA.md
+++ b/Documentation/BreakingChanges/003- WPF DataTemplate elements are now visible to UIA.md
@@ -1,0 +1,31 @@
+## 3: WPF DataTemplate elements are now visible to UIA
+
+### Scope
+Edge
+
+### Version Introduced
+4.5
+
+### Change Description
+Previously, DataTemplate elements were invisible to UI Automation. Beginning in 4.5, UI Automation will detect these elements. This is useful in many cases, but can break tests that depend on UIA trees not containing DataTemplate elements.
+
+- [ ] Quirked
+- [ ] Build-time break
+- [x] Source analyzer available
+
+### Recommended Action
+UI Auomation tests for this app may need updated to account for the UIA tree now including previously invisible DataTemplate elements. For example, tests that expect some elements to be next to each other may now need to expect previously invisible UIA elements in between. Or tests that rely on certain counts or indexes for UIA elements may need updated with new values.
+
+### Affected APIs
+* M:System.Windows.DataTemplate.#ctor
+* M:System.Windows.DataTemplate.#ctor(System.Object)
+
+[More information](https://msdn.microsoft.com/en-us/library/hh367887\(v=vs.110\).aspx#wpf)
+
+<!--
+    ### Notes
+    Who knows if they're using UIA, but we probably ought to give informational issue if they have DataTemplates
+    Source analyzer status: Pri 1, source done 
+-->
+
+

--- a/Documentation/BreakingChanges/004- WPF TextBox selected text appears a different colo.md
+++ b/Documentation/BreakingChanges/004- WPF TextBox selected text appears a different colo.md
@@ -1,0 +1,30 @@
+## 4: WPF TextBox selected text appears a different color when the text box is inactive
+
+### Scope
+Edge
+
+### Version Introduced
+4.5
+
+### Change Description
+In .NET 4.5, when a WPF text box control is inactive (it doesn't have focus), the selected text inside the box will appear a different color than when the control is active.
+
+- [ ] Quirked
+- [ ] Build-time break
+- [x] Source analyzer available
+
+### Recommended Action
+Previous (.NET 4.0) behavior may be restored by setting the <a href="https://msdn.microsoft.com/en-us/library/system.windows.frameworkcompatibilitypreferences.areinactiveselectionhighlightbrushkeyssupported(v=vs.110).aspx">FrameworkCompatibilityPreferences.AreInactiveSelectionHighlightBrushKeysSupported</a> property to false.
+
+### Affected APIs
+* T:System.Windows.Controls.TextBox
+
+[More information](https://msdn.microsoft.com/en-us/library/hh367887\(v=vs.110\).aspx#wpf)
+
+<!--
+    ### Notes
+    May as well give an informational issue about this since it's so easy to detect and has a workaround
+    Source analyzer status: Pri 1, source done
+-->
+
+

--- a/Documentation/BreakingChanges/005- ListT.ForEach.md
+++ b/Documentation/BreakingChanges/005- ListT.ForEach.md
@@ -1,0 +1,30 @@
+## 5: List<T>.ForEach
+
+### Scope
+Edge
+
+### Version Introduced
+4.5
+
+### Change Description
+Beginning in .NET 4.5, a List&lt;T&gt;.ForEach enumerator will throw an InvalidOperationException exception if an element in the calling collection is modified. Previously, this would not throw an exception but could lead to race conditions.
+
+- [x] Quirked
+- [ ] Build-time break
+- [x] Source analyzer available
+
+### Recommended Action
+Ideally, code should be fixed to not modify lists while enumerating their elements because that is never a safe operation. To revert to the previous behavior, though, an app may target .NET 4.0.
+
+### Affected APIs
+* M:System.Collections.Generic.List`1.ForEach(System.Action{`0})
+
+[More information](https://msdn.microsoft.com/en-us/library/hh367887\(v=vs.110\).aspx#core)
+
+<!--
+    ### Notes
+    This introduces an exception, but requires retargeting
+    Source analyzer status: Pri 1, source done
+-->
+
+

--- a/Documentation/BreakingChanges/006- System.Uri.md
+++ b/Documentation/BreakingChanges/006- System.Uri.md
@@ -1,0 +1,37 @@
+## 6: System.Uri
+
+### Scope
+Major
+
+### Version Introduced
+4.5
+
+### Change Description
+URI parsing has changed in several ways in .NET 4.5. Note, however, that these changes only affect code targeting .NET 4.5. If a binary targets .NET 4.0, the old behavior will be observed.  
+Changes to URI parsing in .NET 4.5 include:<ul><li>URI parsing will perform normalization and character checking according to the latest IRI rules in RFC 3987</li><li>Unicode normalization form C will only be performed on the host portion of the URI</li><li>Invalid mailto: URIs will now cause an exception</li><li>Trailing dots at the end of a path segment are now preserved</li><li>file:// URIs do not escape the '?' character</li><li>Unicode control characters U+0080 through U+009F are not supported</li><li>Comma characters (',' %2c) are not automatically unescaped</li></ul>
+
+- [x] Quirked
+- [ ] Build-time break
+- [x] Source analyzer available
+
+### Recommended Action
+If the old .NET 4.0 URI parsing semantics are necessary (they often aren't), they can be used by targeting .NET 4.0. This can be accomplished by using a TargetFrameworkAttribute on the assembly, or through Visual Studio's project system UI in the 'project properties' page.
+
+### Affected APIs
+* M:System.Uri.#ctor(System.String)
+* M:System.Uri.#ctor(System.String,System.Boolean)
+* M:System.Uri.#ctor(System.String,System.UriKind)
+* M:System.Uri.#ctor(System.Uri,System.String)
+* M:System.Uri.TryCreate(System.String,System.UriKind,System.Uri@)
+* M:System.Uri.TryCreate(System.Uri,System.String,System.Uri@)
+* M:System.Uri.TryCreate(System.Uri,System.Uri,System.Uri@)
+
+[More information](https://msdn.microsoft.com/en-us/library/hh367887\(v=vs.110\).aspx#core)
+
+<!--
+    ### Notes
+    Changes IRI parsing, requires access to parameters to detect
+    Source analyzer status: Pri 1, source done
+-->
+
+

--- a/Documentation/BreakingChanges/010- System.Uri escaping now supports RFC 3986 (http.md
+++ b/Documentation/BreakingChanges/010- System.Uri escaping now supports RFC 3986 (http.md
@@ -1,0 +1,33 @@
+## 10: System.Uri escaping now supports RFC 3986 (http://tools.ietf.org/html/rfc3986)
+
+### Scope
+Minor
+
+### Version Introduced
+4.5
+
+### Change Description
+URI escaping has changed in .NET 4.5 to support <a href="http://tools.ietf.org/html/rfc3986">RFC 3986</a>. Specific changes include:<ul><li>EscapeDataString  escapes reserved characters based on <a href="http://tools.ietf.org/html/rfc3986">RFC 3986</a>.</li><li>EscapeUriString  does not escape reserved characters.</li><li>UnescapeDataString  does not throw an exception if it encounters an invalid escape sequence.</li><li>Unreserved escaped characters are un-escaped.</li></ul>
+
+- [ ] Quirked
+- [ ] Build-time break
+- [x] Source analyzer available
+
+### Recommended Action
+* Update applications to not rely on UnescapeDataString to throw in the case of an invalid escape sequence. Such sequences must be detected directly now. 
+* Similarly, expect that Escaped and Unescaped URI and Data strings may vary from .NET 4.0 and .NET 4.5 and should not be compared across .NET versions directly. Instead, they should be parsed and normalized in a single .NET version before any comparisons are made.
+
+### Affected APIs
+* M:System.Uri.EscapeDataString(System.String)
+* M:System.Uri.EscapeUriString(System.String)
+* M:System.Uri.UnescapeDataString(System.String)
+
+[More information](https://msdn.microsoft.com/en-us/library/hh367887\(v=vs.110\).aspx#core)
+
+<!--
+    ### Notes
+    Escaping behavior has changed. EscapeUriString does not escape reserved characters, EscapeDataString escapes reserved characters, and UnescapeDataString no longer throws on invalid escape sequences. See http://tools.ietf.org/html/rfc3986 for more information on reserved characters. Difficult to detect because of the dependency on input parameters.
+    Source analyzer status: Pri 1, source done 
+-->
+
+

--- a/Documentation/BreakingChanges/026- Task.WaitAll methods with time-out arguments.md
+++ b/Documentation/BreakingChanges/026- Task.WaitAll methods with time-out arguments.md
@@ -1,0 +1,34 @@
+## 26: Task.WaitAll methods with time-out arguments
+
+### Scope
+Minor
+
+### Version Introduced
+4.5
+
+### Change Description
+Task.WaitAll behavior was made more consistent in .NET 4.5. 
+
+In the .NET Framework 4, these methods behaved inconsistently. When the time-out expired, if one or more tasks were completed or canceled before the method call, the method threw an AggregateException exception. When the time-out expired, if no tasks were completed or canceled before the method call, but one or more tasks entered these states after the method call, the method returned false.<br/><br/>In the .NET Framework 4.5, these method overloads now return false if any tasks are still running when the time-out interval expired, and they throw an AggregateException exception only if an input task was cancelled (regardless of whether it was before or after the method call) and no other tasks are still running.
+
+- [ ] Quirked
+- [ ] Build-time break
+- [ ] Source analyzer available
+
+### Recommended Action
+If an AggregateException was being caught as a means of detecting a task that was cancelled prior to the WaitAll call being invoked, that code should instead do the same detection via the IsCanceled property (for example: .Any(t =&gt; t.IsCanceled)) since .NET 4.6 will only throw in that case if all awaited tasks are completed prior to the timeout.
+
+### Affected APIs
+* M:System.Threading.Tasks.Task.WaitAll(System.Threading.Tasks.Task[],System.Int32)
+* M:System.Threading.Tasks.Task.WaitAll(System.Threading.Tasks.Task[],System.Int32,System.Threading.CancellationToken)
+* M:System.Threading.Tasks.Task.WaitAll(System.Threading.Tasks.Task[],System.TimeSpan)
+
+[More information](https://msdn.microsoft.com/en-us/library/hh367887\(v=vs.110\).aspx#core)
+
+<!--
+    ### Notes
+    Check for try/catch block with WaitAll in it
+    Source analyzer status: Pri 2, NOT DONE
+-->
+
+

--- a/PortabilityTools.sln
+++ b/PortabilityTools.sln
@@ -33,6 +33,12 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Fx.Portability.Te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Fx.Portability.MetadataReader.Tests", "tests\Microsoft.Fx.Portability.MetadataReader.Tests\Microsoft.Fx.Portability.MetadataReader.Tests.csproj", "{B44085A7-0DCD-4CE2-BDD9-B2E5268DCCCC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Fx.Portability.Reports.Html", "src\Microsoft.Fx.Portability.Reports.Html\Microsoft.Fx.Portability.Reports.Html.csproj", "{83F4A5FE-FAF8-4952-899E-EA0BB08F8E60}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Fx.Portability.Reports.Json", "src\Microsoft.Fx.Portability.Reports.Json\Microsoft.Fx.Portability.Reports.Json.csproj", "{DBD3216D-7901-490D-B219-C63D3E001E0D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Fx.Portability.Offline", "src\Microsoft.Fx.Portability.Offline\Microsoft.Fx.Portability.Offline.csproj", "{F3D148CA-D49D-4315-9CD6-AE7B0EEA9549}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -67,6 +73,18 @@ Global
 		{B44085A7-0DCD-4CE2-BDD9-B2E5268DCCCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B44085A7-0DCD-4CE2-BDD9-B2E5268DCCCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B44085A7-0DCD-4CE2-BDD9-B2E5268DCCCC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{83F4A5FE-FAF8-4952-899E-EA0BB08F8E60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{83F4A5FE-FAF8-4952-899E-EA0BB08F8E60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{83F4A5FE-FAF8-4952-899E-EA0BB08F8E60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{83F4A5FE-FAF8-4952-899E-EA0BB08F8E60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DBD3216D-7901-490D-B219-C63D3E001E0D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DBD3216D-7901-490D-B219-C63D3E001E0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DBD3216D-7901-490D-B219-C63D3E001E0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DBD3216D-7901-490D-B219-C63D3E001E0D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F3D148CA-D49D-4315-9CD6-AE7B0EEA9549}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3D148CA-D49D-4315-9CD6-AE7B0EEA9549}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F3D148CA-D49D-4315-9CD6-AE7B0EEA9549}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F3D148CA-D49D-4315-9CD6-AE7B0EEA9549}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -79,5 +97,8 @@ Global
 		{C556C618-D062-4988-9379-99A716D8F2C1} = {F8292A68-AF7C-4B26-B1B8-B232548EF118}
 		{6900A49C-D463-43E2-AB21-487E8B73EF5C} = {7DC7AA2C-0401-495B-B42C-32F44085EBE6}
 		{B44085A7-0DCD-4CE2-BDD9-B2E5268DCCCC} = {7DC7AA2C-0401-495B-B42C-32F44085EBE6}
+		{83F4A5FE-FAF8-4952-899E-EA0BB08F8E60} = {6234AABE-C4F3-4094-9C0D-FFD589235DBE}
+		{DBD3216D-7901-490D-B219-C63D3E001E0D} = {6234AABE-C4F3-4094-9C0D-FFD589235DBE}
+		{F3D148CA-D49D-4315-9CD6-AE7B0EEA9549} = {6234AABE-C4F3-4094-9C0D-FFD589235DBE}
 	EndGlobalSection
 EndGlobal

--- a/src/ApiPort/CommandLine/AnalyzeOptionSet.cs
+++ b/src/ApiPort/CommandLine/AnalyzeOptionSet.cs
@@ -32,13 +32,6 @@ namespace ApiPort.CommandLine
                 RequestFlags |= AnalyzeRequestFlags.ShowNonPortableApis;
             }
 
-            // If no output formats have been supplied, default to Excel
-            // TODO: Should probably get this from the service, not hard-coded
-            if (!OutputFormats.Any())
-            {
-                UpdateOutputFormats("Excel");
-            }
-
             return InputAssemblies.Any();
         }
     }

--- a/src/ApiPort/DependencyBuilder.cs
+++ b/src/ApiPort/DependencyBuilder.cs
@@ -45,6 +45,9 @@ namespace ApiPort
             container.RegisterType<IAnalysisEngine, AnalysisEngine>(new ContainerControlledLifetimeManager());
             container.RegisterType<ICollection<IReportWriter>>(new ContainerControlledLifetimeManager(), new InjectionFactory(WriterCollection));
 
+            // Register the default output format name
+            container.RegisterInstance("DefaultOutputFormat", "Excel");
+
             if (Console.IsOutputRedirected)
             {
                 container.RegisterInstance<IProgressReporter>(new TextWriterProgressReporter(Console.Out));

--- a/src/ApiPort/Program.cs
+++ b/src/ApiPort/Program.cs
@@ -45,7 +45,7 @@ namespace ApiPort
                             ListTargets(apiPortClient, container.Resolve<ITargetMapper>()).Wait();
                             break;
                         case AppCommands.AnalyzeAssemblies:
-                            AnalyzeAssembliesAsync(apiPortClient, options, progressReport, container.Resolve<IFileWriter>()).Wait();
+                            AnalyzeAssembliesAsync(apiPortClient, options, progressReport, container.Resolve<IFileWriter>(), container.Resolve<string>("DefaultOutputFormat")).Wait();
                             break;
 #if DOCID_SEARCH
                         case AppCommands.DocIdSearch:
@@ -248,17 +248,20 @@ namespace ApiPort
             Console.WriteLine(LocalizedStrings.TargetsListNoVersion, LocalizedStrings.WhatAsteriskMeans);
         }
 
-        private static async Task AnalyzeAssembliesAsync(ApiPortClient apiPort, ICommandLineOptions options, IProgressReporter progressReport, IFileWriter writer)
+        private static async Task AnalyzeAssembliesAsync(ApiPortClient apiPort, ICommandLineOptions options, IProgressReporter progressReport, IFileWriter writer, string defaultOutputFormat)
         {
             foreach (var errorInput in options.InvalidInputFiles)
             {
                 progressReport.ReportIssue(string.Format(Microsoft.Fx.Portability.Resources.LocalizedStrings.InvalidFileName, errorInput));
             }
 
-            var results = await apiPort.GetAnalysisReportAsync(options);
+            // If no output formats were specified, use the default
+            var outputFormats = options.OutputFormats.Any() ? options.OutputFormats : new[] { defaultOutputFormat };
+
+            var results = await apiPort.GetAnalysisReportAsync(options, outputFormats);
             var outputPaths = new List<string>();
 
-            foreach (var resultAndFormat in results.Zip(options.OutputFormats, (r, f) => new { Result = r, Format = f }))
+            foreach (var resultAndFormat in results.Zip(outputFormats, (r, f) => new { Result = r, Format = f }))
             {
                 var outputPath = await CreateReport(resultAndFormat.Result, apiPort, options.OutputFileName, resultAndFormat.Format, progressReport, writer);
 

--- a/src/Microsoft.Fx.Portability.MetadataReader/packages.config
+++ b/src/Microsoft.Fx.Portability.MetadataReader/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Collections.Immutable" version="1.1.34-rc-00001" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.1.0-alpha-00002" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.1.0-alpha-00008" targetFramework="net45" />
 </packages>

--- a/src/Microsoft.Fx.Portability.Offline/Data.cs
+++ b/src/Microsoft.Fx.Portability.Offline/Data.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Fx.Portability.ObjectModel;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.Fx.Portability
+{
+    internal static class Data
+    {
+        public static DotNetCatalog LoadCatalog()
+        {
+            using (var stream = OpenFileOrResource("catalog.bin"))
+            {
+                return stream.DecompressToObject<DotNetCatalog>();
+            }
+        }
+
+        public static IEnumerable<BreakingChange> LoadBreakingChanges()
+        {
+            // Prefer a local 'BreakingChanges' directory to embedded breaking changes
+            if (Directory.Exists(Path.Combine(GetCurrentDirectoryName(), "BreakingChanges")))
+            {
+                var breakingChanges = new List<BreakingChange>();
+                foreach (var file in Directory.GetFiles(Path.Combine(GetCurrentDirectoryName(), "BreakingChanges"), "*", SearchOption.AllDirectories))
+                {
+                    using (var fs = File.Open(file, FileMode.Open, FileAccess.Read))
+                    {
+                        breakingChanges.AddRange(ParseBreakingChange(fs, Path.GetExtension(file)));
+                    }
+                }
+
+                return breakingChanges;
+            }
+            // If no BreakingChanges folder exists, then we'll fall back to the old model of looking for
+            // BreakingChanges.json either next to the assembly or, if not there, embedded as a resource
+            else
+            {
+                using (var stream = OpenFileOrResource("BreakingChanges.json"))
+                {
+                    var breakingChanges = stream.Deserialize<IEnumerable<BreakingChange>>();
+
+                    if (breakingChanges == null)
+                    {
+                        Trace.WriteLine("No data was found in 'BreakingChanges.json'");
+                        return Enumerable.Empty<BreakingChange>();
+                    }
+
+                    return breakingChanges;
+                }
+            }
+        }
+
+        private static Stream OpenFileOrResource(string path)
+        {
+            var file = Path.Combine(GetCurrentDirectoryName(), path);
+
+            if (File.Exists(file))
+            {
+                return File.OpenRead(file);
+            }
+            else
+            {
+                var stream = typeof(Data).Assembly.GetManifestResourceStream("Microsoft.Fx.Portability.data." + path);
+
+                if (stream == null)
+                {
+                    throw new FileNotFoundException("Could not find data file next to or embedded in assembly.", path);
+                }
+
+                return stream;
+            }
+        }
+
+        private static string GetCurrentDirectoryName()
+        {
+            return Path.GetDirectoryName(typeof(Data).Assembly.Location);
+        }
+
+        private static IEnumerable<BreakingChange> ParseBreakingChange(Stream stream, string extension)
+        {
+            if (string.Equals(".md", extension, StringComparison.OrdinalIgnoreCase))
+            {
+                return BreakingChangeParser.FromMarkdown(stream);
+            }
+            if (string.Equals(".json", extension, StringComparison.OrdinalIgnoreCase))
+            {
+                return stream.Deserialize<IEnumerable<BreakingChange>>();
+            }
+            else
+            {
+                return Enumerable.Empty<BreakingChange>();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
+++ b/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F3D148CA-D49D-4315-9CD6-AE7B0EEA9549}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.Fx.Portability</RootNamespace>
+    <AssemblyName>Microsoft.Fx.Portability.Offline</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Fx.Portability-net45\Microsoft.Fx.Portability-net45.csproj">
+      <Project>{fc1429e3-46c3-49ed-b99f-b45e1ccfb86b}</Project>
+      <Name>Microsoft.Fx.Portability-net45</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Data.cs" />
+    <Compile Include="OfflineApiCatalogLookup.cs" />
+    <Compile Include="OfflineApiPortService.cs" />
+    <Compile Include="OfflineApiRecommendations.cs" />
+    <Compile Include="OfflineBreakingChanges.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <PropertyGroup>
+    <DataPath>$(MSBuildThisFileDirectory)data\</DataPath>
+    <CatalogDataFile>$(DataPath)catalog.bin</CatalogDataFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(CatalogDataFile)" />
+    <None Include="download.ps1" />
+    <None Include="unity.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="DownloadContent" BeforeTargets="BeforeBuild">
+    <Exec Command="powershell.exe -noprofile -noninteractive -ExecutionPolicy unrestricted -file $(MSBuildThisFileDirectory)download.ps1 $(CatalogDataFile) $(DataPath)" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
+++ b/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
@@ -62,7 +62,7 @@
   </ItemGroup>
   <PropertyGroup>
     <DataPath>$(MSBuildThisFileDirectory)data\</DataPath>
-    <BreakingChangePath>$(DataPath)BreakingChanges\</BreakingChangePath>
+    <BreakingChangePath>$(MSBuildThisFileDirectory)..\..\Documentation\BreakingChanges\</BreakingChangePath>
     <CatalogDataFile>$(DataPath)catalog.bin</CatalogDataFile>
   </PropertyGroup>
   <ItemGroup>
@@ -75,7 +75,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="DownloadContent" BeforeTargets="BeforeBuild">
-    <Exec Command="powershell.exe -noprofile -noninteractive -ExecutionPolicy unrestricted -file $(MSBuildThisFileDirectory)download.ps1 $(CatalogDataFile) $(BreakingChangePath)" />
+    <Exec Command="powershell.exe -noprofile -noninteractive -ExecutionPolicy unrestricted -file $(MSBuildThisFileDirectory)download.ps1 $(CatalogDataFile)" />
   </Target>
   <Target Name="BeforeBuild">
   </Target>
@@ -83,7 +83,7 @@
   <!-- Copy breaking changes for use by Microsoft.FX.Portability.Offline at runtime -->
     <ItemGroup>
       <BreakingChanges Include="
-        $(DataPath)BreakingChanges\*.md;
+        $(BreakingChangePath)*.md;
       " />
     </ItemGroup>
     <Copy SourceFiles="@(BreakingChanges)" DestinationFolder="$(OutputPath)\BreakingChanges" SkipUnchangedFiles="true" />

--- a/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
+++ b/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
@@ -62,6 +62,7 @@
   </ItemGroup>
   <PropertyGroup>
     <DataPath>$(MSBuildThisFileDirectory)data\</DataPath>
+    <BreakingChangePath>$(DataPath)BreakingChanges\</BreakingChangePath>
     <CatalogDataFile>$(DataPath)catalog.bin</CatalogDataFile>
   </PropertyGroup>
   <ItemGroup>
@@ -74,7 +75,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="DownloadContent" BeforeTargets="BeforeBuild">
-    <Exec Command="powershell.exe -noprofile -noninteractive -ExecutionPolicy unrestricted -file $(MSBuildThisFileDirectory)download.ps1 $(CatalogDataFile) $(DataPath)" />
+    <Exec Command="powershell.exe -noprofile -noninteractive -ExecutionPolicy unrestricted -file $(MSBuildThisFileDirectory)download.ps1 $(CatalogDataFile) $(BreakingChangePath)" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
+++ b/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
@@ -67,7 +67,9 @@
   <ItemGroup>
     <EmbeddedResource Include="$(CatalogDataFile)" />
     <None Include="download.ps1" />
-    <None Include="unity.config" />
+    <None Include="unity.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
+++ b/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
@@ -67,6 +67,10 @@
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(CatalogDataFile)" />
+    <EmbeddedResource Include="$(BreakingChangePath)*.md" >
+      <Link>data\%(Filename)%(Extension)</Link>
+      <BreakingChange>true</BreakingChange>
+    </EmbeddedResource>
     <None Include="download.ps1" />
     <None Include="unity.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -82,9 +86,7 @@
   <Target Name="AfterBuild">
   <!-- Copy breaking changes for use by Microsoft.FX.Portability.Offline at runtime -->
     <ItemGroup>
-      <BreakingChanges Include="
-        $(BreakingChangePath)*.md;
-      " />
+      <BreakingChanges Include="@(EmbeddedResource)" Condition="'%(EmbeddedResource.BreakingChange)'=='true'" />
     </ItemGroup>
     <Copy SourceFiles="@(BreakingChanges)" DestinationFolder="$(OutputPath)\BreakingChanges" SkipUnchangedFiles="true" />
   </Target>

--- a/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
+++ b/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
@@ -77,11 +77,15 @@
   <Target Name="DownloadContent" BeforeTargets="BeforeBuild">
     <Exec Command="powershell.exe -noprofile -noninteractive -ExecutionPolicy unrestricted -file $(MSBuildThisFileDirectory)download.ps1 $(CatalogDataFile) $(BreakingChangePath)" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
   <Target Name="AfterBuild">
+  <!-- Copy breaking changes for use by Microsoft.FX.Portability.Offline at runtime -->
+    <ItemGroup>
+      <BreakingChanges Include="
+        $(DataPath)BreakingChanges\*.md;
+      " />
+    </ItemGroup>
+    <Copy SourceFiles="@(BreakingChanges)" DestinationFolder="$(OutputPath)\BreakingChanges" SkipUnchangedFiles="true" />
   </Target>
-  -->
 </Project>

--- a/src/Microsoft.Fx.Portability.Offline/OfflineApiCatalogLookup.cs
+++ b/src/Microsoft.Fx.Portability.Offline/OfflineApiCatalogLookup.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Fx.Portability.ObjectModel;
+using System;
+
+namespace Microsoft.Fx.Portability
+{
+    public class OfflineApiCatalogLookup : CloudApiCatalogLookup
+    {
+        public OfflineApiCatalogLookup(IProgressReporter progressReporter)
+            : base(GetData(progressReporter))
+        { }
+
+        private static DotNetCatalog GetData(IProgressReporter progressReporter)
+        {
+            using (var progressTask = progressReporter.StartTask("Loading catalog"))
+            {
+                try
+                {
+                    return Data.LoadCatalog();
+                }
+                catch (Exception)
+                {
+                    progressTask.Abort();
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Fx.Portability.Offline/OfflineApiPortService.cs
+++ b/src/Microsoft.Fx.Portability.Offline/OfflineApiPortService.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Fx.Portability.Analyzer;
+using Microsoft.Fx.Portability.ObjectModel;
+using Microsoft.Fx.Portability.Reporting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+
+namespace Microsoft.Fx.Portability
+{
+    public class OfflineApiPortService : IApiPortService
+    {
+        private readonly ITargetMapper _mapper;
+        private readonly IApiCatalogLookup _lookup;
+        private readonly ICollection<FrameworkName> _defaultTargets; 
+        private readonly IRequestAnalyzer _requestAnalyzer;
+        private readonly ICollection<IReportWriter> _reportWriters;
+
+        public OfflineApiPortService(IApiCatalogLookup lookup, IRequestAnalyzer requestAnalyzer, ITargetMapper mapper, ICollection<IReportWriter> reportWriters,ITargetNameParser targetNameParser)
+        {
+            _lookup = lookup;
+            _requestAnalyzer = requestAnalyzer;
+            _mapper = mapper;
+            _reportWriters = reportWriters;
+            _defaultTargets = new HashSet<FrameworkName>(targetNameParser.DefaultTargets);
+        }
+
+        public Task<ServiceResponse<IEnumerable<AvailableTarget>>> GetTargetsAsync()
+        {
+            var targets = _lookup
+                .GetPublicTargets()
+                .Select(target => new AvailableTarget { Name = target.Identifier, Version = target.Version, IsSet = _defaultTargets.Contains(target) });
+
+            var response = new ServiceResponse<IEnumerable<AvailableTarget>>(targets);
+
+            return Task.FromResult(response);
+        }
+
+        public Task<ServiceResponse<AnalyzeResponse>> SendAnalysisAsync(AnalyzeRequest a)
+        {
+            var response = _requestAnalyzer.AnalyzeRequest(a, Guid.NewGuid().ToString());
+            var serviceResponse = new ServiceResponse<AnalyzeResponse>(response);
+
+            return Task.FromResult(serviceResponse);
+        }
+
+        public Task<ServiceResponse<byte[]>> SendAnalysisAsync(AnalyzeRequest a, string format)
+        {
+            var response = _requestAnalyzer.AnalyzeRequest(a, Guid.NewGuid().ToString());
+
+            var writer = _reportWriters.FirstOrDefault(w => string.Equals(w.Format.DisplayName, format, StringComparison.InvariantCultureIgnoreCase));
+
+            if (writer == null)
+            {
+                throw new UnknownReportFormatException(format);
+            }
+
+            using (var ms = new MemoryStream())
+            {
+                writer.WriteStream(ms, response);
+
+                return WrapResponse(ms.ToArray());
+            }
+        }
+
+        public Task<ServiceResponse<IEnumerable<ResultFormatInformation>>> GetResultFormatsAsync()
+        {
+            var formats = _reportWriters.Select(r => r.Format);
+
+            return WrapResponse(formats);
+        }
+
+        private Task<ServiceResponse<T>> WrapResponse<T>(T data)
+        {
+            var response = new ServiceResponse<T>(data);
+
+            return Task.FromResult(response);
+        }
+
+        public Task<ServiceResponse<UsageDataCollection>> GetUsageDataAsync(int? skip = null, int? top = null, UsageDataFilter? filter = null, IEnumerable<string> targets = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ServiceResponse<AnalyzeResponse>> GetAnalysisAsync(string submissionId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ServiceResponse<byte[]>> GetAnalysisAsync(string submissionId, string format)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ServiceResponse<ApiInformation>> GetApiInformationAsync(string docId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ServiceResponse<IReadOnlyCollection<ApiDefinition>>> SearchFxApiAsync(string query, int? top = null)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.Fx.Portability.Offline/OfflineApiRecommendations.cs
+++ b/src/Microsoft.Fx.Portability.Offline/OfflineApiRecommendations.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Fx.Portability.ObjectModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Fx.Portability
+{
+    public class OfflineApiRecommendations : IApiRecommendations
+    {
+        private IEnumerable<BreakingChange> _breakingChanges;
+        private IApiCatalogLookup _lookup;
+
+        public OfflineApiRecommendations(IApiCatalogLookup lookup, IEnumerable<BreakingChange> breakingChanges)
+        {
+            _lookup = lookup;
+            _breakingChanges = breakingChanges;
+        }
+
+        public IEnumerable<ApiNote> GetNotes(string docId)
+        {
+            return Enumerable.Empty<ApiNote>();
+        }
+
+        public IEnumerable<BreakingChange> GetBreakingChanges(string docId)
+        {
+            return _breakingChanges.Where(b => b.ApplicableApis.Contains(docId, StringComparer.Ordinal));
+        }
+
+        public string GetRecommendedChanges(string docId)
+        {
+            return _lookup.GetRecommendedChange(docId);
+        }
+
+        public string GetSourceCompatibleChanges(string docId)
+        {
+            return _lookup.GetSourceCompatibilityEquivalent(docId);
+        }
+
+        public string GetComponent(string docId)
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/src/Microsoft.Fx.Portability.Offline/OfflineBreakingChanges.cs
+++ b/src/Microsoft.Fx.Portability.Offline/OfflineBreakingChanges.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Fx.Portability
+{
+    public class OfflineBreakingChanges : IEnumerable<BreakingChange>
+    {
+        private readonly IEnumerable<BreakingChange> _breakingChanges;
+
+        public OfflineBreakingChanges(IProgressReporter progressReporter)
+        {
+            using (var progressTask = progressReporter.StartTask("Loading breaking changes"))
+            {
+                try
+                {
+                    _breakingChanges = Data.LoadBreakingChanges();
+                }
+                catch (Exception)
+                {
+                    progressTask.Abort();
+                    throw;
+                }
+            }
+        }
+
+        public IEnumerator<BreakingChange> GetEnumerator()
+        {
+            return _breakingChanges.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return ((System.Collections.IEnumerable)_breakingChanges).GetEnumerator();
+        }
+    }
+}

--- a/src/Microsoft.Fx.Portability.Offline/README.md
+++ b/src/Microsoft.Fx.Portability.Offline/README.md
@@ -1,0 +1,26 @@
+# Microsoft.Fx.Portability.Offline Usage
+Microsoft.Fx.Portability.Offline enables ApiPort to work locally (without 
+sending any data to a remote service) via dependency injection.
+
+In order to use ApiPort in offline mode, copy the binary output of this 
+project next to ApiPort.exe. Note that because ApiPort typically expects the 
+server-side component to generate reports, any report generators used must 
+also be deployed next to ApiPort.exe. The html and json report generators can 
+be found in their own directories next to this project.
+
+The unity.config file contained in this project controls which local 
+components are used by ApiPort.exe. By default, it includes the local 
+Microsoft.Fx.Portability.Offline analysis library, as well as local html and 
+json report generators. If either report generator is not deployed next to 
+ApiPort.exe, the associated registration should be removed from Unity.config.
+
+### Common Setup Steps
+For most local uses of ApiPort.exe, the necessary setup steps will be:
+
+1. Build the PortabilityTools solution
+2. Copy the binary output of Microsoft.Fx.Portability.Offline next to 
+   ApiPort.exe
+3. Copy the binary output of Microsoft.Fx.Portability.Reports.Html next to 
+   ApiPort.exe
+4. Copy the binary output of Microsoft.Fx.Portability.Reports.Json next to 
+   ApiPort.exe

--- a/src/Microsoft.Fx.Portability.Offline/download.ps1
+++ b/src/Microsoft.Fx.Portability.Offline/download.ps1
@@ -29,34 +29,22 @@ function DownloadFile($url, $outputPath) {
 	}
 }
 
-function ExtractBreakingChanges( $zipfilename, $destination )
+function DownloadBreakingChangeFile($destination, $fileName)
 {
-	# Only bother extracting if the BreakingChanges folder doesn't exist yet
-	if (Test-Path $destination\BreakingChanges) {
-		return;
-	}
-
-	# Create the output directory
-	[System.IO.Directory]::CreateDirectory($destination + "\\BreakingChanges")
-
-	# Open the archive
-	[System.Reflection.Assembly]::LoadWithPartialName("System.IO.Compression") | Out-Null
-	[System.Reflection.Assembly]::LoadWithPartialName("System.IO.Compression.FileSystem") | Out-Null
-	$archiveMode = [System.IO.Compression.ZipArchiveMode]::Read
-	$archive = [System.IO.Compression.ZipFile]::Open($zipfilename, $archiveMode)
-
-	# Find markdown files from the BreakingChanges directory and extract them
-	Foreach ($entry in $archive.Entries) {
-		if ($entry.Name -ne "" -And 
-		[System.IO.Path]::GetDirectoryName($entry.FullName).Contains("BreakingChanges") -And
-		[System.IO.Path]::GetExtension($entry.FullName).ToLowerInvariant().Equals(".md")) {
-			[System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $destination + "\\BreakingChanges\\" + $entry.Name)
-		}
-	}
-
-	$archive.Dispose()
+	$url = "https://raw.githubusercontent.com/Microsoft/dotnet-apiport/master/Documentation/BreakingChanges/" + $fileName
+	$outputPath = $destination + $fileName
+	DownloadFile $url $outputPath
 }
 
 DownloadFile "TBD" $catalogPath
-DownloadFile "TBD" $breakingChangePath\Recommendations.zip
-ExtractBreakingChanges "$breakingChangePath\Recommendations.zip" "$breakingChangePath"
+
+# Unfortunately, it's not possible to download a specific directory from a Github repo (only the entire repo)
+# Rather than download the entire ApiPort repo at build-time, list the individual breaking change files to download
+DownloadBreakingChangeFile $breakingChangePath "! Template.md"
+DownloadBreakingChangeFile $breakingChangePath "001- SoapFormatter cannot deserialize Hashtable and sim.md"
+DownloadBreakingChangeFile $breakingChangePath "003- WPF DataTemplate elements are now visible to UIA.md"
+DownloadBreakingChangeFile $breakingChangePath "004- WPF TextBox selected text appears a different colo.md"
+DownloadBreakingChangeFile $breakingChangePath "005- ListT.ForEach.md"
+DownloadBreakingChangeFile $breakingChangePath "006- System.Uri.md"
+DownloadBreakingChangeFile $breakingChangePath "010- System.Uri escaping now supports RFC 3986 (http.md"
+DownloadBreakingChangeFile $breakingChangePath "026- Task.WaitAll methods with time-out arguments.md"

--- a/src/Microsoft.Fx.Portability.Offline/download.ps1
+++ b/src/Microsoft.Fx.Portability.Offline/download.ps1
@@ -1,7 +1,7 @@
 ﻿# Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-param($catalogPath, $breakingChangePath)
+param($catalogPath)
 
 function DownloadFile($url, $outputPath) {
 	Write-Host "Attempt to download to $outputPath"
@@ -29,22 +29,4 @@ function DownloadFile($url, $outputPath) {
 	}
 }
 
-function DownloadBreakingChangeFile($destination, $fileName)
-{
-	$url = "https://raw.githubusercontent.com/Microsoft/dotnet-apiport/master/Documentation/BreakingChanges/" + $fileName
-	$outputPath = $destination + $fileName
-	DownloadFile $url $outputPath
-}
-
 DownloadFile "https://portabilitystorage.blob.core.windows.net/data/public%2Fcatalog.bin?sr=b&sv=2015-02-21&si=ReadPublicCatalog&sig=r0Q61Nm4ZAqXYbWIg76%2BYw4VGsw9%2BdWuN%2FeHJYHJguw%3D" $catalogPath
-
-# Unfortunately, it's not possible to download a specific directory from a Github repo (only the entire repo)
-# Rather than download the entire ApiPort repo at build-time, list the individual breaking change files to download
-DownloadBreakingChangeFile $breakingChangePath "! Template.md"
-DownloadBreakingChangeFile $breakingChangePath "001- SoapFormatter cannot deserialize Hashtable and sim.md"
-DownloadBreakingChangeFile $breakingChangePath "003- WPF DataTemplate elements are now visible to UIA.md"
-DownloadBreakingChangeFile $breakingChangePath "004- WPF TextBox selected text appears a different colo.md"
-DownloadBreakingChangeFile $breakingChangePath "005- ListT.ForEach.md"
-DownloadBreakingChangeFile $breakingChangePath "006- System.Uri.md"
-DownloadBreakingChangeFile $breakingChangePath "010- System.Uri escaping now supports RFC 3986 (http.md"
-DownloadBreakingChangeFile $breakingChangePath "026- Task.WaitAll methods with time-out arguments.md"

--- a/src/Microsoft.Fx.Portability.Offline/download.ps1
+++ b/src/Microsoft.Fx.Portability.Offline/download.ps1
@@ -36,7 +36,7 @@ function DownloadBreakingChangeFile($destination, $fileName)
 	DownloadFile $url $outputPath
 }
 
-DownloadFile "TBD" $catalogPath
+DownloadFile "https://portabilitystorage.blob.core.windows.net/data/public%2Fcatalog.bin?sr=b&sv=2015-02-21&si=ReadPublicCatalog&sig=r0Q61Nm4ZAqXYbWIg76%2BYw4VGsw9%2BdWuN%2FeHJYHJguw%3D" $catalogPath
 
 # Unfortunately, it's not possible to download a specific directory from a Github repo (only the entire repo)
 # Rather than download the entire ApiPort repo at build-time, list the individual breaking change files to download

--- a/src/Microsoft.Fx.Portability.Offline/download.ps1
+++ b/src/Microsoft.Fx.Portability.Offline/download.ps1
@@ -1,0 +1,62 @@
+﻿# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+param($catalogPath, $breakingChangePath)
+
+function DownloadFile($url, $outputPath) {
+	Write-Host "Attempt to download to $outputPath"
+	
+	# If the file has been downloaded don't download again. An empty file implies a failed download
+	if(Test-Path $outputPath) {
+		$file = Get-ChildItem $outputPath
+
+		if($file.Length -gt 0) {
+			Write-Host "$outputPath is already downloaded"
+			return;
+		}
+	}
+	
+	try {
+		# Create placeholder so directory exists
+		New-Item -Type File $OutputPath -Force | Out-Null
+		
+		# Attempt to download.  If fails, placeholder remains so msbuild won't complain
+		Invoke-WebRequest $url -OutFile $OutputPath | Out-Null 
+
+		Write-Host "Downloaded $OutputPath"
+	} catch {
+		Write-Host "Failed to download '$url'"
+	}
+}
+
+function ExtractBreakingChanges( $zipfilename, $destination )
+{
+	# Only bother extracting if the BreakingChanges folder doesn't exist yet
+	if (Test-Path $destination\BreakingChanges) {
+		return;
+	}
+
+	# Create the output directory
+	[System.IO.Directory]::CreateDirectory($destination + "\\BreakingChanges")
+
+	# Open the archive
+	[System.Reflection.Assembly]::LoadWithPartialName("System.IO.Compression") | Out-Null
+	[System.Reflection.Assembly]::LoadWithPartialName("System.IO.Compression.FileSystem") | Out-Null
+	$archiveMode = [System.IO.Compression.ZipArchiveMode]::Read
+	$archive = [System.IO.Compression.ZipFile]::Open($zipfilename, $archiveMode)
+
+	# Find markdown files from the BreakingChanges directory and extract them
+	Foreach ($entry in $archive.Entries) {
+		if ($entry.Name -ne "" -And 
+		[System.IO.Path]::GetDirectoryName($entry.FullName).Contains("BreakingChanges") -And
+		[System.IO.Path]::GetExtension($entry.FullName).ToLowerInvariant().Equals(".md")) {
+			[System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $destination + "\\BreakingChanges\\" + $entry.Name)
+		}
+	}
+
+	$archive.Dispose()
+}
+
+DownloadFile "TBD" $catalogPath
+DownloadFile "TBD" $breakingChangePath\Recommendations.zip
+ExtractBreakingChanges "$breakingChangePath\Recommendations.zip" "$breakingChangePath"

--- a/src/Microsoft.Fx.Portability.Offline/packages.config
+++ b/src/Microsoft.Fx.Portability.Offline/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+</packages>

--- a/src/Microsoft.Fx.Portability.Offline/unity.config
+++ b/src/Microsoft.Fx.Portability.Offline/unity.config
@@ -38,6 +38,7 @@
           <param name="defaultTargets" parameterType="System.String" value=".NET Framework" />
         </constructor>
       </register>
+      <instance name="DefaultOutputFormat" value="HTML" />
     </container>
   </unity>
 </configuration>

--- a/src/Microsoft.Fx.Portability.Offline/unity.config
+++ b/src/Microsoft.Fx.Portability.Offline/unity.config
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <section name="unity" type="Microsoft.Practices.Unity.Configuration.UnityConfigurationSection, Microsoft.Practices.Unity.Configuration"/>
+  </configSections>
+  <unity xmlns="http://schemas.microsoft.com/practices/2010/unity">
+    <typeAliases>
+      <typeAlias alias="singleton" type="Microsoft.Practices.Unity.ContainerControlledLifetimeManager, Microsoft.Practices.Unity" />
+      <typeAlias alias="IEnumerable`1" type="System.Collections.Generic.IEnumerable`1, mscorlib" />
+      <typeAlias alias="IApiPortService" type="Microsoft.Fx.Portability.IApiPortService, Microsoft.Fx.Portability" />
+      <typeAlias alias="IApiCatalogLookup" type="Microsoft.Fx.Portability.ObjectModel.IApiCatalogLookup, Microsoft.Fx.Portability" />
+    </typeAliases>
+    <container>
+      <register type="IApiPortService" mapTo="Microsoft.Fx.Portability.OfflineApiPortService, Microsoft.Fx.Portability.Offline"  >
+        <lifetime type="singleton" />
+      </register>
+      <register type="IApiCatalogLookup" mapTo="Microsoft.Fx.Portability.OfflineApiCatalogLookup, Microsoft.Fx.Portability.Offline"  >
+        <lifetime type="singleton" />
+      </register>
+      <register type="IEnumerable`1" mapTo="Microsoft.Fx.Portability.OfflineBreakingChanges, Microsoft.Fx.Portability.Offline"  >
+        <lifetime type="singleton" />
+      </register>
+      <register type="Microsoft.Fx.Portability.ObjectModel.IApiRecommendations, Microsoft.Fx.Portability" mapTo="Microsoft.Fx.Portability.OfflineApiRecommendations, Microsoft.Fx.Portability.Offline">
+        <lifetime type="singleton" />
+      </register>
+      <register name="json" type="Microsoft.Fx.Portability.Reporting.IReportWriter, Microsoft.Fx.Portability" mapTo="Microsoft.Fx.Portability.Reports.JsonReportWriter, Microsoft.Fx.Portability.Reports.Json">
+        <lifetime type="singleton" />
+      </register>
+      <register name="html" type="Microsoft.Fx.Portability.Reporting.IReportWriter, Microsoft.Fx.Portability" mapTo="Microsoft.Fx.Portability.Reports.HtmlReportWriter, Microsoft.Fx.Portability.Reports.Html">
+        <lifetime type="singleton" />
+      </register>
+      <register type="Microsoft.Fx.Portability.ITargetNameParser, Microsoft.Fx.Portability" mapTo="Microsoft.Fx.Portability.Analysis.TargetNameParser, Microsoft.Fx.Portability">
+        <lifetime type="singleton" />
+        <constructor>
+          <param name="catalog">
+            <dependency />
+          </param>
+          <param name="defaultTargets" parameterType="System.String" value=".NET Framework" />
+        </constructor>
+      </register>
+    </container>
+  </unity>
+</configuration>

--- a/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MarkdownDeep;
+using Microsoft.Fx.Portability.ObjectModel;
+using Microsoft.Fx.Portability.Reporting;
+using Microsoft.Fx.Portability.Reporting.ObjectModel;
+using RazorEngine.Configuration;
+using RazorEngine.Templating;
+using RazorEngine.Text;
+using System.IO;
+using System.Reflection;
+using System.Text;
+
+namespace Microsoft.Fx.Portability.Reports
+{
+    public class HtmlReportWriter : IReportWriter
+    {
+        private static readonly IRazorEngineService _razorService = CreateService();
+
+        private readonly ITargetMapper _targetMapper;
+        private readonly ResultFormatInformation _formatInformation;
+
+        public HtmlReportWriter(ITargetMapper targetMapper)
+        {
+            _targetMapper = targetMapper;
+
+            _formatInformation = new ResultFormatInformation
+            {
+                DisplayName = "HTML",
+                MimeType = "text/html",
+                FileExtension = ".html"
+            };
+        }
+
+        public ResultFormatInformation Format { get { return _formatInformation; } }
+
+        public void WriteStream(Stream stream, AnalyzeResponse response)
+        {
+            const string ReportTemplateName = "ReportTemplate";
+
+            using (var writer = new StreamWriter(stream))
+            {
+                var reportObject = new RazorHtmlObject(response, _targetMapper);
+                var mainTemplate = Resolve(ReportTemplateName);
+                var razor = _razorService.RunCompile(mainTemplate, ReportTemplateName, typeof(RazorHtmlObject), reportObject);
+
+                writer.Write(razor);
+            }
+        }
+
+        private static IRazorEngineService CreateService()
+        {
+            var config = new TemplateServiceConfiguration
+            {
+                BaseTemplateType = typeof(HtmlSupportTemplateBase<>)
+            };
+
+            return RazorEngineService.Create(config);
+        }
+
+        private static string Resolve(string name)
+        {
+            var names = typeof(HtmlReportWriter).GetTypeInfo().Assembly.GetManifestResourceNames();
+            using (var template = typeof(HtmlReportWriter).GetTypeInfo().Assembly.GetManifestResourceStream("Microsoft.Fx.Portability.Reports.Resources." + name + ".cshtml"))
+            using (var reader = new StreamReader(template, Encoding.UTF8))
+            {
+                return reader.ReadToEnd();
+            }
+        }
+
+        public class HtmlHelper
+        {
+            private readonly Markdown _md = new Markdown();
+
+            public string ConvertMarkdownToHtml(string markdown)
+            {
+                return _md.Transform(markdown);
+            }
+
+            public IEncodedString Raw(string rawString)
+            {
+                return new RawString(rawString);
+            }
+
+            public IEncodedString Partial(string name)
+            {
+                var template = Resolve(name);
+                var razor = _razorService.RunCompile(template, name);
+
+                return Raw(razor);
+            }
+
+            public IEncodedString Partial<T>(string name, T model)
+            {
+                var template = Resolve(name);
+                var razor = _razorService.RunCompile(template, name, typeof(T), model);
+
+                return Raw(razor);
+            }
+        }
+
+        public abstract class HtmlSupportTemplateBase<T> : TemplateBase<T>
+        {
+            public HtmlSupportTemplateBase()
+            {
+                Html = new HtmlHelper();
+            }
+
+            public HtmlHelper Html { get; set; }
+        }
+    }
+}

--- a/src/Microsoft.Fx.Portability.Reports.Html/Microsoft.Fx.Portability.Reports.Html.csproj
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Microsoft.Fx.Portability.Reports.Html.csproj
@@ -1,0 +1,99 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{83F4A5FE-FAF8-4952-899E-EA0BB08F8E60}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.Fx.Portability.Reports</RootNamespace>
+    <AssemblyName>Microsoft.Fx.Portability.Reports.Html</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Fx.Portability">
+      <HintPath>..\..\packages\Microsoft.Fx.Portability.1.0.0-alpha-15042201\lib\net45\Microsoft.Fx.Portability.dll</HintPath>
+    </Reference>
+    <Reference Include="MarkdownDeep">
+      <HintPath>..\..\packages\MarkdownDeep.NET-Signed.1.5\lib\.NetFramework 3.5\MarkdownDeep.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="RazorEngine, Version=3.6.1.0, Culture=neutral, PublicKeyToken=9ee697374c7e744a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\RazorEngine.3.6.1\lib\net45\RazorEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.2\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web.Http, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.2\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.AspNet.Razor.3.0.0\lib\net45\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Fx.Portability-net45\Microsoft.Fx.Portability-net45.csproj">
+      <Project>{fc1429e3-46c3-49ed-b99f-b45e1ccfb86b}</Project>
+      <Name>Microsoft.Fx.Portability-net45</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="HtmlReportWriter.cs" />
+    <Compile Include="RazorHtmlObject.cs" />
+    <EmbeddedResource Include="Resources\_PortabilityReport.cshtml" />
+    <Compile Include="TargetSupportedIn.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+    <EmbeddedResource Include="Resources\ReportTemplate.cshtml" />
+    <EmbeddedResource Include="Resources\_Scripts.cshtml" />
+    <EmbeddedResource Include="Resources\_Styles.cshtml" />
+    <EmbeddedResource Include="Resources\_BreakingChangesReport.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Microsoft.Fx.Portability.Reports.Html/RazorHtmlObject.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/RazorHtmlObject.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Fx.Portability.ObjectModel;
+using Microsoft.Fx.Portability.Reporting.ObjectModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Fx.Portability.Reports
+{
+    /// <summary>
+    /// Please do not use this class directly, it is for Razor so that the engine can compute the HTML pages properly.
+    /// </summary>
+    public sealed class RazorHtmlObject
+    {
+        private readonly ITargetMapper _targetMapper;
+
+        public ReportingResult ReportingResult { get; private set; }
+
+        public IEnumerable<MissingTypeInfo> MissingTypes { get; private set; }
+
+        public IOrderedEnumerable<AssemblyUsageInfo> OrderedAssembliesByIdentity { get; private set; }
+
+        public ITargetMapper TargetMapper { get; private set; }
+
+        public IEnumerable<string> TargetHeaders { get; private set; }
+
+        public IEnumerable<KeyValuePair<string, ICollection<string>>> OrderedUnresolvedAssemblies { get; private set; }
+
+        public IOrderedEnumerable<KeyValuePair<AssemblyInfo, IDictionary<BreakingChange, IEnumerable<MemberInfo>>>> OrderedBreakingChangesByAssembly { get; private set; }
+
+        public IDictionary<BreakingChange, IEnumerable<MemberInfo>> BreakingChangesSummary { get; private set; }
+
+        public IOrderedEnumerable<AssemblyInfo> OrderedBreakingChangeSkippedAssemblies { get; private set; }
+
+        public RazorHtmlObject(AnalyzeResponse response, ITargetMapper targetMapper)
+        {
+            _targetMapper = targetMapper;
+            RequestFlags = response.ReportingResult.RequestFlags;
+            ReportingResult = response.ReportingResult;
+            TargetMapper = _targetMapper;
+            OrderedUnresolvedAssemblies = response.ReportingResult.GetUnresolvedAssemblies().OrderBy(asm => asm.Key);
+            OrderedAssembliesByIdentity = response.ReportingResult.GetAssemblyUsageInfo().OrderBy(a => a.SourceAssembly.AssemblyIdentity);
+            MissingTypes = response.ReportingResult.GetMissingTypes();
+            TargetHeaders = _targetMapper.GetTargetNames(response.ReportingResult.Targets, true);
+            OrderedBreakingChangesByAssembly = GetGroupedBreakingChanges(response.BreakingChanges, response.ReportingResult.GetAssemblyUsageInfo().Select(a => a.SourceAssembly));
+            BreakingChangesSummary = GetBreakingChangesSummary(OrderedBreakingChangesByAssembly);
+            OrderedBreakingChangeSkippedAssemblies = response.BreakingChangeSkippedAssemblies.OrderBy(a => a.AssemblyIdentity);
+        }
+
+        private IDictionary<BreakingChange, IEnumerable<MemberInfo>> GetBreakingChangesSummary(IEnumerable<KeyValuePair<AssemblyInfo, IDictionary<BreakingChange, IEnumerable<MemberInfo>>>> orderedBreakingChangesByAssembly)
+        {
+            return orderedBreakingChangesByAssembly
+                .SelectMany(o => o.Value)
+                .GroupBy(o => o.Key)
+                .Select(o => new KeyValuePair<BreakingChange, IEnumerable<MemberInfo>>(o.Key, new SortedSet<MemberInfo>(o.SelectMany(j => j.Value))))
+                .ToDictionary(o => o.Key, o => o.Value);
+        }
+
+        private IOrderedEnumerable<KeyValuePair<AssemblyInfo, IDictionary<BreakingChange, IEnumerable<MemberInfo>>>> GetGroupedBreakingChanges(IList<BreakingChangeDependency> breakingChanges, IEnumerable<AssemblyInfo> assembliesToInclude)
+        {
+            Dictionary<AssemblyInfo, IDictionary<BreakingChange, IEnumerable<MemberInfo>>> ret = new Dictionary<AssemblyInfo, IDictionary<BreakingChange, IEnumerable<MemberInfo>>>();
+            foreach (BreakingChangeDependency b in breakingChanges)
+            {
+                // Add breaking changes, grouped by assembly, each with a collection of MemberInfos that trigger the break
+                if (!ret.ContainsKey(b.DependantAssembly))
+                {
+                    ret.Add(b.DependantAssembly, new Dictionary<BreakingChange, IEnumerable<MemberInfo>>());
+                }
+                if (!ret[b.DependantAssembly].ContainsKey(b.Break))
+                {
+                    ret[b.DependantAssembly].Add(b.Break, new List<MemberInfo>());
+                }
+                if (!ret[b.DependantAssembly][b.Break].Contains(b.Member))
+                {
+                    (ret[b.DependantAssembly][b.Break] as IList<MemberInfo>).Add(b.Member);
+                }
+            }
+
+            // If a full list of assemblies was passed, include empty entries for the remaining assemblies
+            // so that our compat summary can be complete
+            if (assembliesToInclude != null)
+            {
+                foreach (var a in assembliesToInclude)
+                {
+                    if (!ret.ContainsKey(a))
+                    {
+                        ret.Add(a, new Dictionary<BreakingChange, IEnumerable<MemberInfo>>());
+                    }
+                }
+            }
+
+            // Order meaningfully (by issue - from high to low pri - and then by assembly name)
+            return ret
+                .OrderByDescending(x => x.Value.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Major && !b.Key.IsRetargeting).Count())
+                .ThenByDescending(x => x.Value.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Minor && !b.Key.IsRetargeting).Count())
+                .ThenByDescending(x => x.Value.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Edge && !b.Key.IsRetargeting).Count())
+                .ThenByDescending(x => x.Value.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Major && b.Key.IsRetargeting).Count())
+                .ThenByDescending(x => x.Value.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Minor && b.Key.IsRetargeting).Count())
+                .ThenByDescending(x => x.Value.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Edge && b.Key.IsRetargeting).Count())
+                .ThenBy(x => x.Key);
+        }
+
+        public string RemoveTypeOrMemberPrefix(string assemblyName)
+        {
+            string[] split = assemblyName.Split(new string[] { ":" }, 2, StringSplitOptions.RemoveEmptyEntries);
+            return split.Length == 2 ? split[1] : split[0];
+        }
+
+        public IList<string> GetUnresolvedAssemblies(AssemblyUsageInfo assembly)
+        {
+            string assemblyName = assembly.SourceAssembly.AssemblyIdentity;
+            var unresolvedAssemblyIdentities = from pair in OrderedUnresolvedAssemblies
+                                               where pair.Value.Contains(assemblyName)
+                                               select pair.Key;
+            return unresolvedAssemblyIdentities.ToList();
+        }
+
+        public IReadOnlyList<MissingTypeInfo> MatchingMissingTypes(AssemblyUsageInfo assembly)
+        {
+            var matching = MissingTypes.Where(t => t.UsedIn.Contains(assembly.SourceAssembly)).OrderBy(type => type.TypeName).ToList();
+            return matching;
+        }
+
+        public IEnumerable<TargetSupportedIn> GetMatchingTargetsAndSupportedVersions(IEnumerable<Version> usedVersions)
+        {
+            var zipped = usedVersions.Zip(ReportingResult.Targets, (a, b) => { return new TargetSupportedIn(b, a); });
+            return zipped;
+        }
+
+        public AnalyzeRequestFlags RequestFlags { get; set; }
+    }
+}

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/ReportTemplate.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/ReportTemplate.cshtml
@@ -1,0 +1,89 @@
+﻿/*
+   Copyright (c) Microsoft. All rights reserved.
+   Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*/
+
+@model Microsoft.Fx.Portability.Reports.RazorHtmlObject
+
+@using Microsoft.Fx.Portability
+@using Microsoft.Fx.Portability.Reporting.ObjectModel
+@using Microsoft.Fx.Portability.Resources
+@using System.IO
+@using System.Linq
+@using System.Runtime.Versioning
+
+@{
+    ViewBag.Title = LocalizedStrings.HtmlReportTitle;
+    var submissionId = Model.ReportingResult.SubmissionId;
+    var includeBreakingChanges = Model.RequestFlags.HasFlag(Microsoft.Fx.Portability.ObjectModel.AnalyzeRequestFlags.ShowBreakingChanges);
+    var includePortabilityReport = Model.RequestFlags.HasFlag(Microsoft.Fx.Portability.ObjectModel.AnalyzeRequestFlags.ShowNonPortableApis);
+}
+
+<!DOCTYPE html>
+<html xmlns:msxsl="urn:schemas-microsoft-com:xslt">
+<head>
+    <meta content="en-us" http-equiv="Content-Language" />
+    <meta content="text/html; charset=utf-16" http-equiv="Content-Type" />
+    <title _locid="PortabilityAnalysis0">@LocalizedStrings.HtmlReportTitle</title>
+    @Html.Partial("_Styles")
+</head>
+<body>
+    <h1 _locid="PortabilityReport">@LocalizedStrings.HtmlReportTitle</h1>
+    <div id="content">
+        <div id="submissionHeader" style="font-size:8pt;">
+            <p>
+                <i>
+                    @LocalizedStrings.SubmissionId&nbsp;
+                    @submissionId
+
+                    @* TODO: Add back in logic to create URIs when finished abstracting IReportWriter. *@
+                    @*
+                        @if (reportingResult.Headers.HasSubmissionEndpoint)
+                        {
+                            <a href="@reportingResult.Headers.GetSubmissionUrl(@submissionId)">@submissionId</a>
+                        }
+                        else
+                        {
+                            @submissionId
+                        }
+                    *@
+                </i>
+            </p>
+
+            <div id="toc">
+                <h2>Contents</h2>
+                <ul>
+                    @if (includeBreakingChanges)
+                    {
+                        <li>
+                            <span class="tocItem"><a href="#@LocalizedStrings.CompatibilityPageTitle">@LocalizedStrings.CompatibilityPageTitle</a></span>
+                        </li>
+                    }
+                    @if (includePortabilityReport)
+                    {
+                        <li>
+                            <span class="tocItem"><a href="#@LocalizedStrings.PortabilitySummaryPageTitle">@LocalizedStrings.PortabilitySummaryPageTitle</a></span>
+                        </li>
+                    }
+                </ul>
+            </div>
+        </div>
+
+        @if (includeBreakingChanges)
+        {
+            <div id="breakingChangesReport">
+                @Html.Partial("_BreakingChangesReport", Model)
+            </div>
+        }
+
+        @if (includePortabilityReport)
+        {
+            <div id="portabilityReport">
+                @Html.Partial("_PortabilityReport", Model)
+            </div>
+        }
+    </div>
+
+    @Html.Partial("_Scripts")
+</body>
+</html>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/ReportTemplate.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/ReportTemplate.cshtml
@@ -1,7 +1,7 @@
-﻿/*
+﻿<!--
    Copyright (c) Microsoft. All rights reserved.
    Licensed under the MIT license. See LICENSE file in the project root for full license information.
-*/
+-->
 
 @model Microsoft.Fx.Portability.Reports.RazorHtmlObject
 

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_BreakingChangesReport.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_BreakingChangesReport.cshtml
@@ -1,7 +1,7 @@
-﻿/*
+﻿<!--
    Copyright (c) Microsoft. All rights reserved.
    Licensed under the MIT license. See LICENSE file in the project root for full license information.
-*/
+-->
 
 @model Microsoft.Fx.Portability.Reports.RazorHtmlObject
 

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_BreakingChangesReport.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_BreakingChangesReport.cshtml
@@ -1,0 +1,240 @@
+﻿/*
+   Copyright (c) Microsoft. All rights reserved.
+   Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*/
+
+@model Microsoft.Fx.Portability.Reports.RazorHtmlObject
+
+@using Microsoft.Fx.Portability
+@using Microsoft.Fx.Portability.ObjectModel
+@using Microsoft.Fx.Portability.Reporting.ObjectModel
+@using Microsoft.Fx.Portability.Resources
+@using System.IO
+@using System.Linq
+@using System.Runtime.Versioning
+
+@{
+    var reportingResult = Model.ReportingResult;
+}
+
+@helper WriteStyledBreakingChangeCount(IEnumerable<KeyValuePair<BreakingChange, IEnumerable<MemberInfo>>> breaks, int warningThreshold, int errorThreshold)
+{
+    var count = breaks.Count();
+    var colorClass = count <= warningThreshold ? "NoBreakingChanges" : (count <= errorThreshold ? "FewBreakingChanges" : "ManyBreakingChanges");
+    <span class="@colorClass">@count</span>
+}
+
+@helper WriteAssembly(AssemblyInfo assembly, string friendlyName = null)
+{
+    var nameToDisplay = friendlyName ?? assembly.ToString();
+    <span class="assembly-name">@nameToDisplay</span>
+    if (!string.IsNullOrEmpty(assembly.TargetFrameworkMoniker))
+    {
+        <span class="assembly-tfm">(@assembly.TargetFrameworkMoniker)</span>
+    }
+}
+
+@helper WriteCompatibilityResults(string name, string description, IEnumerable<KeyValuePair<BreakingChange, IEnumerable<MemberInfo>>> breaks, int warningThreshold, int errorThreshold)
+{
+    <h4><abbr title="@description">@name</abbr> - @WriteStyledBreakingChangeCount(breaks, warningThreshold, errorThreshold)</h4>
+    <div id="BreakDetails" class="BreakDetails">
+        @if (breaks.Count() > 0)
+        {
+            <table>
+                <colgroup>
+                    <col span="1" class="BreakingChangeID">
+                    <col span="1" class="APIColumn">
+                    <col span="2" class="LongDescriptionColumn">
+                </colgroup>
+                <tbody>
+                    <tr>
+                        <th>ID</th>
+                        <th>API</th>
+                        <th>Details</th>
+                        <th>Recommendation</th>
+                        <th class="NarrowHeader"><div>Quirked</div></th>
+                        <th class="NarrowHeader"><div>Version Introduced</div></th>
+                        <th class="NarrowHeader"><div>Version Reverted</div></th>
+                        <th class="NarrowHeader"><div>Analyzer Available</div></th>
+                        <th class="NarrowHeader"><div>Link</div></th>
+                    </tr>
+                    @foreach (KeyValuePair<BreakingChange, IEnumerable<MemberInfo>> b in breaks)
+                    {
+                        <tr>
+                            <td>@b.Key.Id</td>
+                            <td class="MemberNames">
+                                <ul>
+                                    @foreach (string member in @b.Value.Select(m => m.ToString()).Distinct().OrderBy(s => s)) // Distinct because the members can appear multiple times if they exist in multiple referenced assemblies
+                                    {
+                                        // Remove the docid member/type prefix
+                                        var index = member.IndexOf(":");
+                                        var fixedName = index > -1 ? member.Substring(index + 1) : member;
+                                        <li>@fixedName</li>
+                                    }
+                                </ul>
+                            </td>
+                            <td>@{WriteLiteral(Html.ConvertMarkdownToHtml(b.Key.Details));}</td>
+                            <td>@{WriteLiteral(Html.ConvertMarkdownToHtml(b.Key.Suggestion));}</td>
+                            <td>@b.Key.IsQuirked</td>
+                            <td>@b.Key.VersionBroken</td>
+                            <td>@b.Key.VersionFixed</td>
+                            @{
+                                var analyzerText = b.Key.IsSourceAnalyzerAvailable ? "Yes" : string.Empty;
+                            }
+                            <td>@analyzerText</td>
+                            <td>
+                                @if (!string.IsNullOrWhiteSpace(b.Key.Link))
+                                {
+                                    <a href="@b.Key.Link">More info</a>
+                                }
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+        else
+        {
+            <p class="CompatMessage GoodMessage">No @name.ToLowerInvariant() detected.</p>
+        }
+    </div>
+}
+
+@helper WriteCompatSummary(IDictionary<BreakingChange, IEnumerable<MemberInfo>> breaks, AssemblyInfo assembly, ReportingResult reportingResult, int loopCounter)
+{
+    var majorIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Major && !b.Key.IsRetargeting);
+    var minorIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Minor && !b.Key.IsRetargeting);
+    var edgeIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Edge && !b.Key.IsRetargeting);
+    var totalCompatIssues = majorIssues.Count() + minorIssues.Count() + edgeIssues.Count();
+    var majorRetargetingIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Major && b.Key.IsRetargeting);
+    var minorRetargetingIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Minor && b.Key.IsRetargeting);
+    var edgeRetargetingIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Edge && b.Key.IsRetargeting);
+    var totalRetargetingIssues = majorRetargetingIssues.Count() + minorRetargetingIssues.Count() + edgeRetargetingIssues.Count();
+
+    // Don't bother writing details for assemblies without issues
+    if (totalCompatIssues + totalRetargetingIssues == 0)
+    {
+        return;
+    }
+
+    var runtimeIssuesDivName = "RuntimeIssues" + loopCounter.ToString();
+    var retargetingIssuesDivName = "RetargetingIssues" + loopCounter.ToString();
+    var runtimeIssuesButtonName = "Toggle" + runtimeIssuesDivName;
+    var retargetingIssuesButtonName = "Toggle" + retargetingIssuesDivName;
+
+    <div id="assemblyCompatDetails">
+        @if (assembly != null)
+        {
+            <h3><a name="Compat-@assembly">@WriteAssembly(assembly, reportingResult.GetNameForAssemblyInfo(assembly))</a></h3>
+        }
+        <h3>Runtime Compatibility Issues (@totalCompatIssues) <button class="ToggleButton" id="@runtimeIssuesButtonName">&#8212</button></h3>
+        <div id="@runtimeIssuesDivName">
+            <p>@LocalizedStrings.RuntimeCompatIssueDescription</p>
+            @WriteCompatibilityResults("Major Compatibility Issues", LocalizedStrings.MajorCompatIssueDescription, majorIssues, 0, 2)
+            @WriteCompatibilityResults("Minor Compatibility Issues", LocalizedStrings.MinorCompatIssueDescription, minorIssues, 0, 3)
+            @WriteCompatibilityResults("Edge Compatibility Issues", LocalizedStrings.EdgeCompatIssueDescription, edgeIssues, 0, 100)
+        </div>
+        <h3>Retargeting Compatibility Issues (@totalRetargetingIssues) <button class="ToggleButton" id="@retargetingIssuesButtonName">+</button></h3>
+        <div class="BeginToggledOff" id="@retargetingIssuesDivName">
+            <p>@Html.Raw(LocalizedStrings.RetargetingCompatIssueDescriptionPart1)</p>
+            <p>@Html.Raw(LocalizedStrings.RetargetingCompatIssueDescriptionPart2)</p>
+            @WriteCompatibilityResults("Major Retargeting Issues", LocalizedStrings.MajorCompatIssueDescription, majorRetargetingIssues, 0, 2)
+            @WriteCompatibilityResults("Minor Retargeting Issues", LocalizedStrings.MinorCompatIssueDescription, minorRetargetingIssues, 0, 3)
+            @WriteCompatibilityResults("Edge Retargeting Issues", LocalizedStrings.EdgeCompatIssueDescription, edgeRetargetingIssues, 0, 100)
+        </div>
+    </div>
+    <p>
+        <a href="#@LocalizedStrings.CompatibilityPageTitle">@LocalizedStrings.BackToSummary</a>
+    </p>
+    <br />
+}
+
+<h2>
+    <a name="@LocalizedStrings.CompatibilityPageTitle"></a>@LocalizedStrings.CompatibilityPageTitle
+</h2>
+<div id="summary-compat-byassembly">
+    <h3 class="compat-subheader">Per Assembly Overview:</h3>
+    <table>
+        <tbody>
+            <tr>
+                <th rowspan="2">@LocalizedStrings.AssemblyHeader</th>
+                <th colspan="3" class="textCentered"><abbr title="@LocalizedStrings.RuntimeCompatIssueDescription">Runtime Issues</abbr></th>
+                <th colspan="3" class="textCentered"><abbr title="@LocalizedStrings.RetargetingCompatIssueDescriptionPlainText">Retargeting Issues</abbr></th>
+            </tr>
+            <tr>
+                <th><abbr title="@LocalizedStrings.MajorCompatIssueDescription">Major</abbr></th>
+                <th><abbr title="@LocalizedStrings.MinorCompatIssueDescription">Minor</abbr></th>
+                <th><abbr title="@LocalizedStrings.EdgeCompatIssueDescription">Edge</abbr></th>
+                <th><abbr title="@LocalizedStrings.MajorCompatIssueDescription">Major</abbr></th>
+                <th><abbr title="@LocalizedStrings.MinorCompatIssueDescription">Minor</abbr></th>
+                <th><abbr title="@LocalizedStrings.EdgeCompatIssueDescription">Edge</abbr></th>
+            </tr>
+
+            @*Writing the summary body information here.*@
+            @foreach (var kvp in Model.OrderedBreakingChangesByAssembly)
+            {
+                var assm = kvp.Key;
+                if (!Model.OrderedBreakingChangeSkippedAssemblies.Contains(assm))
+                {
+                    var breaks = kvp.Value;
+                    var majorIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Major && !b.Key.IsRetargeting);
+                    var minorIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Minor && !b.Key.IsRetargeting);
+                    var edgeIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Edge && !b.Key.IsRetargeting);
+                    var majorRetargetingIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Major && b.Key.IsRetargeting);
+                    var minorRetargetingIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Minor && b.Key.IsRetargeting);
+                    var edgeRetargetingIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Edge && b.Key.IsRetargeting);
+
+                    // Determine if the row is important or not (based on issue counts)
+                    var rowClass = (majorIssues.Count() > 0 || minorIssues.Count() > 0) ? string.Empty : "lowPriRow";
+
+                    // Create a link to compat details if they will exist
+                    var link = (majorIssues.Count() + minorIssues.Count() + edgeIssues.Count() + majorRetargetingIssues.Count() + minorRetargetingIssues.Count() + edgeRetargetingIssues.Count()) > 0 ?
+                                "#Compat-" + assm :
+                                "#" + LocalizedStrings.CompatibilityPageTitle;
+                    <tr class="@rowClass">
+                        <td><strong><a href="@link">@WriteAssembly(assm, reportingResult.GetNameForAssemblyInfo(assm))</a></strong></td>
+                        <td class="textCentered">@WriteStyledBreakingChangeCount(majorIssues, 0, 2)</td>
+                        <td class="textCentered">@WriteStyledBreakingChangeCount(minorIssues, 0, 3)</td>
+                        <td class="textCentered">@WriteStyledBreakingChangeCount(edgeIssues, 0, 100)</td>
+                        <td class="textCentered">@WriteStyledBreakingChangeCount(majorRetargetingIssues, 0, 2)</td>
+                        <td class="textCentered">@WriteStyledBreakingChangeCount(minorRetargetingIssues, 0, 3)</td>
+                        <td class="textCentered">@WriteStyledBreakingChangeCount(edgeRetargetingIssues, 0, 100)</td>
+                    </tr>
+                }
+            }
+        </tbody>
+    </table>
+    <p>@LocalizedStrings.BreakingChangeDisclaimer</p>
+</div>
+@if (Model.OrderedBreakingChangeSkippedAssemblies.Count() > 0)
+{
+    <div id="summary-compat-skippedassemblies">
+        <h3 class="compat-subheader">Ignored Assemblies:</h3>
+        <table>
+            <tr>
+                <th>Assembly</th>
+            </tr>
+            @foreach(AssemblyInfo a in Model.OrderedBreakingChangeSkippedAssemblies)
+            {
+                <tr>
+                    <td>@WriteAssembly(a)</td>
+                </tr>
+            }
+        </table>
+    </div>
+}
+<div id="summary-compat-bybreakingchange">
+    <h3 class="compat-subheader">Submission Overview:</h3>
+
+    @WriteCompatSummary(Model.BreakingChangesSummary, null, null, 0)
+</div>
+<div id="CompatDetails">
+    @{
+        var loopCounter = 1;
+
+        foreach (var kvp in Model.OrderedBreakingChangesByAssembly)
+        {
+            @WriteCompatSummary(kvp.Value, kvp.Key, reportingResult, loopCounter++)
+        }
+    }
+</div>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
@@ -1,7 +1,7 @@
-﻿/*
+﻿<!--
    Copyright (c) Microsoft. All rights reserved.
    Licensed under the MIT license. See LICENSE file in the project root for full license information.
-*/
+-->
 
 @model Microsoft.Fx.Portability.Reports.RazorHtmlObject
 

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
@@ -1,0 +1,189 @@
+﻿/*
+   Copyright (c) Microsoft. All rights reserved.
+   Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*/
+
+@model Microsoft.Fx.Portability.Reports.RazorHtmlObject
+
+@using Microsoft.Fx.Portability
+@using Microsoft.Fx.Portability.Reporting.ObjectModel
+@using Microsoft.Fx.Portability.Resources
+@using System.IO
+@using System.Linq
+@using System.Runtime.Versioning
+
+@{
+    var reportingResult = Model.ReportingResult;
+}
+
+@helper WriteTableDataStringWithStyle(string docId, string data, string cellStyle)
+{
+    <td style="@cellStyle">@data</td>
+    @* TODO: Add back in logic to create URIs when finished abstracting IReportWriter. *@
+    @*
+        var serviceHeaders = Model.ReportingResult.Headers;
+        <td style="@cellStyle">
+            @if (serviceHeaders.HasApiEndpoint)
+            {
+                <a href="@serviceHeaders.GetDocIdUrl(docId).AbsoluteUri">@data</a>
+            }
+            else
+            {
+                @data
+            }
+        </td>
+    *@
+}
+
+@helper WriteTableDataString(string docId, string data)
+{
+    <td>@data</td>
+    @* TODO: Add back in logic to create URIs when finished abstracting IReportWriter. *@
+    @*
+        var serviceHeaders = Model.ReportingResult.Headers;
+        <td>
+            @if (serviceHeaders.HasApiEndpoint)
+            {
+                <a href="@serviceHeaders.GetDocIdUrl(docId).AbsoluteUri">@data</a>
+            }
+            else
+            {
+                @data
+            }
+        </td>*@
+}
+
+@helper WriteTableVersionsRow(IEnumerable<Version> usedVersions)
+{
+    foreach (var version in Model.GetMatchingTargetsAndSupportedVersions(usedVersions))
+    {
+        var className = version.SupportedIn == null || version.Target.Version < version.SupportedIn ? "IconErrorEncoded" : "IconSuccessEncoded";
+        <td class="@className"></td>
+    }
+}
+
+@helper WriteAssembly(Microsoft.Fx.Portability.ObjectModel.AssemblyInfo assembly)
+{
+    <span class="assembly-name">@assembly</span>
+    if (!string.IsNullOrEmpty(assembly.TargetFrameworkMoniker))
+    {
+        <span class="assembly-tfm">(@assembly.TargetFrameworkMoniker)</span>
+    }
+}
+
+<h2 _locid="SummaryTitle">
+    <a name="@LocalizedStrings.PortabilitySummaryPageTitle"></a>@LocalizedStrings.PortabilitySummaryPageTitle
+</h2>
+<table>
+    <tbody>
+        <tr>
+            <th>@LocalizedStrings.AssemblyHeader</th>
+            @foreach (var target in Model.TargetHeaders)
+            {
+                <th>@target</th>
+            }
+        </tr>
+
+        @*Writing the summary body information here.*@
+        @foreach (var assembly in Model.OrderedAssembliesByIdentity)
+        {
+            <tr>
+                <td><strong><a href="#@assembly.SourceAssembly">@WriteAssembly(assembly.SourceAssembly)</a></strong></td>
+                @foreach (var usageData in @assembly.UsageData)
+                {
+                    <td class="text-center">@usageData.PortabilityIndex.ToString("P2")</td>
+                }
+            </tr>
+        }
+        @foreach (var invalidAssembly in reportingResult.GetAssembliesWithError())
+        {
+            var fileName = Path.GetFileName(invalidAssembly);
+            var message = string.Format("{0} is an invalid assembly.", fileName);
+            <tr>
+                <td>@message</td>
+            </tr>
+        }
+    </tbody>
+</table>
+<div id="details">
+    @foreach (var assembly in Model.OrderedAssembliesByIdentity)
+    {
+        // avoid writing blank details tables (happens if a non-.NET assembly is analyzed)
+        bool isDotNETAssembly = false;
+        foreach (var type in Model.MissingTypes)
+        {
+            if (type.UsedIn.Contains(assembly.SourceAssembly))
+            {
+                isDotNETAssembly = true;
+                break;
+            }
+        }
+        if (!isDotNETAssembly)
+        {
+            continue;
+        }
+
+        var assemblyName = reportingResult.GetNameForAssemblyInfo(assembly.SourceAssembly);
+        <a name="#@assembly.SourceAssembly"><h3>@WriteAssembly(assembly.SourceAssembly)</h3></a>
+        var usedUnresolvedAssembly = Model.GetUnresolvedAssemblies(assembly);
+        if (usedUnresolvedAssembly.Count > 0)
+        {
+            <table>
+                <tbody>
+                    <tr><th>Missing Assemblies</th></tr>
+                    @foreach (var name in usedUnresolvedAssembly)
+                    {
+                        <tr><td>@name</td></tr>
+                    }
+                </tbody>
+            </table>
+            <a>&nbsp;</a> @*insert a blank line for readability*@
+        }
+
+        var detailColumnHeaders = new List<string>();
+        detailColumnHeaders.Add(LocalizedStrings.TargetTypeHeader);
+        detailColumnHeaders.AddRange(Model.TargetHeaders);
+        detailColumnHeaders.Add(LocalizedStrings.RecommendedChanges);
+        <table>
+            <tbody>
+                <tr>
+                    @foreach (var header in detailColumnHeaders)
+                    {
+                        <th>@header</th>
+                    }
+                </tr>
+                @*  IsMissing  => the type is entirely unsupported
+                    !IsMissing => only some members are unsupported *@
+                @foreach (var type in Model.MatchingMissingTypes(assembly))
+                {
+                    var name = Model.RemoveTypeOrMemberPrefix(type.TypeName);
+                    <tr>
+                        @WriteTableDataString(type.TypeName, name)
+                        @WriteTableVersionsRow(type.TargetVersionStatus)
+                        <td>@type.RecommendedChanges</td>
+                    </tr>
+                    @*write a row for each of the type's missing members*@
+                    foreach (var member in type.MissingMembers.OrderBy(y => y.MemberName).ToList())
+                    {
+                        var formattedName = member.MemberName.Substring(type.TypeName.Length + 1);
+                        <tr>
+                            @WriteTableDataStringWithStyle(member.DocId, formattedName, "padding-left:2em")
+                            @WriteTableVersionsRow(member.TargetVersionStatus)
+                            <td>@member.RecommendedChanges</td>
+                        </tr>
+                    }
+                    <tr>
+                        @foreach (var column in detailColumnHeaders)
+                        {
+                            <td>&nbsp;</td>
+                        }
+                    </tr>
+                }
+            </tbody>
+        </table>
+
+        <p>
+            <a href="#@LocalizedStrings.PortabilitySummaryPageTitle">@LocalizedStrings.BackToSummary</a>
+        </p>
+    }
+</div>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Scripts.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Scripts.cshtml
@@ -1,7 +1,7 @@
-﻿/*
+﻿<!--
    Copyright (c) Microsoft. All rights reserved.
    Licensed under the MIT license. See LICENSE file in the project root for full license information.
-*/
+-->
 
 <script>
     // Toggle the element controlled by a toggle button on or off

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Scripts.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Scripts.cshtml
@@ -1,0 +1,43 @@
+﻿/*
+   Copyright (c) Microsoft. All rights reserved.
+   Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*/
+
+<script>
+    // Toggle the element controlled by a toggle button on or off
+    function toggle(caller) {
+        var elementName = this.id.substr(6);
+        var element = document.getElementById(elementName);
+        var currentClass = element.getAttribute('class');
+        if (currentClass === null) {
+            // If the element has no class, then it's on. Turn it off.
+            element.setAttribute('class', 'ToggledOff');
+            this.innerHTML = '+';
+        }
+        else if (currentClass.search(/\bToggledOff\b/) > -1) {
+            // If it has ToggledOff as a class, then it's off. Turn it on.
+            element.setAttribute('class', currentClass.replace(/\bToggledOff\b/, '').trim());
+            this.innerHTML = '&#8212';
+        }
+        else {
+            // If it doesn't have ToggledOff as a class, then it's on. Turn it off.
+            element.setAttribute('class', currentClass.concat(' ToggledOff').trim());
+            this.innerHTML = '+';
+        }
+    }
+
+    // Hook up toggle buttons' click events
+    var toggleButtons = document.getElementsByClassName('ToggleButton');
+    for (var i = 0; i < toggleButtons.length; i++) {
+        toggleButtons[i].addEventListener('click', toggle);
+    }
+
+    // Turn off any elements that should begin collapsed. Note that this is done with the extra
+    // BeginToggledOff class instead of applying ToggledOff directly to these elements because they should be
+    // visible if javascript is unavailable for some reason.
+    var beginCollapsed = document.getElementsByClassName('BeginToggledOff');
+    for (var i = 0; i < beginCollapsed.length; i++) {
+        var currentClass = beginCollapsed[i].getAttribute('class');
+        beginCollapsed[i].setAttribute('class', currentClass.concat(' ToggledOff').trim());
+    }
+</script>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Styles.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Styles.cshtml
@@ -1,0 +1,286 @@
+﻿/*
+   Copyright (c) Microsoft. All rights reserved.
+   Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*/
+
+<style>
+    /* Body style, for the entire document */
+    body {
+        background: #F3F3F4;
+        color: #1E1E1F;
+        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        padding: 0;
+        margin: 0;
+    }
+
+    /* Header1 style, used for the main title */
+    h1 {
+        padding: 10px 0px 10px 10px;
+        font-size: 21pt;
+        background-color: #E2E2E2;
+        border-bottom: 1px #C1C1C2 solid;
+        color: #201F20;
+        margin: 0;
+        font-weight: normal;
+    }
+
+    /* Header2 style, used for "Overview" and other sections */
+    h2 {
+        font-size: 18pt;
+        font-weight: normal;
+        padding: 15px 0 5px 0;
+        margin: 0;
+    }
+
+    /* Header3 style, used for sub-sections, such as project name */
+    h3 {
+        font-weight: normal;
+        font-size: 15pt;
+        margin: 0;
+        padding: 15px 0 5px 0;
+        background-color: transparent;
+    }
+
+    h4 {
+        font-weight: normal;
+        font-size: 13pt;
+        margin: 0;
+        padding: 0 0 0 0;
+        background-color: transparent;
+    }
+
+    /* Color all hyperlinks one color */
+    a {
+        color: #1382CE;
+    }
+
+    /* Paragraph text (for longer informational messages) */
+    p {
+        font-size: 10pt;
+    }
+
+    /* Make sure abbreviations are decorated on all browsers */
+    abbr {
+        text-decoration: none;
+        border-bottom: 1px dotted;
+    }
+
+    /* Table styles */
+    table {
+        border-spacing: 0 0;
+        border-collapse: collapse;
+        font-size: 10pt;
+    }
+
+        table th {
+            background: #E7E7E8;
+            text-align: left;
+            text-decoration: none;
+            font-weight: normal;
+            vertical-align: bottom;
+            padding: 3px 6px 3px 6px;
+        }
+
+        table td {
+            vertical-align: top;
+            padding: 3px 6px 5px 5px;
+            margin: 0px;
+            border: 1px solid #E7E7E8;
+            background: #F7F7F8;
+        }
+
+    .lowPriRow td {
+        background: #F0F0F0;
+    }
+
+    .lowPriRow a {
+        color: #6f9bba;
+    }
+
+
+    .lowPriRow .NoBreakingChanges {
+        color: #4e7e4e;
+    }
+
+    .lowPriRow .FewBreakingChanges {
+        color: #eeb550;
+    }
+
+    .lowPriRow .ManyBreakingChanges {
+        color: #ff7070;
+    }
+
+    .BreakDetails table {
+        table-layout: fixed;
+        width: 100%;
+        word-wrap: break-word;
+    }
+
+    .BreakingChangeID {
+        width: 35px;
+    }
+
+    .APIColumn {
+        width: 20%;
+    }
+
+    .LongDescriptionColumn {
+        width: 30%;
+    }
+
+    th.NarrowHeader {
+        height: 68px;
+    }
+
+    .NarrowHeader div {
+        height: 100%;
+        width: 68px;
+        min-width: 68px;
+        word-wrap: normal;
+        transform: rotate(-90deg);
+        -webkit-transform: rotate(-90deg); /* Safari/Chrome */
+        -moz-transform: rotate(-90deg); /* Firefox */
+        -o-transform: rotate(-90deg); /* Opera */
+        -ms-transform: rotate(-90deg); /* IE 9 */
+    }
+
+    .NoBreakingChanges {
+        color: #006400;
+        font-weight: bold;
+    }
+
+    .FewBreakingChanges {
+        color: #ffa500;
+        font-weight: bold;
+    }
+
+    .ManyBreakingChanges {
+        color: #dd0000;
+        font-weight: bold;
+    }
+
+    .BreakDetails {
+        margin-left: 30px;
+    }
+
+    .CompatMessage {
+        font-style: italic;
+        font-size: 10pt;
+    }
+
+    .GoodMessage {
+        color: darkgreen;
+    }
+
+    .ToggleButton {
+        font-size: 16px;
+        padding: 0px 3px;
+        color: #ffffff;
+        border-radius: 4px;
+        border: 1px solid #657298;
+        background-color: #9bb4d7;
+        display: inline-block;
+    }
+
+        .ToggleButton:hover {
+            background-color: #7892c2;
+        }
+
+    .ToggledOff {
+        display: none;
+    }
+
+    .MemberNames ul {
+        list-style-type: none;
+        padding: 0px;
+        margin: 0px;
+    }
+
+    .MemberNames li {
+        padding-bottom: 4px;
+    }
+
+    /* Local link is a style for hyperlinks that link to file:/// content, there are lots so color them as 'normal' text until the user mouse overs */
+    .localLink {
+        color: #1E1E1F;
+        background: #EEEEED;
+        text-decoration: none;
+    }
+
+        .localLink:hover {
+            color: #1382CE;
+            background: #FFFF99;
+            text-decoration: none;
+        }
+
+    /* Center text, used in the over views cells that contain message level counts */
+    .textCentered {
+        text-align: center;
+    }
+
+    /* The message cells in message tables should take up all avaliable space */
+    .messageCell {
+        width: 100%;
+    }
+
+    /* Padding around the content after the h1 */
+    #content {
+        padding: 0px 12px 12px 12px;
+    }
+
+    /* The overview table expands to width, with a max width of 97% */
+    #overview table {
+        width: auto;
+        max-width: 75%;
+    }
+
+    /* The messages tables are always 97% width */
+    #messages table {
+        width: 97%;
+    }
+
+    /* All Icons */
+    .IconSuccessEncoded, .IconInfoEncoded, .IconWarningEncoded, .IconErrorEncoded {
+        min-width: 18px;
+        min-height: 18px;
+        background-repeat: no-repeat;
+        background-position: center;
+    }
+
+    /* Success icon encoded */
+    .IconSuccessEncoded {
+        /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+        /* [---XsltValidateInternal-Base64EncodedImage:IconSuccess#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABPElEQVR4Xp1Tv0vDUBi8FqeA4NpBcBLcWnQSApncOnTo4FSnjP0DsnXpH5CxiwbHDg4Zuj4oOEXiJgiC4FDcCkLWmIMc1Pfw+eMgQ77v3Xf3Pe51YKGqqisAEwCR1TIAsiAIblSo6xrdHeJR85Xle3mdmCQKb0PsfqyxxzM8K15HZADl/H5+sHpZwYfxyRjTs+kWwKBx8yoHd2mRiuzF8mkJniWH/13u3Fjrs/EdhsdDFHGB/DLXEJBDLh1MWPAhPo1BLB4WX5yQywHR+m3tVe/t97D52CB/ziG0nIgD/qDuYg8WuCcVZ2YGwlJ3YDugkpR/VNcAEx6GEKhERSr71FuO4YCM4XBdwKvecjIlkSnsO0Hyp/GxSeJAdzBKzpOtnPwyyiPdAZhpZptT04tU+zk7s8czeges//s5C5+CwqrR4/gw+AAAAABJRU5ErkJggg==);
+    }
+
+    /* Information icon encoded */
+    .IconInfoEncoded {
+        /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+        /* [---XsltValidateInternal-Base64EncodedImage:IconInformation#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABHElEQVR4Xs2TsUoDQRRF7wwoziokjZUKadInhdhukR9YP8DMX1hYW+QvdsXa/QHBbcXC7W0CamWTQnclFutceIQJwwaWNLlwm5k5d94M76mmaeCrrmsLYOocY12FcxZFUeozCqKqqgYA8uevv1H6VuPxcwlfk5N92KHBxfFeCSAxxswlYAW/Xr989x/mv9gkhtyMDhcAxgzRsp7flj8B/HF1RsMXq+NZMkopaHe7lbKxQUEIGbKsYNoGn969060hZBkQex/W8oRQwsQaW2o3Ago2SVcJUzAgY3N0lTCZZm+zPS8HB51gMmS1DEYyOz9acKO1D8JWTlafKIMxdhvlfdyT94Vv5h7P8Ky7nQzACmhvKq3zk3PjW9asz9D/1oigecsioooAAAAASUVORK5CYII=);
+    }
+
+    /* Warning icon encoded */
+    .IconWarningEncoded {
+        /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+        /* [---XsltValidateInternal-Base64EncodedImage:IconWarning#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAx0lEQVR4XpWSMQ7CMAxFf4xAyBMLCxMrO8dhaBcuwdCJS3RJBw7SA/QGTCxdWJgiQYWKXJWKIXHIlyw5lqr34tQgEOdcBsCOx5yZK3hCCKdYXneQkh4pEfqzLfu+wVDSyyzFoJjfz9NB+pAF+eizx2Vruts0k15mPgvS6GYvpVtQhB61IB/dk6AF6fS4Ben0uIX5odtFe8Q/eW1KvFeH4e8khT6+gm5B+t3juyDt7n0jpe+CANTd+oTUjN/U3yVaABnSUjFz/gFq44JaVSCXeQAAAABJRU5ErkJggg==);
+    }
+
+    /* Error icon encoded */
+    .IconErrorEncoded {
+        /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+        /* [---XsltValidateInternal-Base64EncodedImage:IconError#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABQElEQVR4XqWTvUoEQRCE6wYPZUA80AfwAQz23uCMjA7MDRQEIzPBVEyNTQUFIw00vcQTTMzuAh/AxEQQT8HF/3G/oGGnEUGuoNnd6qoZuqltyKEsyzVJq5I6rnUp6SjGeGhESikzzlc1eL7opfuVbrqbU1Zw9NCgtQMaZpY0eNnaaL2fHusvTK5vKu7sjSS1Y4y3QUA6K3e3Mau5UFDyMP7tYF9o8cAHZv68vipoIJg971PZIZ5HiwdvYGGvFVFHmGmZ2MxwmQYPXubPl9Up0tfoMQGetXd6mRbvhBw+boZ6WF7Mbv1+GsHRk0fQmPAH1GfmZirbCfDJ61tw3Px8/8pZsPAG4jlVhcPgZ7adwNWBB68lkRQWFiTgFlbnLY3DGGM7izIJIyT/jjIvEJw6fdJTc6krDzh6aMwMP9bvDH4ADSsa9uSWVJkAAAAASUVORK5CYII=);
+    }
+
+    .tocItem {
+        font-size: 14pt;
+    }
+
+    .compat-subheader {
+        font-weight: 700;
+        font-style: italic;
+    }
+</style>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Styles.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Styles.cshtml
@@ -1,7 +1,7 @@
-﻿/*
+﻿<!--
    Copyright (c) Microsoft. All rights reserved.
    Licensed under the MIT license. See LICENSE file in the project root for full license information.
-*/
+-->
 
 <style>
     /* Body style, for the entire document */

--- a/src/Microsoft.Fx.Portability.Reports.Html/TargetSupportedIn.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/TargetSupportedIn.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.Versioning;
+
+namespace Microsoft.Fx.Portability.Reports
+{
+    public sealed class TargetSupportedIn
+    {
+        public readonly Version SupportedIn;
+
+        public readonly FrameworkName Target;
+
+        public TargetSupportedIn(FrameworkName target, Version supportedIn)
+        {
+            Target = target;
+            SupportedIn = supportedIn;
+        }
+    }
+}

--- a/src/Microsoft.Fx.Portability.Reports.Html/app.config
+++ b/src/Microsoft.Fx.Portability.Reports.Html/app.config
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <configSections>
+        <sectionGroup name="system.web.webPages.razor" type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
+            <section name="host" type="System.Web.WebPages.Razor.Configuration.HostSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
+            <section name="pages" type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
+    <system.web>
+        <compilation debug="false" targetFramework="4.5" />
+    </system.web>
+    <system.web.webPages.razor>
+        <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+        <pages pageBaseType="System.Web.Mvc.WebViewPage">
+            <namespaces>
+                <add namespace="System.Web.Mvc" />
+                <add namespace="System.Web.Mvc.Ajax" />
+                <add namespace="System.Web.Mvc.Html" />
+                <add namespace="System.Web.Optimization" />
+                <add namespace="System.Web.Routing" />
+                <add namespace="WebApplication1" />
+                <add namespace="Microsoft.Fx.Portability.ObjectModel" />
+            </namespaces>
+        </pages>
+    </system.web.webPages.razor>
+    <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Microsoft.Fx.Portability.Reports.Html/packages.config
+++ b/src/Microsoft.Fx.Portability.Reports.Html/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MarkdownDeep.NET-Signed" version="1.5" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.0.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="RazorEngine" version="3.6.1" targetFramework="net45" />
+</packages> 

--- a/src/Microsoft.Fx.Portability.Reports.Json/JsonReportWriter.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Json/JsonReportWriter.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Fx.Portability.ObjectModel;
+using Microsoft.Fx.Portability.Reporting;
+using Newtonsoft.Json;
+using System.IO;
+
+namespace Microsoft.Fx.Portability.Reports
+{
+    public class JsonReportWriter : IReportWriter
+    {
+        private readonly ResultFormatInformation _formatInformation;
+
+        public JsonReportWriter()
+        {
+            _formatInformation = new ResultFormatInformation
+            {
+                DisplayName = "Json",
+                MimeType = "application/json",
+                FileExtension = ".json"
+            };
+        }
+
+        public ResultFormatInformation Format
+        {
+            get { return _formatInformation; }
+        }
+
+        public void WriteStream(Stream stream, AnalyzeResponse response)
+        {
+            using (var streamWriter = new StreamWriter(stream))
+            using (var writer = new JsonTextWriter(streamWriter))
+            {
+                DataExtensions.Serializer.Serialize(writer, response);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Fx.Portability.Reports.Json/Microsoft.Fx.Portability.Reports.Json.csproj
+++ b/src/Microsoft.Fx.Portability.Reports.Json/Microsoft.Fx.Portability.Reports.Json.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DBD3216D-7901-490D-B219-C63D3E001E0D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.Fx.Portability.Reports</RootNamespace>
+    <AssemblyName>Microsoft.Fx.Portability.Reports.Json</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Fx.Portability-net45\Microsoft.Fx.Portability-net45.csproj">
+      <Project>{fc1429e3-46c3-49ed-b99f-b45e1ccfb86b}</Project>
+      <Name>Microsoft.Fx.Portability-net45</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="JsonReportWriter.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Microsoft.Fx.Portability.Reports.Json/packages.config
+++ b/src/Microsoft.Fx.Portability.Reports.Json/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+</packages>

--- a/src/Microsoft.Fx.Portability/ApiPortClient.cs
+++ b/src/Microsoft.Fx.Portability/ApiPortClient.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Fx.Portability
             }
         }
 
-        public async Task<IEnumerable<byte[]>> GetAnalysisReportAsync(IApiPortOptions options)
+        public async Task<IEnumerable<byte[]>> GetAnalysisReportAsync(IApiPortOptions options, IEnumerable<string> outputFormats)
         {
             var dependencyInfo = _dependencyFinder.FindDependencies(options.InputAssemblies, _progressReport);
 
@@ -60,7 +60,7 @@ namespace Microsoft.Fx.Portability
             {
                 AnalyzeRequest request = GenerateRequest(options, dependencyInfo);
 
-                var tasks = options.OutputFormats
+                var tasks = outputFormats
                     .Select(f => GetResultFromServiceAsync(request, f))
                     .ToList();
 


### PR DESCRIPTION
These changes add the following (optional) components to ApiPort -

* Microsoft.FX.Portability.Offline (for offline analysis)
* A few seed breaking change files to allow for offline breaking change analysis (the expectation is that more breaking change files will be added as UE and subject matter experts review them)
* The HTML and Json report writers for offline use (including a couple minor bug fixes).

With these changes, users can inject offline components (via Unity.config) and run ApiPort entirely offline.