### PR TITLE
Improve logging for InternalServerErrors

### DIFF
--- a/PortabilityTools.sln
+++ b/PortabilityTools.sln
@@ -40,6 +40,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Fx.Portability.Re
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{FEEF35CB-3AC4-40C5-9CB0-85E52E38D5C6}"
 	ProjectSection(SolutionItems) = preProject
+		build\Get-CatalogFile.ps1 = build\Get-CatalogFile.ps1
 		build\Get-Nuget.ps1 = build\Get-Nuget.ps1
 		build\Microsoft.Fx.Portability.MetadataReader.nuspec = build\Microsoft.Fx.Portability.MetadataReader.nuspec
 		build\Microsoft.Fx.Portability.nuspec = build\Microsoft.Fx.Portability.nuspec

--- a/src/ApiPort/CommandLine/AnalyzeOptions.cs
+++ b/src/ApiPort/CommandLine/AnalyzeOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ApiPort.Resources;
@@ -222,7 +222,7 @@ namespace ApiPort.CommandLine
                         {
                             // Temporary workaround for CoreCLR-on-Linux bug (dotnet/corefx#4727) that prevents get_FileVersion from working on that platform
                             // This bug is now fixed and the correct behavior should be present in .NET Core RC2
-                            return new Version(0,0).ToString();
+                            return new Version(0, 0).ToString();
                         }
                     }
                 }

--- a/src/ApiPort/CommandLineOptions.cs
+++ b/src/ApiPort/CommandLineOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ApiPort.CommandLine;
@@ -70,7 +70,7 @@ namespace ApiPort
                 // TODO: Get invalid parameter (Microsoft.Framework.Configuration currently does not surface this)
                 Program.WriteColorLine($"Invalid parameter passed to {suppliedCommand}", ConsoleColor.Red);
             }
-            
+
             var location = typeof(CommandLineOptions).GetTypeInfo().Assembly.Location;
             var path =
 #if NETCORE

--- a/src/Microsoft.Fx.Portability/CompressedHttpClient.cs
+++ b/src/Microsoft.Fx.Portability/CompressedHttpClient.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Fx.Portability.Reporting.ObjectModel;
 using Microsoft.Fx.Portability.Resources;
 using System;
-using System.Diagnostics;
 using System.Globalization;
 using System.Net;
 using System.Net.Http;
@@ -130,6 +128,15 @@ namespace Microsoft.Fx.Portability
                             throw new NotFoundException();
                         case HttpStatusCode.Unauthorized:
                             throw new UnauthorizedEndpointException();
+                        case HttpStatusCode.InternalServerError:
+                            var content = await response.Content?.ReadAsStringAsync();
+
+                            if (string.IsNullOrEmpty(content))
+                            {
+                                throw new PortabilityAnalyzerException(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.UnknownInternalErrorCodeMessage, response.StatusCode, response.ReasonPhrase));
+                            }
+
+                            throw InternalServerErrorException.Create(response.ReasonPhrase, content);
                     }
 
                     throw new PortabilityAnalyzerException(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.UnknownErrorCodeMessage, response.StatusCode));

--- a/src/Microsoft.Fx.Portability/InternalServerErrorException.cs
+++ b/src/Microsoft.Fx.Portability/InternalServerErrorException.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Fx.Portability.Resources;
+using System;
+
+namespace Microsoft.Fx.Portability
+{
+    public class InternalServerErrorException : PortabilityAnalyzerException
+    {
+        private InternalServerErrorException(string message, string exception)
+            : base(string.Format(LocalizedStrings.InternalServerErrorMessage, message, exception))
+        { }
+
+        /// <summary>
+        /// This returns a properly formatted exception received from the server.
+        /// </summary>
+        public static InternalServerErrorException Create(string message, string exception)
+        {
+            var split = exception.Split(new[] { "\\r\\n", "\\r", "\\n" }, StringSplitOptions.RemoveEmptyEntries);
+
+            return new InternalServerErrorException(message, string.Join(Environment.NewLine, split));
+        }
+    }
+}

--- a/src/Microsoft.Fx.Portability/InternalServerErrorException.cs
+++ b/src/Microsoft.Fx.Portability/InternalServerErrorException.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Fx.Portability.Resources;
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Fx.Portability.Resources;
 using System;
 
 namespace Microsoft.Fx.Portability

--- a/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.NET45.csproj
+++ b/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.NET45.csproj
@@ -68,6 +68,7 @@
     <Compile Include="ApiPortServiceSearcher.cs" />
     <Compile Include="BreakingChangeAnalyzerStatus.cs" />
     <Compile Include="IAssemblyFile.cs" />
+    <Compile Include="InternalServerErrorException.cs" />
     <Compile Include="ObjectModel\AssemblyReferenceInformation.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="BreakingChange.cs" />

--- a/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
+++ b/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
@@ -62,6 +62,7 @@
     <Compile Include="ApiPortService.cs" />
     <Compile Include="ApiPortServiceSearcher.cs" />
     <Compile Include="BreakingChangeAnalyzerStatus.cs" />
+    <Compile Include="InternalServerErrorException.cs" />
     <Compile Include="ObjectModel\AssemblyReferenceInformation.cs" />
     <Compile Include="IAssemblyFile.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Fx.Portability.Resources {
     using System;
     using System.Reflection;
 
-
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -248,6 +247,17 @@ namespace Microsoft.Fx.Portability.Resources {
         public static string IdentifyAssembliesToScan {
             get {
                 return ResourceManager.GetString("IdentifyAssembliesToScan", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}
+        ///Exception:
+        ///{1}.
+        /// </summary>
+        public static string InternalServerErrorMessage {
+            get {
+                return ResourceManager.GetString("InternalServerErrorMessage", resourceCulture);
             }
         }
         
@@ -599,6 +609,15 @@ namespace Microsoft.Fx.Portability.Resources {
         public static string UnknownFile {
             get {
                 return ResourceManager.GetString("UnknownFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to There was an issue retrieving error message from the service. Reason: &apos;{0}&apos;. Please wait while we update the service..
+        /// </summary>
+        public static string UnknownInternalErrorCodeMessage {
+            get {
+                return ResourceManager.GetString("UnknownInternalErrorCodeMessage", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
@@ -331,4 +331,13 @@
   <data name="CouldNotWriteReport" xml:space="preserve">
     <value>Could not write report to directory '{0}' with file name '{1}' and extension '{2}'.</value>
   </data>
+  <data name="UnknownInternalErrorCodeMessage" xml:space="preserve">
+    <value>There was an issue retrieving an error message from the service. Reason: '{0}'. Please wait while we update the service.</value>
+    <comment>When an InternalServerError status code is set, the response.Content should never be null.</comment>
+  </data>
+  <data name="InternalServerErrorMessage" xml:space="preserve">
+    <value>{0}
+Exception:
+{1}</value>
+  </data>
 </root>


### PR DESCRIPTION
This improves the output when an error occurs in the PortabilityService.  This now shows the exception that occurs in the server.

@mjrousos, @twsouthwick 