### PR TITLE
Adding logging and error checking to the report writer

### DIFF
--- a/src/Microsoft.Fx.Portability/Reporting/IFileWriter.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/IFileWriter.cs
@@ -7,6 +7,15 @@ namespace Microsoft.Fx.Portability.Reporting
 {
     public interface IFileWriter
     {
+        /// <summary>
+        /// Writes a report.
+        /// </summary>
+        /// <param name="report">Contents of the report</param>
+        /// <param name="extension">File extension of the report</param>
+        /// <param name="outputDirectory">Directory for the output</param>
+        /// <param name="filename">File name for report</param>
+        /// <param name="overwrite">true to overwrite file; otherwise will find a file name that is not conflicting by adding a numerical suffix to the filename</param>
+        /// <returns>The fully qualified name to the report or null if unable to write report.</returns>
         Task<string> WriteReportAsync(byte[] report, string extension, string outputDirectory, string filename, bool overwrite);
     }
 }

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
@@ -143,6 +143,15 @@ namespace Microsoft.Fx.Portability.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not write report to directory &apos;{0}&apos; with file name &apos;{1}&apos; and extension &apos;{2}&apos;..
+        /// </summary>
+        public static string CouldNotWriteReport {
+            get {
+                return ResourceManager.GetString("CouldNotWriteReport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Description.
         /// </summary>
         public static string Description {

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
@@ -328,4 +328,7 @@
   <data name="WritingReport" xml:space="preserve">
     <value>Writing report</value>
   </data>
+  <data name="CouldNotWriteReport" xml:space="preserve">
+    <value>Could not write report to directory '{0}' with file name '{1}' and extension '{2}'.</value>
+  </data>
 </root>


### PR DESCRIPTION
The report writer can report false positives. (ie. That a report was successfully written when it was not.)

This adds checks to ensure that the proper status is shown to users when a report cannot be written. It modifies the output of `ApiPortClient.WriteAnalysisReportsAsync` to only contain the paths of reports that were successfully written to.