### PR TITLE
Copy license terms to ApiPort build

### DIFF
--- a/PortabilityTools.sln
+++ b/PortabilityTools.sln
@@ -40,8 +40,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Fx.Portability.Re
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{FEEF35CB-3AC4-40C5-9CB0-85E52E38D5C6}"
 	ProjectSection(SolutionItems) = preProject
-		build\ci-build.props = build\ci-build.props
-		build\ci-build.targets = build\ci-build.targets
 		build\Get-Nuget.ps1 = build\Get-Nuget.ps1
 		build\Microsoft.Fx.Portability.MetadataReader.nuspec = build\Microsoft.Fx.Portability.MetadataReader.nuspec
 		build\Microsoft.Fx.Portability.nuspec = build\Microsoft.Fx.Portability.nuspec

--- a/build/Microsoft.Fx.Portability.MetadataReader.nuspec
+++ b/build/Microsoft.Fx.Portability.MetadataReader.nuspec
@@ -6,7 +6,7 @@
     <title>Microsoft.Fx.Portability.MetadataReader</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
-    <licenseUrl>https://github.com/Microsoft/dotnet-apiport/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/Microsoft/dotnet-apiport/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Microsoft/dotnet-apiport</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The core data structures and network calls for .NET Portability Analyzer</description>

--- a/build/Microsoft.Fx.Portability.Offline.nuspec
+++ b/build/Microsoft.Fx.Portability.Offline.nuspec
@@ -6,7 +6,7 @@
     <title>Microsoft.Fx.Portability.Offline</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
-    <licenseUrl>https://github.com/Microsoft/dotnet-apiport/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/Microsoft/dotnet-apiport/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Microsoft/dotnet-apiport</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The core data structures and network calls for .NET Portability Analyzer</description>

--- a/build/Microsoft.Fx.Portability.Reports.Html.nuspec
+++ b/build/Microsoft.Fx.Portability.Reports.Html.nuspec
@@ -6,7 +6,7 @@
     <title>Microsoft.Fx.Portability.Reports.Html</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
-    <licenseUrl>https://github.com/Microsoft/dotnet-apiport/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/Microsoft/dotnet-apiport/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Microsoft/dotnet-apiport</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>An HTML formatter for ApiPort reports</description>

--- a/build/Microsoft.Fx.Portability.Reports.Json.nuspec
+++ b/build/Microsoft.Fx.Portability.Reports.Json.nuspec
@@ -6,7 +6,7 @@
     <title>Microsoft.Fx.Portability.Reports.Json</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
-    <licenseUrl>https://github.com/Microsoft/dotnet-apiport/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/Microsoft/dotnet-apiport/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Microsoft/dotnet-apiport</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>An HTML formatter for ApiPort reports</description>

--- a/build/Microsoft.Fx.Portability.nuspec
+++ b/build/Microsoft.Fx.Portability.nuspec
@@ -6,7 +6,7 @@
     <title>Microsoft.Fx.Portability</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
-    <licenseUrl>https://github.com/Microsoft/dotnet-apiport/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/Microsoft/dotnet-apiport/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/Microsoft/dotnet-apiport</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The core data structures and network calls for .NET Portability Analyzer</description>

--- a/build/postbuild.ps1
+++ b/build/postbuild.ps1
@@ -71,7 +71,7 @@ foreach($nuspec in $nuspecs)
 	$count++
 }
 
-function CopyOfflineMode()
+function Copy-OfflineMode()
 {
 	$offlineDrop = "$drop\ApiPort.Offline"
 	Remove-Item $offlineDrop -Recurse -Force -ErrorAction Ignore
@@ -82,8 +82,12 @@ function CopyOfflineMode()
 	copy $drop\Microsoft.Fx.Portability.Reports.Json\net45\* $offlineDrop
 	copy $drop\Microsoft.Fx.Portability.Reports.Html\net45\* $offlineDrop
 }
+
 Write-Progress -Activity "Creating portability nupkgs" -Status "Complete" -PercentComplete 100
 
 Copy-Item "$PSScriptRoot\..\.data\catalog.bin" $drop\Microsoft.Fx.Portability.Offline -Recurse -Force
 
-CopyOfflineMode
+Copy-OfflineMode
+
+# Copying the license terms into our drop so we don't have to manually do it when we want to release
+Copy-Item "$PSScriptRoot\..\docs\LicenseTerms" $drop\ApiPort -Recurse -Force


### PR DESCRIPTION
Copy license terms to ApiPort build output.
Miscellaneous changes:
- Fix nuget license URI
- Remove deleted build files from solution