### PR TITLE
Add an argument check in ApiPortService

### DIFF
--- a/src/Microsoft.Fx.Portability/ApiPortService.cs
+++ b/src/Microsoft.Fx.Portability/ApiPortService.cs
@@ -23,43 +23,41 @@ namespace Microsoft.Fx.Portability
         }
 
         private readonly CompressedHttpClient _client;
-        private readonly string _endpoint;
 
         public ApiPortService(string endpoint, ProductInformation info)
         {
-            _endpoint = endpoint;
+            if (string.IsNullOrWhiteSpace(endpoint))
+            {
+                throw new ArgumentOutOfRangeException(nameof(endpoint), endpoint, "Must be a valid endpoint");
+            }
 
             _client = new CompressedHttpClient(info)
             {
+                BaseAddress = new Uri(endpoint),
                 Timeout = TimeSpan.FromMinutes(10)
             };
         }
 
         public async Task<ServiceResponse<AnalyzeResponse>> SendAnalysisAsync(AnalyzeRequest a)
         {
-            string sendAnalysis = _endpoint + Endpoints.Analyze;
-
-            return await _client.CallAsync<AnalyzeRequest, AnalyzeResponse>(HttpMethod.Post, sendAnalysis, a);
+            return await _client.CallAsync<AnalyzeRequest, AnalyzeResponse>(HttpMethod.Post, Endpoints.Analyze, a);
         }
 
         public async Task<ServiceResponse<byte[]>> SendAnalysisAsync(AnalyzeRequest a, string format)
         {
             var formatInformation = await GetResultFormat(format);
-            var sendAnalysis = _endpoint + Endpoints.Analyze;
 
-            return await _client.CallAsync(HttpMethod.Post, sendAnalysis, a, formatInformation);
+            return await _client.CallAsync(HttpMethod.Post, Endpoints.Analyze, a, formatInformation);
         }
 
         public async Task<ServiceResponse<IEnumerable<AvailableTarget>>> GetTargetsAsync()
         {
-            string targetsUrl = _endpoint + Endpoints.Targets;
-
-            return await _client.CallAsync<IEnumerable<AvailableTarget>>(HttpMethod.Get, targetsUrl);
+            return await _client.CallAsync<IEnumerable<AvailableTarget>>(HttpMethod.Get, Endpoints.Targets);
         }
 
         public async Task<ServiceResponse<UsageDataCollection>> GetUsageDataAsync(int? skip = null, int? top = null, UsageDataFilter? filter = null, IEnumerable<string> targets = null)
         {
-            var usedApiUrl = UrlBuilder.Create(_endpoint + Endpoints.UsedApi)
+            var usedApiUrl = UrlBuilder.Create(Endpoints.UsedApi)
                 .AddQuery("skip", skip)
                 .AddQuery("top", top)
                 .AddQuery("filter", filter)
@@ -71,7 +69,7 @@ namespace Microsoft.Fx.Portability
 
         public async Task<ServiceResponse<AnalyzeResponse>> GetAnalysisAsync(string submissionId)
         {
-            var submissionUrl = UrlBuilder.Create(_endpoint + Endpoints.Analyze).AddPath(submissionId).Url;
+            var submissionUrl = UrlBuilder.Create(Endpoints.Analyze).AddPath(submissionId).Url;
 
             return await _client.CallAsync<AnalyzeResponse>(HttpMethod.Get, submissionUrl);
         }
@@ -79,7 +77,7 @@ namespace Microsoft.Fx.Portability
         public async Task<ServiceResponse<byte[]>> GetAnalysisAsync(string submissionId, string format)
         {
             var formatInformation = await GetResultFormat(format);
-            var submissionUrl = UrlBuilder.Create(_endpoint + Endpoints.Analyze).AddPath(submissionId).Url;
+            var submissionUrl = UrlBuilder.Create(Endpoints.Analyze).AddPath(submissionId).Url;
 
             return await _client.CallAsync(HttpMethod.Get, submissionUrl, formatInformation);
         }
@@ -87,7 +85,7 @@ namespace Microsoft.Fx.Portability
         public async Task<ServiceResponse<ApiInformation>> GetApiInformationAsync(string docId)
         {
             string sendAnalysis = UrlBuilder
-                .Create(_endpoint + Endpoints.FxApi)
+                .Create(Endpoints.FxApi)
                 .AddQuery("docId", docId)
                 .Url;
 
@@ -97,7 +95,7 @@ namespace Microsoft.Fx.Portability
         public async Task<ServiceResponse<IReadOnlyCollection<ApiDefinition>>> SearchFxApiAsync(string query, int? top = null)
         {
             var url = UrlBuilder
-                .Create(_endpoint + Endpoints.FxApiSearch)
+                .Create(Endpoints.FxApiSearch)
                 .AddQuery("q", query)
                 .AddQuery("top", top);
 
@@ -106,9 +104,7 @@ namespace Microsoft.Fx.Portability
 
         public async Task<ServiceResponse<IEnumerable<ResultFormatInformation>>> GetResultFormatsAsync()
         {
-            string url = _endpoint + Endpoints.ResultFormat;
-
-            return await _client.CallAsync<IEnumerable<ResultFormatInformation>>(HttpMethod.Get, url);
+            return await _client.CallAsync<IEnumerable<ResultFormatInformation>>(HttpMethod.Get, Endpoints.ResultFormat);
         }
 
         public void Dispose()

--- a/tests/Microsoft.Fx.Portability.Tests/ApiPortServiceTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ApiPortServiceTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Fx.Portability.Tests
+{
+    public class ApiPortServiceTests
+    {
+        [Fact]
+        public void VerifyParameterChecks()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ApiPortService(null, new ProductInformation("")));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ApiPortService(string.Empty, new ProductInformation("")));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ApiPortService(" \t", new ProductInformation("")));
+        }
+    }
+}

--- a/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Analysis\TargetNameParserTests.cs" />
     <Compile Include="Analyzer\DotNetFrameworkFilterTests.cs" />
     <Compile Include="ApiPortClientTests.cs" />
+    <Compile Include="ApiPortServiceTests.cs" />
     <Compile Include="BreakingChangeParserTests.cs" />
     <Compile Include="ObjectModel\AssemblyReferenceInformationTests.cs" />
     <Compile Include="ObjectModel\IgnoreAssemblyInfoTests.cs" />


### PR DESCRIPTION
While updating the website, a null got passed in as the endpoint, it was tricky to figure out what was happening. This will instead verify it is not a null or whitespace, and then set the 

@JJVertical 