### PR TITLE
Fix FxCop issues and `TypeInitializationException` when building

### DIFF
--- a/src/ApiPort/CommandLine/AnalyzeOptions.cs
+++ b/src/ApiPort/CommandLine/AnalyzeOptions.cs
@@ -192,8 +192,7 @@ namespace ApiPort.CommandLine
                         return y == null ? 0 : -1;
                     }
 
-
-                    return x.Name.CompareTo(y?.Name);
+                    return string.Compare(x.Name, y?.Name, StringComparison.Ordinal);
                 }
             }
 

--- a/src/ApiPort/CommandLine/ApiPortConfiguration.cs
+++ b/src/ApiPort/CommandLine/ApiPortConfiguration.cs
@@ -5,6 +5,7 @@ using Microsoft.Framework.Configuration;
 using Microsoft.Framework.OptionsModel;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -80,11 +81,12 @@ namespace ApiPort.CommandLine
         {
             foreach (var tag in array.Tags)
             {
-                var newKey = $"{array.ExpectedTag}:{array.Count++}";
+                var newKey = string.Format(CultureInfo.InvariantCulture, "{0}:{1}", array.ExpectedTag, array.Count++);
+                var tagFormatted = string.Format(CultureInfo.InvariantCulture, "{0}=", tag);
 
-                if (arg.StartsWith($"{tag}=", StringComparison.OrdinalIgnoreCase))
+                if (arg.StartsWith(tagFormatted, StringComparison.OrdinalIgnoreCase))
                 {
-                    return arg.Replace($"{tag}=", $"{newKey}=");
+                    return arg.Replace(tagFormatted, string.Format(CultureInfo.InvariantCulture, "{0}=", newKey));
                 }
                 else if (string.Equals(arg, tag, StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/ApiPort/CommandLineOptions.cs
+++ b/src/ApiPort/CommandLineOptions.cs
@@ -4,6 +4,7 @@
 using ApiPort.CommandLine;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -62,13 +63,13 @@ namespace ApiPort
             if (!string.IsNullOrEmpty(suppliedCommand) && command == null)
             {
                 Console.WriteLine();
-                Program.WriteColorLine($"Unknown command: {suppliedCommand}", ConsoleColor.Red);
+                Program.WriteColorLine(string.Format(CultureInfo.CurrentCulture, "Unknown command: {0}", suppliedCommand), ConsoleColor.Red);
             }
             else if (error)
             {
                 Console.WriteLine();
                 // TODO: Get invalid parameter (Microsoft.Framework.Configuration currently does not surface this)
-                Program.WriteColorLine($"Invalid parameter passed to {suppliedCommand}", ConsoleColor.Red);
+                Program.WriteColorLine(string.Format(CultureInfo.CurrentCulture, "Invalid parameter passed to {0}", suppliedCommand), ConsoleColor.Red);
             }
             
             var location = typeof(CommandLineOptions).GetTypeInfo().Assembly.Location;
@@ -87,7 +88,7 @@ namespace ApiPort
             {
                 Console.WriteLine();
                 Console.WriteLine(new string('=', Math.Min(Console.WindowWidth, 100)));
-                Program.WriteColorLine($"{path} {displayCommand.Name} [options]", ConsoleColor.Yellow);
+                Program.WriteColorLine(string.Format(CultureInfo.CurrentCulture, "{0} {1} [options]", path, displayCommand.Name), ConsoleColor.Yellow);
                 Console.WriteLine();
                 Console.WriteLine(displayCommand.HelpMessage);
             }

--- a/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
@@ -4,7 +4,7 @@
 using Microsoft.Fx.Portability.ObjectModel;
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.Globalization;
 using System.Reflection.Metadata;
 
 namespace Microsoft.Fx.Portability.Analyzer
@@ -115,7 +115,7 @@ namespace Microsoft.Fx.Portability.Analyzer
             return new MemberDependency
             {
                 CallingAssembly = CallingAssembly,
-                MemberDocId = $"T:{type}",
+                MemberDocId = string.Format(CultureInfo.InvariantCulture, "T:{0}", type),
                 DefinedInAssemblyIdentity = definedInAssembly
             };
         }
@@ -157,8 +157,8 @@ namespace Microsoft.Fx.Portability.Analyzer
             return new MemberDependency
             {
                 CallingAssembly = CallingAssembly,
-                MemberDocId = $"{GetPrefix(memberReference)}:{memberRefInfo}",
-                TypeDocId = $"T:{memberRefInfo.ParentType}",
+                MemberDocId = string.Format(CultureInfo.InvariantCulture, "{0}:{1}", GetPrefix(memberReference), memberRefInfo),
+                TypeDocId = string.Format(CultureInfo.InvariantCulture, "T:{0}", memberRefInfo.ParentType),
                 IsPrimitive = memberRefInfo.ParentType.IsPrimitiveType,
                 DefinedInAssemblyIdentity = definedInAssemblyIdentity
             };

--- a/src/Microsoft.Fx.Portability.MetadataReader/MemberDependency.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MemberDependency.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Fx.Portability.ObjectModel;
 using System;
+using System.Globalization;
 
 namespace Microsoft.Fx.Portability.Analyzer
 {
@@ -69,7 +70,7 @@ namespace Microsoft.Fx.Portability.Analyzer
 
         public override string ToString()
         {
-            return string.Format("{0} [{1}]", MemberDocId, CallingAssembly.AssemblyIdentity);
+            return string.Format(CultureInfo.InvariantCulture, "{0} [{1}]", MemberDocId, CallingAssembly.AssemblyIdentity);
         }
 
         public override bool Equals(object obj)

--- a/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfo.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfo.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Decoding;
@@ -277,7 +278,7 @@ namespace Microsoft.Fx.Portability.Analyzer
             {
                 if (MethodSignature.GenericParameterCount > 0)
                 {
-                    sb.Append($"``{MethodSignature.GenericParameterCount}");
+                    sb.Append(string.Format(CultureInfo.InvariantCulture, "``{0}", MethodSignature.GenericParameterCount));
                 }
             }
 

--- a/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfoTypeProvider.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfoTypeProvider.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Fx.Portability.Analyzer.Resources;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Decoding;
 using System.Text;
-using Microsoft.Fx.Portability.Analyzer.Resources;
 
 namespace Microsoft.Fx.Portability.Analyzer
 {
@@ -290,7 +291,7 @@ namespace Microsoft.Fx.Portability.Analyzer
         {
             return new MemberMetadataInfo(elementType)
             {
-                Name = $"{elementType.Name}[]"
+                Name = string.Format(CultureInfo.InvariantCulture, "{0}[]", elementType.Name)
             };
         }
 
@@ -306,7 +307,7 @@ namespace Microsoft.Fx.Portability.Analyzer
         {
             return new MemberMetadataInfo(elementType)
             {
-                Name = $"{elementType.Name}@"
+                Name = string.Format(CultureInfo.InvariantCulture, "{0}@", elementType.Name)
             };
         }
 
@@ -316,7 +317,7 @@ namespace Microsoft.Fx.Portability.Analyzer
             // Type generic arguments are prefixed with `
             return new MemberMetadataInfo
             {
-                Name = $"``{index}",
+                Name = string.Format(CultureInfo.InvariantCulture, "``{0}", index),
                 IsGenericInstance = true
             };
         }
@@ -326,7 +327,7 @@ namespace Microsoft.Fx.Portability.Analyzer
             // Type generic arguments are prefixed with `
             return new MemberMetadataInfo
             {
-                Name = $"`{index}",
+                Name = string.Format(CultureInfo.InvariantCulture, "`{0}", index),
                 IsGenericInstance = true
             };
         }

--- a/src/Microsoft.Fx.Portability.MetadataReader/MetadataReaderExtensions.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MetadataReaderExtensions.cs
@@ -4,6 +4,7 @@
 using Microsoft.Fx.Portability.ObjectModel;
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Decoding;
@@ -91,6 +92,7 @@ namespace Microsoft.Fx.Portability
         /// <param name="metadataReader"></param>
         /// <param name="handle"></param>
         /// <returns></returns>
+        [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:SHA1CannotBeUsed", Justification = "Used to calculate the public key token which is hashed using SHA-1.")]
         private static string FormatPublicKeyToken(this MetadataReader metadataReader, BlobHandle handle)
         {
             byte[] bytes = metadataReader.GetBlobBytes(handle);

--- a/src/Microsoft.Fx.Portability.MetadataReader/ReflectionMetadataDependencyFinder.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/ReflectionMetadataDependencyFinder.cs
@@ -4,7 +4,7 @@
 using Microsoft.Fx.Portability.Resources;
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.Globalization;
 using System.Linq;
 
 namespace Microsoft.Fx.Portability.Analyzer
@@ -44,7 +44,7 @@ namespace Microsoft.Fx.Portability.Analyzer
                 return true;
             }
 
-            _progressReporter.ReportIssue(string.Format(LocalizedStrings.UnknownFile, file.Name));
+            _progressReporter.ReportIssue(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.UnknownFile, file.Name));
 
             return false;
         }

--- a/src/Microsoft.Fx.Portability.MetadataReader/ReflectionMetadataDependencyInfo.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/ReflectionMetadataDependencyInfo.cs
@@ -6,6 +6,7 @@ using Microsoft.Fx.Portability.ObjectModel;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
@@ -137,7 +138,7 @@ namespace Microsoft.Fx.Portability.Analyzer
 
                 // Other exceptions are unexpected, though, and wil benefit from
                 // more details on the scenario that hit them
-                throw new PortabilityAnalyzerException(string.Format(LocalizedStrings.MetadataParsingExceptionMessage, file.Name), exc);
+                throw new PortabilityAnalyzerException(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.MetadataParsingExceptionMessage, file.Name), exc);
             }
         }
 

