### PR TITLE
Make sure that the member name contains only safe characters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Today, the repository contains the following components:
 * **src/ApiPort** Console tool to access portability webservice.
 * **src/Microsoft.Fx.Portability** Provides common types for API Port.
 * **src/Microsoft.Fx.Portability-net45** A project targeting .NET 4.5 of Microsoft.Fx.Portability to allow desktop apps to directly reference it.  *Currently a work-around for beta VS 2015 behavior.*
-* **src/Microsoft.Fx.Portability.MetadataReader** Implements a dependency finder based off of [System.Reflection.Metadata](https://github.com/dotnet/corefx/tree/master/src/System.Reflection.Metadata)
+* **src/Microsoft.Fx.Portability.MetadataReader** Implements a dependency finder based off of [System.Reflection.Metadata](https://github.com/dotnet/corefx/tree/master/src/System.Reflection.Metadata). The library will generate DocIds that conform to [these specifications](https://msdn.microsoft.com/en-us/library/fsbx0t7x.aspx).
 * **tests/Microsoft.Fx.Portability.Tests** Provides tests for Microsoft.Fx.Portability.
 * **tests/Microsoft.Fx.Portability.MetadataReader.Tests** Provides tests for Microsoft.Fx.Portability.MetadataReader.
 

--- a/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfo.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfo.cs
@@ -221,6 +221,26 @@ namespace Microsoft.Fx.Portability.Analyzer
             }
         }
 
+        /// <summary>
+        /// Replace the non-safe characters (<>.,) in a method name with safe ones ({}#@)
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        private string GetDocIdSafeMemberName(string name)
+        {
+            char[] newName = new char[name.Length];
+            for (int i = 0; i < name.Length; i++)
+            {
+                if (name[i] == '<') newName[i] = '{';
+                else if (name[i] == '>') newName[i] = '}';
+                else if (name[i] == '.') newName[i] = '#';
+                else if (name[i] == ',') newName[i] = '@';
+                else newName[i] = name[i];
+
+            }
+            return new string(newName);
+        }
+
         private string GenerateMemberDocId()
         {
             var sb = new StringBuilder();
@@ -234,20 +254,16 @@ namespace Microsoft.Fx.Portability.Analyzer
             }
 
             sb.Append(".");
+            
+            // Make sure that the member name is safe by replacing the unwanted characters.
+            sb.Append(GetDocIdSafeMemberName(Name));
 
-            string name = Name.Replace("<", "{").Replace(">", "}");
             if (Kind == MemberKind.Method)
             {
-                sb.Append(name.Replace(".", "#"));  // Expected output is '#ctor' instead of '.ctor'
-
                 if (MethodSignature.GenericParameterCount > 0)
                 {
                     sb.Append($"``{MethodSignature.GenericParameterCount}");
                 }
-            }
-            else
-            {
-                sb.Append(name);
             }
 
             // Add the method signature 

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -26,6 +26,12 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         }
 
         [Fact]
+        public void NestedGenericTypesWithInvalidNames()
+        {
+            CompareDependencies(TestAssembly.NestedGenericTypesWithInvalidNames, NestedGenericTypesWithInvalidNamesDocId());
+        }
+
+        [Fact]
         // The IL version of this test includes a nested generic type in which the outer type is closed by the inner one is open
         // This is not possible to construct in C#, but was being encoded incorrectly by the metadata reader parser.
         public void NestedGenericTypesFromIL()
@@ -114,7 +120,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             var progressReporter = Substitute.For<IProgressReporter>();
 
             var dependencies = dependencyFinder.FindDependencies(new[] { assemblyToTestFileInfo }, progressReporter);
-            
+
             foreach (var dependency in dependencies.Dependencies)
             {
                 if (string.Equals(dependency.Key.MemberDocId, v, StringComparison.Ordinal))
@@ -143,6 +149,13 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             var expectedOrdered = expected
                 .OrderBy(o => o.Item1, StringComparer.Ordinal)
                 .ToList();
+
+            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            foreach (var item in foundDocIds)
+            {
+                sb.AppendLine(string.Format("yield return Tuple.Create(\"{0}\", 1);", item.Item1));
+            }
+
 
             Assert.Equal(expectedOrdered.Count, foundDocIds.Count);
 
@@ -194,6 +207,52 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             yield return Tuple.Create("T:System.Runtime.CompilerServices.RuntimeCompatibilityAttribute", 1);
             yield return Tuple.Create("T:System.Runtime.Versioning.TargetFrameworkAttribute", 1);
         }
