### PR TITLE
Add a 'category' field to breaking changes

### DIFF
--- a/docs/BreakingChanges/BreakingChangeCategories.json
+++ b/docs/BreakingChanges/BreakingChangeCategories.json
@@ -1,0 +1,19 @@
+[
+    "ASP.NET",
+    "ClickOnce",
+    "Core",
+    "Data",
+    "Entity Framework",
+    "LINQ",
+    "Managed Extensibility Framework (MEF)",
+    "MSBuild",
+    "Networking",
+    "Printing",
+    "Serialization",
+    "Web Applications",
+    "Windows Communication Foundation (WCF)",
+    "Windows Forms",
+    "Windows Presentation Foundation (WPF)",
+    "Windows Workflow Foundation (WF)",
+    "XML, XSLT"
+]

--- a/src/Microsoft.Fx.Portability.Offline/Data.cs
+++ b/src/Microsoft.Fx.Portability.Offline/Data.cs
@@ -23,22 +23,11 @@ namespace Microsoft.Fx.Portability
 
         public static IEnumerable<BreakingChange> LoadBreakingChanges()
         {
-            IEnumerable<string> allowedCategories = null;
-
             // Prefer a local 'BreakingChanges' directory to embedded breaking changes
             if (Directory.Exists(Path.Combine(GetCurrentDirectoryName(), "BreakingChanges")))
             {
-                // Check to see if a file defining valid categories exists
-                var categoriesPath = Path.Combine(GetCurrentDirectoryName(), "BreakingChanges", "BreakingChangeCategories.json");
-                if (File.Exists(categoriesPath))
-                {
-                    using (var categoriesFile = File.Open(categoriesPath, FileMode.Open, FileAccess.Read))
-                    {
-                        allowedCategories = categoriesFile.Deserialize<string[]>();
-                    }
-                }
-
                 var breakingChanges = new List<BreakingChange>();
+                var allowedCategories = GetLocalAllowedCategories();
                 foreach (var file in Directory.GetFiles(Path.Combine(GetCurrentDirectoryName(), "BreakingChanges"), "*", SearchOption.AllDirectories))
                 {
                     using (var fs = File.Open(file, FileMode.Open, FileAccess.Read))
@@ -73,6 +62,20 @@ namespace Microsoft.Fx.Portability
 
                 return breakingChanges;
             }
+        }
+
+        private static IEnumerable<string> GetLocalAllowedCategories()
+        {
+            // Check to see if a file defining valid categories exists
+            var categoriesPath = Path.Combine(GetCurrentDirectoryName(), "BreakingChanges", "BreakingChangeCategories.json");
+            if (File.Exists(categoriesPath))
+            {
+                using (var categoriesFile = File.Open(categoriesPath, FileMode.Open, FileAccess.Read))
+                {
+                    return categoriesFile.Deserialize<string[]>();
+                }
+            }
+            return null;
         }
 
         private static Stream OpenFileOrResource(string path)

--- a/src/Microsoft.Fx.Portability.Offline/Data.cs
+++ b/src/Microsoft.Fx.Portability.Offline/Data.cs
@@ -23,15 +23,27 @@ namespace Microsoft.Fx.Portability
 
         public static IEnumerable<BreakingChange> LoadBreakingChanges()
         {
+            IEnumerable<string> allowedCategories = null;
+
             // Prefer a local 'BreakingChanges' directory to embedded breaking changes
             if (Directory.Exists(Path.Combine(GetCurrentDirectoryName(), "BreakingChanges")))
             {
+                // Check to see if a file defining valid categories exists
+                var categoriesPath = Path.Combine(GetCurrentDirectoryName(), "BreakingChanges", "BreakingChangeCategories.json");
+                if (File.Exists(categoriesPath))
+                {
+                    using (var categoriesFile = File.Open(categoriesPath, FileMode.Open, FileAccess.Read))
+                    {
+                        allowedCategories = categoriesFile.Deserialize<string[]>();
+                    }
+                }
+
                 var breakingChanges = new List<BreakingChange>();
                 foreach (var file in Directory.GetFiles(Path.Combine(GetCurrentDirectoryName(), "BreakingChanges"), "*", SearchOption.AllDirectories))
                 {
                     using (var fs = File.Open(file, FileMode.Open, FileAccess.Read))
                     {
-                        breakingChanges.AddRange(ParseBreakingChange(fs, Path.GetExtension(file)));
+                        breakingChanges.AddRange(ParseBreakingChange(fs, Path.GetExtension(file), allowedCategories));
                     }
                 }
 
@@ -46,7 +58,7 @@ namespace Microsoft.Fx.Portability
                 {
                     using (var stream = typeof(Data).GetTypeInfo().Assembly.GetManifestResourceStream(file))
                     {
-                        var fileBreakingChanges = ParseBreakingChange(stream, Path.GetExtension(file));
+                        var fileBreakingChanges = ParseBreakingChange(stream, Path.GetExtension(file), null);
 
                         if (fileBreakingChanges == null)
                         {
@@ -93,20 +105,24 @@ namespace Microsoft.Fx.Portability
 #endif
         }
 
-        private static IEnumerable<BreakingChange> ParseBreakingChange(Stream stream, string extension)
+        private static IEnumerable<BreakingChange> ParseBreakingChange(Stream stream, string extension, IEnumerable<string> allowedCategories)
         {
             if (string.Equals(".md", extension, StringComparison.OrdinalIgnoreCase))
             {
-                return BreakingChangeParser.FromMarkdown(stream);
+                return BreakingChangeParser.FromMarkdown(stream, allowedCategories);
             }
             if (string.Equals(".json", extension, StringComparison.OrdinalIgnoreCase))
             {
-                return stream.Deserialize<IEnumerable<BreakingChange>>();
+                try
+                {
+                    return stream.Deserialize<IEnumerable<BreakingChange>>();
+                }
+                catch (Exception)
+                {
+                    // An invalid json file will throw an exception when deserialized. Simply ignore such files.
+                }
             }
-            else
-            {
-                return Enumerable.Empty<BreakingChange>();
-            }
+            return Enumerable.Empty<BreakingChange>();
         }
     }
 }

--- a/src/Microsoft.Fx.Portability/BreakingChange.cs
+++ b/src/Microsoft.Fx.Portability/BreakingChange.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Fx.Portability
                 SourceAnalyzerStatus = this.SourceAnalyzerStatus,
                 BugLink = this.BugLink,
                 Notes = this.Notes,
-                ImpactScope = this.ImpactScope
+                ImpactScope = this.ImpactScope,
+                Categories = this.Categories?.ToList()
             };
         }
 
@@ -71,6 +72,8 @@ namespace Microsoft.Fx.Portability
         }
 
         public BreakingChangeImpact ImpactScope { get; set; }
