### PR TITLE
Fixing FxCop errors

### DIFF
--- a/src/Microsoft.Fx.Portability/AliasMappedToMultipleNamesException.cs
+++ b/src/Microsoft.Fx.Portability/AliasMappedToMultipleNamesException.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Fx.Portability
 
         private static string GenerateMessage(IEnumerable<string> invalidNames)
         {
-            return string.Format(LocalizedStrings.AliasMappedToMultipleNamesInvalidAliases, string.Join(s_listSeparator, invalidNames));
+            return string.Format(CultureInfo.CurrentCulture, LocalizedStrings.AliasMappedToMultipleNamesInvalidAliases, string.Join(s_listSeparator, invalidNames));
         }
 
         public AliasMappedToMultipleNamesException(IEnumerable<string> invalidNames)

--- a/src/Microsoft.Fx.Portability/BreakingChangeParser.cs
+++ b/src/Microsoft.Fx.Portability/BreakingChangeParser.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Fx.Portability.Resources;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 
@@ -287,12 +289,12 @@ namespace Microsoft.Fx.Portability
                     // If a list of allowed categories was provided, make sure that the category found is on the list
                     if (!allowedCategories?.Contains(category, StringComparer.OrdinalIgnoreCase) ?? false)
                     {
-                        throw new InvalidOperationException($"Invalid category detected: {category}");
+                        throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.InvalidCategoryDetected, category));
                     }
                     currentBreak.Categories.Add(category);
                     break;
                 default:
-                    throw new InvalidOperationException("Unhandled breaking change parse state: " + state.ToString());
+                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.InvalidBreakingChangeParserState, state.ToString()));
             }
         }
 

--- a/src/Microsoft.Fx.Portability/DataExtensions.cs
+++ b/src/Microsoft.Fx.Portability/DataExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Fx.Portability
 {
     public static class DataExtensions
     {
-        public static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings
+        public static JsonSerializerSettings JsonSettings { get; } = new JsonSerializerSettings
         {
             Formatting = Formatting.Indented,
             Converters = new JsonConverter[]
@@ -24,7 +24,7 @@ namespace Microsoft.Fx.Portability
             }
         };
 
-        public static readonly JsonSerializer Serializer = JsonSerializer.Create(JsonSettings);
+        public static JsonSerializer Serializer { get; } = JsonSerializer.Create(JsonSettings);
 
         public static byte[] Serialize<T>(this T data)
         {

--- a/src/Microsoft.Fx.Portability/ObjectModel/AnalyzeRequest.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/AnalyzeRequest.cs
@@ -37,7 +37,8 @@ namespace Microsoft.Fx.Portability.ObjectModel
         public int CompareTo(object obj)
         {
             var analyzeObject = obj as AnalyzeRequest;
-            return ApplicationName.CompareTo(analyzeObject.ApplicationName);
+
+            return string.Compare(ApplicationName, analyzeObject.ApplicationName, StringComparison.Ordinal);
         }
     }
 }

