### PR TITLE
Show better help message when tool is run

### DIFF
--- a/src/ApiPort/CommandLine/AnalyzeOptionSet.cs
+++ b/src/ApiPort/CommandLine/AnalyzeOptionSet.cs
@@ -10,7 +10,7 @@ namespace ApiPort.CommandLine
     internal class AnalyzeOptionSet : ServiceEndpointOptionSet
     {
         public AnalyzeOptionSet(string name)
-            : base(name, AppCommands.AnalyzeAssemblies)
+            : base(name, AppCommands.AnalyzeAssemblies, LocalizedStrings.CmdAnalyzeHelp)
         {
             Add("f|file=", LocalizedStrings.ListOfAssembliesToAnalyze, UpdateInputAssemblies, true);
             Add("o|out=", LocalizedStrings.OutputFileName, e => OutputFileName = e);

--- a/src/ApiPort/CommandLine/CommandLineOptionSet.cs
+++ b/src/ApiPort/CommandLine/CommandLineOptionSet.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace ApiPort.CommandLine
 {
@@ -35,15 +36,18 @@ namespace ApiPort.CommandLine
             ".ildll"
         };
 
-        public CommandLineOptionSet(string name)
+        public CommandLineOptionSet(string name, string summaryMessage)
         {
             _name = name;
 
+            SummaryMessage = summaryMessage;
             ServiceEndpoint = "http://portability.cloudapp.net";
             Description = string.Empty;
             OutputFileName = "ApiPortAnalysis";
             RequestFlags = AnalyzeRequestFlags.None;
         }
+
+        public string SummaryMessage { get; }
 
         public void Add(string prototype, string description, Action<string> action, bool isRequired)
         {
@@ -70,7 +74,12 @@ namespace ApiPort.CommandLine
 
             if (ShowHelp || !ValidateValues())
             {
-                Console.WriteLine($"Available options for {_name}:");
+                var codebase = new Uri(this.GetType().GetTypeInfo().Assembly.CodeBase);
+                var path = Path.GetFileName(codebase.AbsolutePath);
+
+                Console.WriteLine($"{path} {_name} [options]");
+                Console.WriteLine();
+                Console.WriteLine(SummaryMessage);
                 Console.WriteLine();
 
                 WriteOptionDescriptions(Console.Out);

--- a/src/ApiPort/CommandLine/ServiceEndpointOptionSet.cs
+++ b/src/ApiPort/CommandLine/ServiceEndpointOptionSet.cs
@@ -5,8 +5,8 @@ namespace ApiPort.CommandLine
 {
     internal class ServiceEndpointOptionSet : CommandLineOptionSet
     {
-        public ServiceEndpointOptionSet(string name, AppCommands appCommand)
-            : base(name)
+        public ServiceEndpointOptionSet(string name, AppCommands appCommand, string summaryMessage)
+            : base(name, summaryMessage)
         {
             Command = appCommand;
 

--- a/src/ApiPort/CommandLineOptions.cs
+++ b/src/ApiPort/CommandLineOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ApiPort.CommandLine;
+using ApiPort.Resources;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,8 +14,8 @@ namespace ApiPort
         private static IDictionary<string, Func<string, CommandLineOptionSet>> s_possibleCommands = new Dictionary<string, Func<string, CommandLineOptionSet>>(StringComparer.OrdinalIgnoreCase)
         {
             {"analyze", name => new AnalyzeOptionSet(name) },
-            {"listOutputFormats", name => new  ServiceEndpointOptionSet(name, AppCommands.ListOutputFormats) },
-            {"listTargets", name => new  ServiceEndpointOptionSet(name, AppCommands.ListTargets) },
+            {"listOutputFormats", name => new  ServiceEndpointOptionSet(name, AppCommands.ListOutputFormats, LocalizedStrings.CmdListOutputFormats) },
+            {"listTargets", name => new  ServiceEndpointOptionSet(name, AppCommands.ListTargets, LocalizedStrings.CmdListTargets) },
         };
 
         public static ICommandLineOptions ParseCommandLineOptions(string[] args)
@@ -47,11 +48,11 @@ namespace ApiPort
                 Console.WriteLine();
             }
 
-            Console.WriteLine("Available Commands:");
-
             foreach (var command in s_possibleCommands)
             {
-                Console.WriteLine($"- {command.Key}");
+                Console.WriteLine();
+                Console.WriteLine(new string('=', Math.Min(Console.WindowWidth, 100)));
+                command.Value(command.Key).Parse(new[] { "-?" });
             }
 
             return CommandLineOptionSet.ExitCommandLineOption;

--- a/src/ApiPort/Resources/LocalizedStrings.Designer.cs
+++ b/src/ApiPort/Resources/LocalizedStrings.Designer.cs
@@ -106,6 +106,15 @@ namespace ApiPort.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Analyzes specified files/directories for IL and determines the APIs that are used. This information is analyzed for portability concerns or known breaking changes (depending on input parameters) and returns a report that gives a summary of issues and possible steps forward..
+        /// </summary>
+        public static string CmdAnalyzeHelp {
+            get {
+                return ResourceManager.GetString("CmdAnalyzeHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Specifies a json file defining assemblies that should not be analyzed for specific targets while analyzing breaking changes. This can be useful for excluding assemblies that are known to not regress on certain .NET Framework versions due to breaking changes. Note that, currently, this parameter only affects breaking change analysis; not portability analysis..
         /// </summary>
         public static string CmdHelpIgnoreAssembliesFile {
@@ -151,6 +160,24 @@ namespace ApiPort.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Retrieves a list of output formats that are available in which to receive reports.
+        /// </summary>
+        public static string CmdListOutputFormats {
+            get {
+                return ResourceManager.GetString("CmdListOutputFormats", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Retrieves a list of targets available to analyze assemblies against.
+        /// </summary>
+        public static string CmdListTargets {
+            get {
+                return ResourceManager.GetString("CmdListTargets", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Description.
         /// </summary>
         public static string Description {
@@ -172,8 +199,9 @@ namespace ApiPort.Resources {
         ///   Looks up a localized string similar to Microsoft (R) {0} v{1}
         ///Copyright (C) Microsoft Corporation. All rights reserved.
         ///
-        ///To learn more about how this tool works, including the data we are collecting, go here - http://go.microsoft.com/fwlink/?LinkId=397652
-        ///.
+        ///This tool analyzes .NET assemblies to determine possible problems moving between .NET platforms (such as Windows Store, desktop, Mono, .NET Core, etc) as well as between .NET Framework versions (ie 4.x-&gt;4.y).
+        ///
+        ///To learn more about how this tool works, including the data we are collecting, go here - http://go.microsoft.com/fwlink/?LinkId=397652.
         /// </summary>
         public static string Header {
             get {

--- a/src/ApiPort/Resources/LocalizedStrings.resx
+++ b/src/ApiPort/Resources/LocalizedStrings.resx
@@ -124,8 +124,11 @@
     <value>Microsoft (R) {0} v{1}
 Copyright (C) Microsoft Corporation. All rights reserved.
 
-To learn more about how this tool works, including the data we are collecting, go here - http://go.microsoft.com/fwlink/?LinkId=397652
-</value>
+This tool analyzes .NET assemblies to determine possible problems moving between .NET platforms (such as
+Windows Store, desktop, Mono, .NET Core, etc) as well as between .NET Framework versions (ie 4.x-&gt;4.y).
+
+To learn more about how this tool works, including the data we are collecting, 
+go here - http://go.microsoft.com/fwlink/?LinkId=397652</value>
   </data>
   <data name="ListOfAssembliesToAnalyze" xml:space="preserve">
     <value>Path to assembly file or directory of assemblies.</value>
@@ -230,5 +233,16 @@ To learn more about how this tool works, including the data we are collecting, g
   </data>
   <data name="CmdHelpSuppressBreakingChange" xml:space="preserve">
     <value>Specifies a breaking change (by ID) to suppress during breaking change analysis. Any breaking changes with IDs specified for suppression will not be reported.</value>
+  </data>
+  <data name="CmdAnalyzeHelp" xml:space="preserve">
+    <value>Analyzes specified files/directories for IL and determines the APIs that are used. This information
+is analyzed for portability concerns or known breaking changes (depending on input parameters)
+and returns a report that gives a summary of issues and possible steps forward.</value>
+  </data>
+  <data name="CmdListOutputFormats" xml:space="preserve">
+    <value>Retrieves a list of output formats that are available in which to receive reports</value>
+  </data>
+  <data name="CmdListTargets" xml:space="preserve">
+    <value>Retrieves a list of targets available to analyze assemblies against</value>
   </data>
 </root>


### PR DESCRIPTION
The current help message is not very informative and seems to cause confusion. This updates the help messages to show more detailed info:

```
Microsoft (R) API Portability Analyzer v1.1.0
Copyright (C) Microsoft Corporation. All rights reserved.

This tool analyzes .NET assemblies to determine possible problems moving between .NET platforms (such as Windows Store, desktop, Mono, .NET Core, etc) as well as between .NET Framework versions (ie 4.x->4.y).

To learn more about how this tool works, including the data we are collecting, go here - http://go.microsoft.com/fwlink/?LinkId=397652

====================================================================================================
ApiPort.exe analyze [options]

Analyzes specified files/directories for IL and determines the APIs that are used. This information is analyzed for portability concerns or known breaking changes (depending on input parameters) and returns a report that gives a summary of issues and possible steps forward.

  -e, --endpoint=VALUE       Service endpoint
  -f, --file=VALUE           [Required] Path to assembly file or directory of
                               assemblies.
  -o, --out=VALUE            Output file name
  -d, --description=VALUE    Description of the submission
  -t, --target=VALUE         The target you want to check against.
  -r, --resultFormat=VALUE   The report output format
  -p, --showNonPortableApis  Calculate non-portable APIs
  -b, --showBreakingChanges  Calculate breaking changes on full .NET Framework
      --noDefaultIgnoreFile  Do not use the standard assembly ignore list
                               when analyzing breaking changes. The default
                               ignore list can be found at KnownSafeBreaks.json
  -i, --ignoreAssemblyFile=VALUE
                             Specifies a json file defining assemblies that
                               should not be analyzed for specific targets
                               while analyzing breaking changes. This can be
                               useful for excluding assemblies that are known
                               to not regress on certain .NET Framework
                               versions due to breaking changes. Note that,
                               currently, this parameter only affects breaking
                               change analysis; not portability analysis.
  -s, --suppressBreakingChange=VALUE
                             Specifies a breaking change (by ID) to suppress
                               during breaking change analysis. Any breaking
                               changes with IDs specified for suppression will
                               not be reported.
  -h, -?, --help             Show help

====================================================================================================
ApiPort.exe listOutputFormats [options]

Retrieves a list of output formats that are available in which to receive reports

  -e, --endpoint=VALUE       Service endpoint
  -h, -?, --help             Show help

====================================================================================================
ApiPort.exe listTargets [options]

Retrieves a list of targets available to analyze assemblies against

  -e, --endpoint=VALUE       Service endpoint
  -h, -?, --help             Show help
```