+
+        public IEnumerable<string> Categories;
 
         public int CompareTo(BreakingChange other)
         {

--- a/src/Microsoft.Fx.Portability/BreakingChange.cs
+++ b/src/Microsoft.Fx.Portability/BreakingChange.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Fx.Portability
 
         public string Markdown { get; set; }
 
-        public IEnumerable<string> ApplicableApis { get; set; }
+        public IList<string> ApplicableApis { get; set; }
 
         public IEnumerable<string> Related { get; set; }
 
@@ -73,7 +73,7 @@ namespace Microsoft.Fx.Portability
 
         public BreakingChangeImpact ImpactScope { get; set; }
 
-        public IEnumerable<string> Categories;
+        public IList<string> Categories;
 
         public int CompareTo(BreakingChange other)
         {

--- a/src/Microsoft.Fx.Portability/BreakingChangeParser.cs
+++ b/src/Microsoft.Fx.Portability/BreakingChangeParser.cs
@@ -30,7 +30,20 @@ namespace Microsoft.Fx.Portability
         /// </summary>
         /// <param name="stream">The markdown to parse</param>
         /// <returns>BreakingChanges parsed from the markdown</returns>
-        public static IEnumerable<BreakingChange> FromMarkdown(Stream stream, IEnumerable<string> allowedCategories = null)
+        public static IEnumerable<BreakingChange> FromMarkdown(Stream stream)
+        {
+            // Use a separate overload instead of a default parameter so that binaries built against the older version of 
+            // Microsoft.Fx.Portability (without the new FromMarkdown overload) will keep working without recompilation.
+            return FromMarkdown(stream, null);
+        }
+
+        /// <summary>
+        /// Parses markdown files into BrekaingChange objects
+        /// </summary>
+        /// <param name="stream">The markdown to parse</param>
+        /// <param name="allowedCategories">Valid category strings. Pass null to allow any category. A breaking change using an invalid category will throw an exception while parsing the breaking change.</param>
+        /// <returns>BreakingChanges parsed from the markdown</returns>
+        public static IEnumerable<BreakingChange> FromMarkdown(Stream stream, IEnumerable<string> allowedCategories)
         {
             var breakingChanges = new List<BreakingChange>();
             var state = ParseState.None;

--- a/src/Microsoft.Fx.Portability/BreakingChangeParser.cs
+++ b/src/Microsoft.Fx.Portability/BreakingChangeParser.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Fx.Portability
                     {
                         currentBreak.ApplicableApis = new List<string>();
                     }
-                    ((List<string>)currentBreak.ApplicableApis).Add(api);
+                    currentBreak.ApplicableApis.Add(api);
                     break;
                 case ParseState.Details:
                     if (currentBreak.Details == null)
@@ -277,7 +277,7 @@ namespace Microsoft.Fx.Portability
                     {
                         throw new InvalidOperationException($"Invalid category detected: {category}");
                     }
-                    ((List<string>)currentBreak.Categories).Add(category);
+                    currentBreak.Categories.Add(category);
                     break;
                 default:
                     throw new InvalidOperationException("Unhandled breaking change parse state: " + state.ToString());

--- a/tests/Microsoft.Fx.Portability.Tests/BreakingChangeParserTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/BreakingChangeParserTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Fx.Portability.Tests
             bc.Title = ListTBC.Title;
             bc.Details = ListTBC.Details + "\n\n\n" + UriBC.Details;
             bc.Suggestion = ListTBC.Suggestion + "\n\n" + UriBC.Suggestion;
-            bc.ApplicableApis = ListTBC.ApplicableApis.Concat(UriBC.ApplicableApis);
+            bc.ApplicableApis = ListTBC.ApplicableApis.Concat(UriBC.ApplicableApis).ToList();
             ValidateParse(GetBreakingChangeMarkdown("DupSections.md"), bc);
         }
 
@@ -62,7 +62,7 @@ namespace Microsoft.Fx.Portability.Tests
             bc.ImpactScope = BreakingChangeImpact.Unknown;
             bc.SourceAnalyzerStatus = BreakingChangeAnalyzerStatus.Unknown;
             bc.IsQuirked = false;
-            bc.ApplicableApis = bc.ApplicableApis.Concat(new[] { "##" });
+            bc.ApplicableApis = bc.ApplicableApis.Concat(new[] { "##" }).ToList();
             bc.Suggestion = "\\0\0\0\0\0" + bc.Suggestion + "\u0001\u0002";
             ValidateParse(GetBreakingChangeMarkdown("CorruptData.md"), bc);
         }


### PR DESCRIPTION
Adds a category field to breaking changes, parses that field from markdown (if it exists) and optionally enforces that the category is valid (if valid categories are passed to the parser).

Also, updates Microsoft.Fx.Portability.Offline to pass valid categories so that breaking change categories will be validated in offline mode (online mode will require a separate change to the ApiPort service).