### PR TITLE
Add ability to get parent for an Api and fix OOM when serializing large objects

### DIFF
--- a/src/Microsoft.Fx.Portability/ObjectModel/ApiInfoStorage.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/ApiInfoStorage.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Fx.Portability.ObjectModel
         public string Type { get; set; }
         public string Name { get; set; }
         public string FullName { get; set; }
+
+        /// <summary>
+        /// DocId of the parent. Null if the Api does not have a parent.
+        /// </summary>
+        public string Parent { get; set; }
         public IReadOnlyCollection<FrameworkName> Targets { get; set; }
         public IReadOnlyCollection<ApiMetadataStorage> Metadata { get; set; }
     }


### PR DESCRIPTION
- Add field to expose the parent docId for a given Api
- Encountered an OOM when serializing DotNetCatalog. Fix this by adding methods to write/read from stream rather than return a string.