+
+        private static IEnumerable<Tuple<string, int>> NestedGenericTypesWithInvalidNamesDocId()
+        {
+            yield return Tuple.Create("F:Microsoft.Fx.Portability.MetadataReader.Tests.OtherClass.<GetValues>d__0`1.{}1__state", 1);
+            yield return Tuple.Create("F:Microsoft.Fx.Portability.MetadataReader.Tests.OtherClass.<GetValues>d__0`1.{}2__current", 1);
+            yield return Tuple.Create("F:Microsoft.Fx.Portability.MetadataReader.Tests.OtherClass.<GetValues>d__0`1.{}l__initialThreadId", 1);
+            yield return Tuple.Create("M:Microsoft.Fx.Portability.MetadataReader.Tests.OtherClass.<GetValues>d__0`1.#ctor(System.Int32)", 1);
+            yield return Tuple.Create("M:Microsoft.Fx.Portability.MetadataReader.Tests.OtherClass.<GetValues>d__0`1.System#Collections#Generic#IEnumerable{System#Tuple{T@System#Int32}}#GetEnumerator", 1);
+            yield return Tuple.Create("M:System.Collections.Generic.IEnumerable`1.GetEnumerator", 1);
+            yield return Tuple.Create("M:System.Collections.Generic.IEnumerator`1.get_Current", 1);
+            yield return Tuple.Create("M:System.Collections.IEnumerable.GetEnumerator", 1);
+            yield return Tuple.Create("M:System.Collections.IEnumerator.MoveNext", 1);
+            yield return Tuple.Create("M:System.Collections.IEnumerator.Reset", 1);
+            yield return Tuple.Create("M:System.Collections.IEnumerator.get_Current", 1);
+            yield return Tuple.Create("M:System.Diagnostics.DebuggableAttribute.#ctor(System.Diagnostics.DebuggableAttribute.DebuggingModes)", 1);
+            yield return Tuple.Create("M:System.Diagnostics.DebuggerHiddenAttribute.#ctor", 1);
+            yield return Tuple.Create("M:System.Environment.get_CurrentManagedThreadId", 1);
+            yield return Tuple.Create("M:System.IDisposable.Dispose", 1);
+            yield return Tuple.Create("M:System.NotSupportedException.#ctor", 1);
+            yield return Tuple.Create("M:System.Object.#ctor", 1);
+            yield return Tuple.Create("M:System.Runtime.CompilerServices.CompilationRelaxationsAttribute.#ctor(System.Int32)", 1);
+            yield return Tuple.Create("M:System.Runtime.CompilerServices.CompilerGeneratedAttribute.#ctor", 1);
+            yield return Tuple.Create("M:System.Runtime.CompilerServices.IteratorStateMachineAttribute.#ctor(System.Type)", 1);
+            yield return Tuple.Create("M:System.Runtime.CompilerServices.RuntimeCompatibilityAttribute.#ctor", 1);
+            yield return Tuple.Create("M:System.Runtime.Versioning.TargetFrameworkAttribute.#ctor(System.String)", 1);
+            yield return Tuple.Create("T:Microsoft.Fx.Portability.MetadataReader.Tests.OtherClass.<GetValues>d__0`1", 1);
+            yield return Tuple.Create("T:System.Collections.Generic.IEnumerable`1", 1);
+            yield return Tuple.Create("T:System.Collections.Generic.IEnumerator`1", 1);
+            yield return Tuple.Create("T:System.Collections.IEnumerable", 1);
+            yield return Tuple.Create("T:System.Collections.IEnumerator", 1);
+            yield return Tuple.Create("T:System.Diagnostics.DebuggableAttribute", 1);
+            yield return Tuple.Create("T:System.Diagnostics.DebuggableAttribute.DebuggingModes", 1);
+            yield return Tuple.Create("T:System.Diagnostics.DebuggerHiddenAttribute", 1);
+            yield return Tuple.Create("T:System.Environment", 1);
+            yield return Tuple.Create("T:System.IDisposable", 1);
+            yield return Tuple.Create("T:System.NotSupportedException", 1);
+            yield return Tuple.Create("T:System.Object", 1);
+            yield return Tuple.Create("T:System.Runtime.CompilerServices.CompilationRelaxationsAttribute", 1);
+            yield return Tuple.Create("T:System.Runtime.CompilerServices.CompilerGeneratedAttribute", 1);
+            yield return Tuple.Create("T:System.Runtime.CompilerServices.IteratorStateMachineAttribute", 1);
+            yield return Tuple.Create("T:System.Runtime.CompilerServices.RuntimeCompatibilityAttribute", 1);
+            yield return Tuple.Create("T:System.Runtime.Versioning.TargetFrameworkAttribute", 1);
+            yield return Tuple.Create("T:System.Tuple`2", 1);
+            yield return Tuple.Create("T:System.Type", 1);
+        }
+
 
         private static IEnumerable<Tuple<string, int>> EmptyProjectMemberDocId()
         {

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReflectionMetadataInfoTests.cs" />
     <Compile Include="TestAssembly.cs" />
+    <EmbeddedResource Include="Tests\NestedGenericTypesWithInvalidNames.cs" />
     <EmbeddedResource Include="Tests\OpImplicitMethod2Parameter.cs" />
     <EmbeddedResource Include="Tests\OpImplicitMethod.cs" />
     <EmbeddedResource Include="Tests\Arglist.cs" />

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/TestAssembly.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/TestAssembly.cs
@@ -105,6 +105,15 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             }
         }
 
+        public static string NestedGenericTypesWithInvalidNames
+        {
+            get
+            {
+                var text = GetText("NestedGenericTypesWithInvalidNames.cs");
+                return new TestAssembly("NestedGenericTypesWithInvalidNames", text, new[] { s_mscorlib }).AssemblyPath;
+            }
+        }
+
         public static string ModsFromIL
         {
             get

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Tests/NestedGenericTypesWithInvalidNames.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Tests/NestedGenericTypesWithInvalidNames.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Fx.Portability.MetadataReader.Tests
+{
+    class CallOtherClass
+    {
+        static void Main(string[] args)
+        {
+            OtherClass.GetValues<int>();
+        }
+    }
+
+    public class OtherClass
+    {
+        internal static IEnumerable<Tuple<T, int>> GetValues<T>()
+        {
+            yield break;
+        }
+    }
+}


### PR DESCRIPTION
When we are producing the DocId for a member we need to make sure that name only contains safe characters.
This change introduces a method that does the following replacements:
'<' -> '{'
'>' -> '}'
'.' -> '#'
',' -> '@'

This method will be used for all the members on types.
Fixes #43.