--- a/src/Microsoft.Fx.Portability.Reports.Html/TargetSupportedIn.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/TargetSupportedIn.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Versioning;
 
 namespace Microsoft.Fx.Portability.Reports
@@ -9,7 +10,9 @@ namespace Microsoft.Fx.Portability.Reports
     public sealed class TargetSupportedIn
     {
         public readonly Version SupportedIn;
-
+        
+        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes",
+            Justification = "This is a false positive. FrameworkName is an immutable class.")]
         public readonly FrameworkName Target;
 
         public TargetSupportedIn(FrameworkName target, Version supportedIn)

--- a/src/Microsoft.Fx.Portability/Reporting/ReportFileWriter.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/ReportFileWriter.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Fx.Portability.Reporting
 
             if (!string.IsNullOrEmpty(originalExtension) && !originalExtension.Equals(extension, StringComparison.OrdinalIgnoreCase))
             {
-                _progressReporter.ReportIssue(string.Format(LocalizedStrings.ChangingFileExtension, fileName, originalExtension, extension));
+                _progressReporter.ReportIssue(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.ChangingFileExtension, fileName, originalExtension, extension));
             }
 
             var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);

--- a/src/Microsoft.Fx.Portability/TargetMapper.cs
+++ b/src/Microsoft.Fx.Portability/TargetMapper.cs
@@ -1,16 +1,17 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Fx.Portability.Resources;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 using System.Xml;
 using System.Xml.Linq;
