### PR TITLE
Add documentation and build steps for offline mode

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,11 @@
+@ECHO OFF
+
+:: Libraries are currently pre-release
+SET VersionSuffix=alpha
+
+:: Default to a release build
+IF "%Configuration%"=="" SET Configuration=Release
+
+powershell -noprofile -executionpolicy bypass -file build\restore.ps1
+"%ProgramFiles(x86)%\MSBuild\14.0\bin\MSBuild.exe" /nologo /m /v:m /nr:false /flp:logfile=bin\%Configuration%\msbuild.log;verbosity=normal %*
+powershell -noprofile -executionpolicy bypass -file build\postbuild.ps1 -configuration %Configuration%

--- a/build/Get-CatalogFile.ps1
+++ b/build/Get-CatalogFile.ps1
@@ -29,4 +29,4 @@ function DownloadFile($url, $outputPath) {
 	}
 }
 
-DownloadFile "https://portabilitystorage.blob.core.windows.net/data/public%2Fcatalog.bin?sr=b&sv=2015-02-21&si=ReadPublicCatalog&sig=r0Q61Nm4ZAqXYbWIg76%2BYw4VGsw9%2BdWuN%2FeHJYHJguw%3D" $catalogPath
+DownloadFile "https://portabilitystorage.blob.core.windows.net/catalog/catalog.bin?sr=c&sv=2015-02-21&si=ReadCatalog&sig=8tOHoX2ZvcSFLol0GI6lxmydNPJbnJdHNLKr06aD7t4%3D" $catalogPath

--- a/dir.props
+++ b/dir.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
 	<OutputDrop>$(TF_BUILD_BINARIESDIRECTORY)</OutputDrop>
 	<OutputDrop Condition=" '$(OutputDrop)' == '' ">$(MSBuildThisFileDirectory)\bin\$(Configuration)\</OutputDrop>
+	<OutputIntermediate>$(MSBuildThisFileDirectory)\obj\$(Configuration)</OutputIntermediate>
     <NoWarn>1570,1572,1573,1574,1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>

--- a/docs/HowTo/OfflineMode.md
+++ b/docs/HowTo/OfflineMode.md
@@ -1,0 +1,18 @@
+# Offline Mode
+
+There are times when using the web service is not ideal (extremely large data sets, limited network connectivity, privacy concerns)and
+there is a mode that can enable offline analysis of projects. This is not listed on the release downloads, but can be built manually. 
+The steps to do this:
+
+1. Clone the project: `git clone https://github.com/Microsoft/dotnet-apiport`
+2. Build the project: `build.cmd`. 
+
+	*Note: This command must be used as it gathers the correct assemblies for offline mode. Building in VS does not do this.*
+	
+3. Go to `bin\release\ApiPort.Offline`
+4. Run `ApiPort.exe` from this directory as normal.
+
+## Report writers
+
+Additional reports can be generated in offline mode. Just implement `Microsoft.Fx.Portability.Reporting.IReportWriter` and add the correct
+entry to unity.config. The offline mode will pick it up and allow reports to be returned in custom formats.

--- a/src/ApiPort/ApiPort.csproj
+++ b/src/ApiPort/ApiPort.csproj
@@ -34,6 +34,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
+	<IntermediateOutputPath>$(OutputIntermediate)\$(AssemblyName)</IntermediateOutputPath>
     <OutputPath>$(OutputDrop)\$(AssemblyName)</OutputPath>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>

