### PR TITLE
Fix failing tests

### DIFF
--- a/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Fx.Portability.Analyzer
             {
                 CallingAssembly = CallingAssembly,
                 MemberDocId = $"T:{type}",
-                DefinedInAssemblyIdentity = type.IsAssemblySet ? _reader.FormatAssemblyInfo(type.DefinedInAssembly) : _currentAssemblyInfo
+                DefinedInAssemblyIdentity = type.DefinedInAssembly.HasValue ? _reader.FormatAssemblyInfo(type.DefinedInAssembly.Value) : _currentAssemblyInfo
             };
         }
 
@@ -123,9 +123,9 @@ namespace Microsoft.Fx.Portability.Analyzer
                 IsPrimitive = memberRefInfo.ParentType.IsPrimitiveType
             };
 
-            if (memberRefInfo.ParentType.IsAssemblySet)
+            if (memberRefInfo.ParentType.DefinedInAssembly.HasValue)
             {
-                dep.DefinedInAssemblyIdentity = _reader.FormatAssemblyInfo(memberRefInfo.ParentType.DefinedInAssembly);
+                dep.DefinedInAssemblyIdentity = _reader.FormatAssemblyInfo(memberRefInfo.ParentType.DefinedInAssembly.Value);
             }
             // If no assembly is set, then the type is either a primitive type or it's in the current assembly.
             // Mscorlib is special-cased for testing purposes.

--- a/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfo.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfo.cs
@@ -23,18 +23,15 @@ namespace Microsoft.Fx.Portability.Analyzer
             Names = other.Names;
             MethodSignature = other.MethodSignature;
             Module = other.Module;
-            IsArrayType = other.IsArrayType;
             ArrayTypeInfo = other.ArrayTypeInfo;
             IsTypeDef = other.IsTypeDef;
             IsPrimitiveType = other.IsPrimitiveType;
-            IsFunctionPointer = other.IsFunctionPointer;
             Kind = other.Kind;
             IsGenericInstance = other.IsGenericInstance;
             IsEnclosedType = other.IsEnclosedType;
             Name = other.Name;
             Namespace = other.Namespace;
             DefinedInAssembly = other.DefinedInAssembly;
-            IsAssemblySet = other.IsAssemblySet;
 
             if (other.ParentType != null)
             {
@@ -58,10 +55,9 @@ namespace Microsoft.Fx.Portability.Analyzer
                 Namespace = other2.Namespace;
             }
 
-            if (other2.IsAssemblySet)
+            if (other2.DefinedInAssembly.HasValue)
             {
                 DefinedInAssembly = other2.DefinedInAssembly;
-                IsAssemblySet = true;
             }
         }
 
@@ -73,15 +69,13 @@ namespace Microsoft.Fx.Portability.Analyzer
 
         public List<MemberMetadataInfo> GenericTypeArgs { get; set; }
 
-        public bool IsArrayType { get; set; }
+        public bool IsArrayType => !string.IsNullOrEmpty(ArrayTypeInfo);
 
         public string ArrayTypeInfo { get; set; }
 
         public bool IsTypeDef { get; set; }
 
         public bool IsPrimitiveType { get; set; }
-
-        public bool IsFunctionPointer { get; set; }
 
         public MemberKind Kind { get; set; }
 
@@ -95,9 +89,7 @@ namespace Microsoft.Fx.Portability.Analyzer
 
         public MemberMetadataInfo ParentType { get; set; }
 
-        public AssemblyReference DefinedInAssembly { get; set; }
-
-        public bool IsAssemblySet { get; set; }
+        public AssemblyReference? DefinedInAssembly { get; set; }
 
         public override string ToString()
         {

--- a/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfo.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfo.cs
@@ -127,6 +127,11 @@ namespace Microsoft.Fx.Portability.Analyzer
 
             sb.Append(string.Join(".", displayNames));
 
+            if (IsArrayType)
+            {
+                sb.Append(ArrayTypeInfo);
+            }
+
             return sb.ToString();
         }
 

--- a/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfoTypeProvider.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfoTypeProvider.cs
@@ -136,11 +136,10 @@ namespace Microsoft.Fx.Portability.Analyzer
                     };
 
                 case HandleKind.AssemblyReference:
-                    if (!name.IsAssemblySet)
+                    if (!name.DefinedInAssembly.HasValue)
                     {
                         return new MemberMetadataInfo(name)
                         {
-                            IsAssemblySet = true,
                             DefinedInAssembly = Reader.GetAssemblyReference((AssemblyReferenceHandle)(scope))
                         };
                     }
@@ -334,16 +333,17 @@ namespace Microsoft.Fx.Portability.Analyzer
 
         public MemberMetadataInfo GetFunctionPointerType(MethodSignature<MemberMetadataInfo> signature)
         {
-            StringBuilder nameSb = new StringBuilder("function ");
-            nameSb.Append(signature.ReturnType);
-            nameSb.Append(" (");
-            nameSb.Append(string.Join(",", signature.ParameterTypes));
-            nameSb.Append(")");
+            var pointerName = new StringBuilder("function ")
+                .Append(signature.ReturnType)
+                .Append(" (")
+                .Append(string.Join(",", signature.ParameterTypes))
+                .Append(")")
+                .ToString();
+
             return new MemberMetadataInfo()
             {
-                Name = nameSb.ToString(),
+                Name = pointerName,
                 MethodSignature = signature,
-                IsFunctionPointer = true,
                 Kind = MemberKind.Type
             };
         }
