### PR TITLE
A couple new breaking change files

### DIFF
--- a/docs/BreakingChanges/145 CurrentCulture not preserved across WPF dispatcher operations.md
+++ b/docs/BreakingChanges/145 CurrentCulture not preserved across WPF dispatcher operations.md
@@ -1,0 +1,35 @@
+## 145: CurrentCulture is not preserved across WPF Dispatcher operations
+
+### Scope
+Minor
+
+### Version Introduced
+4.6
+
+### Source Analyzer Status
+Planned
+
+### Change Description
+Beginning in the .NET Framework 4.6, changes to CurrentCulture or CurrentUICulture made within a [Dispatcher](https://msdn.microsoft.com/en-us/library/system.windows.threading.dispatcher%28v=vs.110%29.aspx) will be lost at the end of that dispatcher operation. Similarly, changes to CurrentCulture or CurrentUICulture made outside of a Dispatcher operation may not be reflected when that operation executes.
+
+Practically speaking, this means that CurrentCulture and CurrentUICulture changes may not flow between WPF UI callbacks and other code in a WPF application.
+
+This is due to a change in [ExecutionContext](https://msdn.microsoft.com/en-us/library/system.threading.executioncontext%28v=vs.110%29.aspx) that causes CurrentCulture and CurrentUICulture to be stored in the execution context beginning with apps targeting the .NET Framework 4.6.
+
+- [x] Quirked
+- [ ] Build-time break
+
+### Recommended Action
+Apps affected by this change may work around it by storing the desired CurrentCulture or CurrentUICulture in a field and checking in all Dispatcher operation bodies (including UI event callback handlers) that the correct CurrentCulture and CurrentUICulture are set. Alternatively, because the ExecutionContext change underlying this WPF change only affects apps targeting the .NET Framework 4.6 or newer, this break can be avoided by targeting the .NET Framework 4.5.2.
+
+### Affected APIs
+* Not detectable via API analysis
+
+### Category
+Windows Presentation Foundation (WPF)
+
+<!--
+    ### Notes
+    This issue is not marked as detectable via API analysis because simply looking for CurrentCulture or CurrentUICulture being set is insufficient in most cases - it must be done in a WPF app.
+    Also, looking for WPF Dispatcher invocations is insufficient because many dispatcher invocations are automatic and, besides that, there is no way to know if CurrentCulture or CurrentUICulture matters for those dispatchers.
+-->

--- a/docs/BreakingChanges/145 CurrentCulture not preserved across WPF dispatcher operations.md
+++ b/docs/BreakingChanges/145 CurrentCulture not preserved across WPF dispatcher operations.md
@@ -14,7 +14,7 @@ Beginning in the .NET Framework 4.6, changes to CurrentCulture or CurrentUICultu
 
 Practically speaking, this means that CurrentCulture and CurrentUICulture changes may not flow between WPF UI callbacks and other code in a WPF application.
 
-This is due to a change in [ExecutionContext](https://msdn.microsoft.com/en-us/library/system.threading.executioncontext%28v=vs.110%29.aspx) that causes CurrentCulture and CurrentUICulture to be stored in the execution context beginning with apps targeting the .NET Framework 4.6.
+This is due to a change in [ExecutionContext](https://msdn.microsoft.com/en-us/library/system.threading.executioncontext%28v=vs.110%29.aspx) that causes CurrentCulture and CurrentUICulture to be stored in the execution context beginning with apps targeting the .NET Framework 4.6. WPF dispatcher operations store the execution context used to begin the operation and restore the previous context when the operation is completed. Because CurrentCulture and CurrentUICulture are now part of that context, changes to them within a dispatcher operation are not persisted outside of the operation.
 
 - [x] Quirked
 - [ ] Build-time break

--- a/docs/BreakingChanges/146 CurrentCulture flows across Tasks.md
+++ b/docs/BreakingChanges/146 CurrentCulture flows across Tasks.md
@@ -1,0 +1,32 @@
+## 146: CurrentCulture and CurrentUICulture flow across tasks
+
+### Scope
+Minor
+
+### Version Introduced
+4.6
+
+### Source Analyzer Status
+Planned
+
+### Change Description
+Beginning in the .NET Framework 4.6, [CurrentCulture](https://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.currentculture%28v=vs.110%29.aspx) and [CurrentUICulture](https://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.currentuiculture%28v=vs.110%29.aspx) are stored in the thread's [ExecutionContext](https://msdn.microsoft.com/en-us/library/system.threading.executioncontext%28v=vs.110%29.aspx), which flows across asynchronous operations.
+
+This means that changes to CurrentCulture or CurrentUICulture will be reflected in tasks which are later run asynchronously. This is different from the behavior of previous .NET Framework versions (which would reset CurrentCulture and CurrentUICulture in all asynchronous tasks).
+
+- [x] Quirked
+- [ ] Build-time break
+
+### Recommended Action
+Apps affected by this change may work around it by explicitly setting the desired CurrentCulture or CurrentUICulture as the first operation in an async Task. Alternatively, because the ExecutionContext change only affects apps targeting the .NET Framework 4.6 or newer, this break can be avoided by targeting the .NET Framework 4.5.2.
+
+### Affected APIs
+* `M:System.Globalization.CultureInfo.set_CurrentCulture(System.Globalization.CultureInfo)`
+* `M:System.Threading.Thread.set_CurrentCulture(System.Globalization.CultureInfo)`
+* `M:System.Globalization.CultureInfo.set_CurrentUICulture(System.Globalization.CultureInfo)`
+* `M:System.Threading.Thread.set_CurrentUICulture(System.Globalization.CultureInfo)`
+
+### Category
+Core
+
+[More information](https://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo%28v=vs.110%29.aspx#Async)

--- a/docs/BreakingChanges/146 CurrentCulture flows across Tasks.md
+++ b/docs/BreakingChanges/146 CurrentCulture flows across Tasks.md
@@ -18,7 +18,10 @@ This means that changes to CurrentCulture or CurrentUICulture will be reflected 
 - [ ] Build-time break
 
 ### Recommended Action
-Apps affected by this change may work around it by explicitly setting the desired CurrentCulture or CurrentUICulture as the first operation in an async Task. Alternatively, because the ExecutionContext change only affects apps targeting the .NET Framework 4.6 or newer, this break can be avoided by targeting the .NET Framework 4.5.2.
+Apps affected by this change may work around it by explicitly setting the desired CurrentCulture or CurrentUICulture as the first operation in an async Task. Alternatively, the old behavior (of not flowing CurrentCulture/CurrentUICulture) may be opted into by setting the following compatibility switch:
+```C#
+AppContext.SetSwitch("Switch.System.Globalization.NoAsyncCurrentCulture", true);
+```
 
 ### Affected APIs
 * `M:System.Globalization.CultureInfo.set_CurrentCulture(System.Globalization.CultureInfo)`


### PR DESCRIPTION
ExecutionContexts contain CurrentCulture and CurrentUICulture beginning in 4.6. This leads to a couple breaks we don't have documented yet.