--- a/src/ApiPort/project.json
+++ b/src/ApiPort/project.json
@@ -4,8 +4,8 @@
   },
   "dependencies": {
     "Newtonsoft.Json": "6.0.8",
-    "Microsoft.Framework.Configuration.CommandLine": "1.0.0-beta7",
-    "Microsoft.Framework.OptionsModel": "1.0.0-beta7",
+    "Microsoft.Framework.Configuration.CommandLine": "1.0.0-beta5",
+    "Microsoft.Framework.OptionsModel": "1.0.0-beta5",
     "System.Reflection.Metadata": "1.1.0-alpha-00008",
     "System.Collections.Immutable": "1.1.37",
     "Unity": "3.5.1404"

--- a/src/Microsoft.Fx.Portability.MetadataReader/Microsoft.Fx.Portability.MetadataReader.NET45.csproj
+++ b/src/Microsoft.Fx.Portability.MetadataReader/Microsoft.Fx.Portability.MetadataReader.NET45.csproj
@@ -31,6 +31,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <NugetTarget>net45</NugetTarget>
+	<IntermediateOutputPath>$(OutputIntermediate)\$(AssemblyName)\$(NugetTarget)</IntermediateOutputPath>
     <OutputPath>$(OutputDrop)\$(AssemblyName)\$(NugetTarget)</OutputPath>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>

--- a/src/Microsoft.Fx.Portability.MetadataReader/Microsoft.Fx.Portability.MetadataReader.csproj
+++ b/src/Microsoft.Fx.Portability.MetadataReader/Microsoft.Fx.Portability.MetadataReader.csproj
@@ -35,6 +35,7 @@
   </PropertyGroup>
   <PropertyGroup>
 	<NugetTarget>dotnet</NugetTarget>
+	<IntermediateOutputPath>$(OutputIntermediate)\$(AssemblyName)\$(NugetTarget)</IntermediateOutputPath>
     <OutputPath>$(OutputDrop)\$(AssemblyName)\$(NugetTarget)</OutputPath>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>

--- a/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.NET45.csproj
+++ b/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.NET45.csproj
@@ -30,6 +30,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <NugetTarget>net45</NugetTarget>
+	<IntermediateOutputPath>$(OutputIntermediate)\$(AssemblyName)\$(NugetTarget)</IntermediateOutputPath>
     <OutputPath>$(OutputDrop)\$(AssemblyName)\$(NugetTarget)</OutputPath>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>

--- a/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
+++ b/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
   <PropertyGroup>
 	<NugetTarget>dotnet</NugetTarget>
+	<IntermediateOutputPath>$(OutputIntermediate)\$(AssemblyName)\$(NugetTarget)</IntermediateOutputPath>
     <OutputPath>$(OutputDrop)\$(AssemblyName)\$(NugetTarget)</OutputPath>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>

--- a/src/Microsoft.Fx.Portability.Offline/OfflineApiPortService.cs
+++ b/src/Microsoft.Fx.Portability.Offline/OfflineApiPortService.cs
@@ -34,7 +34,8 @@ namespace Microsoft.Fx.Portability
         {
             var targets = _lookup
                 .GetPublicTargets()
-                .Select(target => new AvailableTarget { Name = target.Identifier, Version = target.Version, IsSet = _defaultTargets.Contains(target) });
+                .Select(target => new AvailableTarget { Name = target.Identifier, Version = target.Version, IsSet = _defaultTargets.Contains(target) })
+				.OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase);
 
             var response = new ServiceResponse<IEnumerable<AvailableTarget>>(targets);
 

--- a/src/Microsoft.Fx.Portability.Reports.Html/Microsoft.Fx.Portability.Reports.Html.csproj
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Microsoft.Fx.Portability.Reports.Html.csproj
@@ -31,6 +31,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <NugetTarget>net45</NugetTarget>
+	<IntermediateOutputPath>$(OutputIntermediate)\$(AssemblyName)\$(NugetTarget)</IntermediateOutputPath>
     <OutputPath>$(OutputDrop)\$(AssemblyName)\$(NugetTarget)</OutputPath>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>

--- a/src/Microsoft.Fx.Portability.Reports.Json/Microsoft.Fx.Portability.Reports.Json.NET45.csproj
+++ b/src/Microsoft.Fx.Portability.Reports.Json/Microsoft.Fx.Portability.Reports.Json.NET45.csproj
@@ -31,6 +31,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <NugetTarget>net45</NugetTarget>
+	<IntermediateOutputPath>$(OutputIntermediate)\$(AssemblyName)\$(NugetTarget)</IntermediateOutputPath>
     <OutputPath>$(OutputDrop)\$(AssemblyName)\$(NugetTarget)</OutputPath>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>

--- a/src/Microsoft.Fx.Portability.Reports.Json/Microsoft.Fx.Portability.Reports.Json.csproj
+++ b/src/Microsoft.Fx.Portability.Reports.Json/Microsoft.Fx.Portability.Reports.Json.csproj
@@ -35,6 +35,7 @@
   </PropertyGroup>
   <PropertyGroup>
 	<NugetTarget>dotnet</NugetTarget>
+	<IntermediateOutputPath>$(OutputIntermediate)\$(AssemblyName)\$(NugetTarget)</IntermediateOutputPath>
     <OutputPath>$(OutputDrop)\$(AssemblyName)\$(NugetTarget)</OutputPath>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>

--- a/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.NET45.csproj
+++ b/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.NET45.csproj
@@ -30,6 +30,7 @@
   </PropertyGroup>
   <PropertyGroup>
 	<NugetTarget>net45</NugetTarget>
+	<IntermediateOutputPath>$(OutputIntermediate)\$(AssemblyName)\$(NugetTarget)</IntermediateOutputPath>
     <OutputPath>$(OutputDrop)\$(AssemblyName)\$(NugetTarget)</OutputPath>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>

--- a/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
+++ b/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
@@ -35,6 +35,7 @@
   </PropertyGroup>
   <PropertyGroup>
 	<NugetTarget>dotnet</NugetTarget>
+	<IntermediateOutputPath>$(OutputIntermediate)\$(AssemblyName)\$(NugetTarget)</IntermediateOutputPath>
     <OutputPath>$(OutputDrop)\$(AssemblyName)\$(NugetTarget)</OutputPath>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
This adds a build.cmd that will collect the assemblies needed for offline mode. There was also a build race issue with the default obj/ folders, so this separates each project to its own.