--- a/src/Microsoft.Fx.Portability/ObjectModel/AnalyzeResponse.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/AnalyzeResponse.cs
@@ -38,7 +38,8 @@ namespace Microsoft.Fx.Portability.ObjectModel
         public int CompareTo(object obj)
         {
             var analyzeObject = obj as AnalyzeResponse;
-            return SubmissionId.CompareTo(analyzeObject.SubmissionId);
+
+            return string.Compare(SubmissionId, analyzeObject.SubmissionId, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Microsoft.Fx.Portability/ObjectModel/AssemblyInfo.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/AssemblyInfo.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Fx.Portability.Resources;
 using System;
+using System.Globalization;
 
 namespace Microsoft.Fx.Portability.ObjectModel
 {
@@ -72,7 +73,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         public string GetFullAssemblyIdentity()
         {
-            return string.Format(LocalizedStrings.FullAssemblyIdentity, AssemblyIdentity, FileVersion);
+            return string.Format(CultureInfo.InvariantCulture, LocalizedStrings.FullAssemblyIdentity, AssemblyIdentity, FileVersion);
         }
 
         public int CompareTo(object obj)

--- a/src/Microsoft.Fx.Portability/ObjectModel/AssemblyInfo.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/AssemblyInfo.cs
@@ -78,7 +78,8 @@ namespace Microsoft.Fx.Portability.ObjectModel
         public int CompareTo(object obj)
         {
             var obj2 = obj as AssemblyInfo;
-            return AssemblyIdentity.CompareTo(obj2.AssemblyIdentity);
+
+            return string.Compare(AssemblyIdentity, obj2.AssemblyIdentity, StringComparison.Ordinal);
         }
     }
 }

--- a/src/Microsoft.Fx.Portability/ObjectModel/AssemblyReferenceInformation.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/AssemblyReferenceInformation.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Globalization;
 
 namespace Microsoft.Fx.Portability.ObjectModel
 {
@@ -18,7 +19,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
             Culture = culture;
             PublicKeyToken = publicKeyToken;
 
-            _string = $"{Name}, Version={Version}, Culture={Culture}, PublicKeyToken={PublicKeyToken}";
+            _string = string.Format(CultureInfo.InvariantCulture, "{0}, Version={1}, Culture={2}, PublicKeyToken={3}", Name, Version, Culture, PublicKeyToken);
         }
 
         public string Name { get; }

--- a/src/Microsoft.Fx.Portability/ObjectModel/DiagnosticAnalyzerInfo.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/DiagnosticAnalyzerInfo.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Fx.Portability.ObjectModel
 {
@@ -31,7 +32,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
             }
 
             var regExMatches = s_regEx.Match(Id);
-            return regExMatches.Success ? int.Parse(regExMatches.Captures[0].Value) : -1;
+            return regExMatches.Success ? int.Parse(regExMatches.Captures[0].Value, CultureInfo.InvariantCulture) : -1;
         }
     }
 }

--- a/src/Microsoft.Fx.Portability/ObjectModel/MemberInfo.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/MemberInfo.cs
@@ -85,7 +85,8 @@ namespace Microsoft.Fx.Portability.ObjectModel
         public int CompareTo(object obj)
         {
             var obj2 = obj as MemberInfo;
-            return MemberDocId.CompareTo(obj2.MemberDocId);
+
+            return string.Compare(MemberDocId, obj2.MemberDocId, StringComparison.Ordinal);
         }
     }
 }

--- a/src/Microsoft.Fx.Portability/ObjectModel/TargetInformation.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/TargetInformation.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
         {
             if (ExpandedTargets.Any())
             {
-                return string.Format(LocalizedStrings.TargetInformationGroups, Name, string.Join(s_ListSeparator, ExpandedTargets));
+                return string.Format(CultureInfo.CurrentCulture, LocalizedStrings.TargetInformationGroups, Name, string.Join(s_ListSeparator, ExpandedTargets));
             }
             else
             {

--- a/src/Microsoft.Fx.Portability/Reporting/ObjectModel/MissingInfo.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/ObjectModel/MissingInfo.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Fx.Portability.Resources;
 using System;
+using System.Globalization;
 
 namespace Microsoft.Fx.Portability.Reporting.ObjectModel
 {
@@ -36,7 +37,7 @@ namespace Microsoft.Fx.Portability.Reporting.ObjectModel
             }
             else
             {
-                return string.Format(LocalizedStrings.SupportedOn, version);
+                return string.Format(CultureInfo.CurrentCulture, LocalizedStrings.SupportedOn, version);
             }
         }
     }