-using Microsoft.Fx.Portability.Resources;
 
 #if FEATURE_XML_SCHEMA
 using System.Xml.Schema;
@@ -84,8 +85,8 @@ namespace Microsoft.Fx.Portability
             Load(stream, null);
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
-            MessageId = "System.Xml.XmlReader.Create",
+        [SuppressMessage("Microsoft.Security.Xml", "CA3053:UseXmlSecureResolver",
+            Target = "XmlReader.Create(System.IO.Stream)",
             Justification = @"For the call to XmlReader.Create() below, CA3053 recommends setting the
 XmlReaderSettings.XmlResolver property to either null or an instance of XmlSecureResolver.
 However, the said XmlResolver property no longer exists in .NET portable framework (i.e. core framework) which means there is no way to set it.

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Fx.Portability.ObjectModel;
 using NSubstitute;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -92,7 +93,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             _output.WriteLine("Found docids:");
             _output.WriteLine(string.Join(Environment.NewLine, dependencies.Dependencies.Select(o => o.Key.MemberDocId).OrderBy(o => o)));
 
-            Assert.True(false, $"Could not find docid '{docid}'");
+            Assert.True(false, string.Format(CultureInfo.CurrentCulture, "Could not find docid '{0}'", docid));
         }
 
         [Fact]

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/TestAssembly.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/TestAssembly.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
 
             private static string GetText(string fileName)
             {
-                var name = s_assembly.GetManifestResourceNames().Single(n => n.EndsWith(fileName));
+                var name = s_assembly.GetManifestResourceNames().Single(n => n.EndsWith(fileName, StringComparison.Ordinal));
 
                 using (var stream = s_assembly.GetManifestResourceStream(name))
                 using (var reader = new StreamReader(stream))
@@ -90,7 +90,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
 
             public ResourceStreamAssemblyFile(string fileName)
             {
-                Name = s_assembly.GetManifestResourceNames().Single(n => n.EndsWith(fileName));
+                Name = s_assembly.GetManifestResourceNames().Single(n => n.EndsWith(fileName, StringComparison.Ordinal));
                 Exists = Name != null;
             }
 

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/project.json
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "MicroBuild.Core": "0.1.1",
-    "Microsoft.CodeAnalysis.CSharp": "1.1.0",
+    "Microsoft.CodeAnalysis.Csharp": "1.1.1",
     "Newtonsoft.Json": "6.0.8",
     "NSubstitute": "1.9.2",
     "System.Reflection.Metadata": "1.2.0-rc2-23713",


### PR DESCRIPTION
- There were a lot more FxCop issues (after fixing the initial ones) when I tested it manually
   - [CA1305: Specify IFormatProvider](https://msdn.microsoft.com/en-us/library/ms182190.aspx)
   - [CA1307: Specify StringComparison](https://msdn.microsoft.com/en-us/library/bb386080.aspx)
   - Suppressed [CA2104](https://msdn.microsoft.com/en-us/library/ms182302.aspx) and CA5354
- Building from command-line resulted in a [Roslyn bug](https://github.com/dotnet/roslyn/issues/7276) which was fixed by upgrading to the newest nuget