@@ -356,7 +356,6 @@ namespace Microsoft.Fx.Portability.Analyzer
 
         public MemberMetadataInfo GetArrayType(MemberMetadataInfo elementType, ArrayShape shape)
         {
-            elementType.IsArrayType = true;
             var builder = new StringBuilder("[");
 
             for (int i = 0; i < shape.Rank; i++)

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         [InlineData("Spec.cs", "F:N.X`1.q")]
         [InlineData("Spec.cs", "M:N.X`1.f")]
         [InlineData("Spec.cs", "M:N.X`1.bb(System.String,System.Int32@,System.Void*)")]
-        [InlineData("Spec.cs", "M:N.X`1.gg(System.Int16[],System.Int32[0:,0:])")] // Failing, tracked with https://github.com/Microsoft/dotnet-apiport/issues/96
+        [InlineData("Spec.cs", "M:N.X`1.gg(System.Int16[],System.Int32[0:,0:])")]
         [InlineData("Spec.cs", "M:N.X`1.op_Addition(N.X{`0},N.X{`0})")]
         [InlineData("Spec.cs", "M:N.X`1.get_prop")]
         [InlineData("Spec.cs", "M:N.X`1.set_prop(System.Int32)")]

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -55,14 +55,13 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         [InlineData("Spec.cs", "M:N.X`1.#ctor")]
         [InlineData("Spec.cs", "M:N.X`1.#ctor(System.Int32)")]
         [InlineData("Spec.cs", "F:N.X`1.q")]
-        [InlineData("Spec.cs", "F:N.X`1.PI")] // Failing, tracked with https://github.com/Microsoft/dotnet-apiport/issues/95
         [InlineData("Spec.cs", "M:N.X`1.f")]
         [InlineData("Spec.cs", "M:N.X`1.bb(System.String,System.Int32@,System.Void*)")]
         [InlineData("Spec.cs", "M:N.X`1.gg(System.Int16[],System.Int32[0:,0:])")] // Failing, tracked with https://github.com/Microsoft/dotnet-apiport/issues/96
         [InlineData("Spec.cs", "M:N.X`1.op_Addition(N.X{`0},N.X{`0})")]
         [InlineData("Spec.cs", "M:N.X`1.get_prop")]
         [InlineData("Spec.cs", "M:N.X`1.set_prop(System.Int32)")]
-        [InlineData("Spec.cs", "E:N.X`1.d")] // Failing, tracked with https://github.com/Microsoft/dotnet-apiport/issues/94
+        [InlineData("Spec.cs", "M:N.X`1.add_d(N.X{`0}.D)")]
         [InlineData("Spec.cs", "M:N.X`1.get_Item(System.String)")]
         [InlineData("Spec.cs", "T:N.X`1.Nested")]
         [InlineData("Spec.cs", "T:N.X`1.D")]

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -8,11 +8,19 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Fx.Portability.MetadataReader.Tests
 {
     public class ManagedMetadataReaderTests
     {
+        private readonly ITestOutputHelper _output;
+
+        public ManagedMetadataReaderTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [InlineData("Arglist.cs", "M:TestClass.ArglistMethod(System.Int32,__arglist)")]
         [InlineData("Arglist.cs", "M:TestClass.ArglistMethod2(__arglist)")]
         [InlineData("GenericClassMemberWithDifferentGeneric.cs", "M:Microsoft.Fx.Portability.MetadataReader.Tests.Tests.GenericClass`1.MemberWithDifferentGeneric``1(``0)")]
@@ -82,6 +90,9 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
                     return;
                 }
             }
+
+            _output.WriteLine("Found docids:");
+            _output.WriteLine(string.Join(Environment.NewLine, dependencies.Dependencies.Select(o => o.Key.MemberDocId).OrderBy(o => o)));
 
             Assert.True(false, $"Could not find docid '{docid}'");
         }

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ReflectionMetadataInfoTests.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ReflectionMetadataInfoTests.cs
@@ -8,11 +8,19 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Fx.Portability.MetadataReader.Tests
 {
     public class ReflectionMetadataInfoTests
     {
+        private readonly ITestOutputHelper _log;
+
+        public ReflectionMetadataInfoTests(ITestOutputHelper log)
+        {
+            _log = log;
+        }
+
         [Fact]
         public void UnresolvedAssemblyTest()
         {
@@ -26,6 +34,12 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             var actual = dependencies.UnresolvedAssemblies
                             .Select(u => u.Key)
                             .OrderBy(u => u);
+
+            _log.WriteLine("Actual unresolved assemblies:");
+            foreach(var assembly in actual)
+            {
+                _log.WriteLine(assembly);
+            }
 
             Assert.Equal(_expectedResult.Count(), actual.Count());
 
@@ -42,7 +56,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             progressReport.Received(0).ReportIssue(Arg.Any<string>());
         }
 
-        private IEnumerable<string> _expectedResult = new[]
+        private static readonly IEnumerable<string> _expectedResult = new[]
         {
             "Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
             "Microsoft.CodeAnalysis.CSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
@@ -52,6 +66,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             "NSubstitute, Version=1.8.1.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca",
             "System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
             "System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+            "xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c",
             "xunit.assert, Version=2.1.0.3109, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c",
             "xunit.core, Version=2.1.0.3109, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c"
         }.OrderBy(o => o);


### PR DESCRIPTION
There were some issues created to track various doc id generation failures.  Two of them (#94, #95) are actual non-issues (we don't generate the docid, but we don't need to).  The third (#96) was an actual issue where we weren't including array information for types (we were for methods).

Fix #96 
Fix #95 
Fix #94 