--- a/src/Microsoft.Fx.Portability/Reporting/ObjectModel/MissingTypeInfo.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/ObjectModel/MissingTypeInfo.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Fx.Portability.Reporting.ObjectModel
         public MissingTypeInfo(AssemblyInfo sourceAssembly, string docId, List<Version> targetStatus, string recommendedChanges)
             : base(docId)
         {
-            int pos = DocId.IndexOf("T:");
+            int pos = DocId.IndexOf("T:", StringComparison.Ordinal);
             if (pos == -1)
                 throw new ArgumentException(LocalizedStrings.MemberShouldBeDefinedOnTypeException, "docId");
 

--- a/src/Microsoft.Fx.Portability/Reporting/ReportFileWriter.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/ReportFileWriter.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Fx.Portability.Reporting
                 // This file exists already but since we don't care about uniqueness, we'll overwrite it.
                 if (!isUnique)
                 {
-                    _progressReporter.ReportIssue(string.Format(LocalizedStrings.OverwriteFile, uniqueName));
+                    _progressReporter.ReportIssue(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.OverwriteFile, uniqueName));
                     return uniqueName;
                 }
 

--- a/src/Microsoft.Fx.Portability/Reporting/ReportFileWriter.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/ReportFileWriter.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Fx.Portability.Resources;
 using System;
+using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -76,7 +77,7 @@ namespace Microsoft.Fx.Portability.Reporting
             var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
 
             var fileNameFormatString = string.Concat(fileNameWithoutExtension, "{0}", extension);
-            var uniqueName = string.Format(fileNameFormatString, string.Empty);
+            var uniqueName = string.Format(CultureInfo.InvariantCulture, fileNameFormatString, string.Empty);
 
             int i = 1;
 
@@ -89,8 +90,8 @@ namespace Microsoft.Fx.Portability.Reporting
                     return uniqueName;
                 }
 
-                var suffix = string.Format("({0})", i++);
-                uniqueName = string.Format(fileNameFormatString, suffix);
+                var suffix = string.Format(CultureInfo.InvariantCulture, "({0})", i++);
+                uniqueName = string.Format(CultureInfo.InvariantCulture, fileNameFormatString, suffix);
             }
 
             return uniqueName;

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
@@ -261,6 +261,24 @@ namespace Microsoft.Fx.Portability.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unhandled breaking change parse state: {0}.
+        /// </summary>
+        public static string InvalidBreakingChangeParserState {
+            get {
+                return ResourceManager.GetString("InvalidBreakingChangeParserState", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid category detected: {0}.
+        /// </summary>
+        public static string InvalidCategoryDetected {
+            get {
+                return ResourceManager.GetString("InvalidCategoryDetected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid data.
         /// </summary>
         public static string InvalidDataMessage {

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
@@ -331,4 +331,10 @@
   <data name="CouldNotWriteReport" xml:space="preserve">
     <value>Could not write report to directory '{0}' with file name '{1}' and extension '{2}'.</value>
   </data>
+  <data name="InvalidCategoryDetected" xml:space="preserve">
+    <value>Invalid category detected: {0}</value>
+  </data>
+  <data name="InvalidBreakingChangeParserState" xml:space="preserve">
+    <value>Unhandled breaking change parse state: {0}</value>
+  </data>
 </root>

--- a/src/Microsoft.Fx.Portability/ServiceHeaders.cs
+++ b/src/Microsoft.Fx.Portability/ServiceHeaders.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -92,12 +93,12 @@ namespace Microsoft.Fx.Portability
 
         public Uri GetDocIdUrl(string docId)
         {
-            return new Uri(string.Format("{0}{1}{2}", WebsiteEndpoint, ApiInfoUrl, WebUtility.UrlEncode(docId)));
+            return new Uri(string.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", WebsiteEndpoint, ApiInfoUrl, WebUtility.UrlEncode(docId)));
         }
 
         public Uri GetSubmissionUrl(string submissionId)
         {
-            return new Uri(string.Format("{0}{1}{2}", WebsiteEndpoint, SubmissionUrl, WebUtility.UrlEncode(submissionId)));
+            return new Uri(string.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", WebsiteEndpoint, SubmissionUrl, WebUtility.UrlEncode(submissionId)));
         }
     }
 }

--- a/src/Microsoft.Fx.Portability/TargetMapper.cs
+++ b/src/Microsoft.Fx.Portability/TargetMapper.cs
@@ -249,7 +249,7 @@ namespace Microsoft.Fx.Portability
 
             if (validate && groups.Any(g => g.Length != 2))
             {
-                throw new ArgumentOutOfRangeException("aliasString", aliasString, string.Format("An alias should be separated from names by '{0}'", AliasTargetSeparator));
+                throw new ArgumentOutOfRangeException("aliasString", aliasString, string.Format(CultureInfo.CurrentCulture, "An alias should be separated from names by '{0}'", AliasTargetSeparator));
             }
 
             foreach (var group in groups)

--- a/src/Microsoft.Fx.Portability/TargetMapper.cs
+++ b/src/Microsoft.Fx.Portability/TargetMapper.cs
@@ -84,6 +84,12 @@ namespace Microsoft.Fx.Portability
             Load(stream, null);
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
+            MessageId = "System.Xml.XmlReader.Create",
+            Justification = @"For the call to XmlReader.Create() below, CA3053 recommends setting the
+XmlReaderSettings.XmlResolver property to either null or an instance of XmlSecureResolver.
+However, the said XmlResolver property no longer exists in .NET portable framework (i.e. core framework) which means there is no way to set it.
+So we suppress this error until the reporting for CA3053 has been updated to account for .NET portable framework.")]
         private void Load(Stream stream, string path)
         {
             try

--- a/src/Microsoft.Fx.Portability/UnknownReportFormatException.cs
+++ b/src/Microsoft.Fx.Portability/UnknownReportFormatException.cs
@@ -2,13 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Fx.Portability.Resources;
+using System.Globalization;
 
 namespace Microsoft.Fx.Portability
 {
     public class UnknownReportFormatException : PortabilityAnalyzerException
     {
         public UnknownReportFormatException(string format)
-            : base(string.Format(LocalizedStrings.UnknownResultFormat, format))
+            : base(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.UnknownResultFormat, format))
         { }
     }
 }

--- a/src/Microsoft.Fx.Portability/UrlBuilder.cs
+++ b/src/Microsoft.Fx.Portability/UrlBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Microsoft.Fx.Portability
 {
@@ -65,7 +66,7 @@ namespace Microsoft.Fx.Portability
                 throw new InvalidOperationException("Cannot add to the path once a query has begun");
             }
 
-            var newUrl = string.Format("{0}/{1}", _url, Uri.EscapeDataString(path));
+            var newUrl = string.Format(CultureInfo.InvariantCulture, "{0}/{1}", _url, Uri.EscapeDataString(path));
 
             return new UrlBuilder(newUrl, false);
         }
@@ -77,7 +78,7 @@ namespace Microsoft.Fx.Portability
                 return this;
             }
 
-            var newUrl = string.Format(formatString, _url, _queryStarted ? '&' : '?', Uri.EscapeDataString(name), Uri.EscapeDataString(value.ToString()));
+            var newUrl = string.Format(CultureInfo.InvariantCulture, formatString, _url, _queryStarted ? '&' : '?', Uri.EscapeDataString(name), Uri.EscapeDataString(value.ToString()));
 
             return new UrlBuilder(newUrl, true);
         }


### PR DESCRIPTION
After running FxCop over the solution, several errors showed up.  This fixes errors:
- [CA1305: Specify IFormatProvider](https://msdn.microsoft.com/en-us/library/ms182190.aspx)
- [CA1307: Specify StringComparison](https://msdn.microsoft.com/en-us/library/bb386080.aspx)
- [CA2104: Do not declare read only mutable reference types](https://msdn.microsoft.com/en-us/library/ms182302.aspx)

Warning CA3053 is suppressed because the action required to fix it requires a field that does not exist in .NET Core.