### PR TITLE
Adding ability to GetAncestors for an Api

### DIFF
--- a/src/Microsoft.Fx.Portability/ApiDefinition.cs
+++ b/src/Microsoft.Fx.Portability/ApiDefinition.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Fx.Portability
         private string _returnType;
         private string _name;
         private string _fullName;
+        private string _parent;
 
         public string DocId
         {
@@ -32,6 +33,15 @@ namespace Microsoft.Fx.Portability
         {
             get { return _fullName ?? string.Empty; }
             set { _fullName = value; }
+        }
+
+        /// <summary>
+        /// DocId of Api's parent
+        /// </summary>
+        public string Parent
+        {
+            get { return _parent ?? string.Empty; }
+            set { _parent = value; }
         }
 
         public override bool Equals(object obj)

--- a/src/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
             _frameworkAssemblies = new HashSet<string>(catalog.FrameworkAssemblyIdenties, StringComparer.OrdinalIgnoreCase);
 
-            _docIdToApi = catalog.Apis.ToDictionary(key => key.DocId, key => new ApiDefinition { DocId = key.DocId, Name = key.Name, ReturnType = key.Type, FullName = key.FullName });
+            _docIdToApi = catalog.Apis.ToDictionary(key => key.DocId, key => new ApiDefinition { DocId = key.DocId, Name = key.Name, ReturnType = key.Type, FullName = key.FullName, Parent = key.Parent });
         }
 
         public IEnumerable<string> DocIds
@@ -163,6 +163,25 @@ namespace Microsoft.Fx.Portability.ObjectModel
         public IEnumerable<TargetInfo> GetAllTargets()
         {
             return _allTargets;
+        }
+
+        /// <summary>
+        /// Retrieves the ancestors for a given docId. 
+        /// This retrieves the Api's parent first and then the parent's ancestor
+        /// until it reaches the root.
+        /// </summary>
+        public IEnumerable<string> GetAncestors(string docId)
+        {
+            var api = GetApiDefinition(docId);
+            var parent = api.Parent;
+
+            while (!string.IsNullOrEmpty(parent))
+            {
+                yield return parent;
+
+                api = GetApiDefinition(parent);
+                parent = api.Parent;
+            }
         }
 
         public string BuiltBy { get { return _builtBy; } }

--- a/src/Microsoft.Fx.Portability/ObjectModel/IApiCatalogLookup.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/IApiCatalogLookup.cs
@@ -23,5 +23,10 @@ namespace Microsoft.Fx.Portability.ObjectModel
         bool IsMemberInTarget(string docId, FrameworkName targetName, out Version introducedVersion);
         bool IsMemberInTarget(string docId, FrameworkName targetName);
         IEnumerable<FrameworkName> GetSupportedVersions(string docId);
+
+        /// <summary>
+        /// Retrieves the ancestors for a given docId
+        /// </summary>
+        IEnumerable<string> GetAncestors(string docId);
     }
 }

--- a/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="BreakingChangeParserTests.cs" />
     <Compile Include="BreakingChangeTests.cs" />
     <Compile Include="ObjectModel\AssemblyReferenceInformationTests.cs" />
+    <Compile Include="ObjectModel\CloudApiCatalogLookupTests.cs" />
     <Compile Include="ObjectModel\IgnoreAssemblyInfoTests.cs" />
     <Compile Include="ObjectModel\DiagnosticAnalyzerInfoTests.cs" />
     <Compile Include="ObjectModel\TargetInformationTests.cs" />
@@ -64,6 +65,7 @@
     <Compile Include="SerializationTests.cs" />
     <Compile Include="TargetMapTests.cs" />
     <Compile Include="TestData\TestCatalog.cs" />
+    <Compile Include="TestData\TestDotNetCatalog.cs" />
     <Compile Include="UrlBuilderTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Microsoft.Fx.Portability.Tests/ObjectModel/CloudApiCatalogLookupTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ObjectModel/CloudApiCatalogLookupTests.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Fx.Portability.ObjectModel;
-using System.Reflection;
+using Microsoft.Fx.Portability.Tests.TestData;
 using Xunit;
 
 namespace Microsoft.Fx.Portability.Tests.ObjectModel
@@ -12,7 +12,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         [Theory]
         public void GetAncestorsTest(string docId, string ancestors)
         {
-            var dotnetCatalog = GetDotNetCatalog();
+            var dotnetCatalog = new TestDotNetCatalog();
             var catalog = new CloudApiCatalogLookup(dotnetCatalog);
 
             var expected = ancestors != null ? ancestors.Split(';') : null;
@@ -26,18 +26,16 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
             }
         }
 
-        private static DotNetCatalog GetDotNetCatalog()
+        [InlineData("N:System.Collections.Concurrent")]
+        [Theory]
+        public void GetAncestorsTestEmpty(string docId)
         {
-            const string catalogName = "Microsoft.Fx.Portability.Tests.TestAssets.DummyApiCatalog.json";
+            var dotnetCatalog = new TestDotNetCatalog();
+            var catalog = new CloudApiCatalogLookup(dotnetCatalog);
 
-            DotNetCatalog catalog = null;
+            var results = catalog.GetAncestors(docId);
 
-            using (var template = typeof(CloudApiCatalogLookupTests).GetTypeInfo().Assembly.GetManifestResourceStream(catalogName))
-            {
-                catalog = template.Deserialize<DotNetCatalog>();
-            }
-
-            return catalog;
+            Assert.Empty(results);
         }
     }
 }

--- a/tests/Microsoft.Fx.Portability.Tests/ObjectModel/CloudApiCatalogLookupTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ObjectModel/CloudApiCatalogLookupTests.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.Fx.Portability.ObjectModel;
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.Fx.Portability.Tests.ObjectModel
+{
+    public class CloudApiCatalogLookupTests
+    {
+        [InlineData("N:System.Collections", null)]
+        [InlineData("M:System.Collections.Concurrent.ConcurrentBag`1.get_Count", "P:System.Collections.Concurrent.ConcurrentBag`1.Count;T:System.Collections.Concurrent.ConcurrentBag`1;N:System.Collections.Concurrent")]
+        [InlineData("T:System.Collections.Concurrent.ConcurrentBag`1", "N:System.Collections.Concurrent")]
+        [Theory]
+        public void GetAncestorsTest(string docId, string ancestors)
+        {
+            var dotnetCatalog = GetDotNetCatalog();
+            var catalog = new CloudApiCatalogLookup(dotnetCatalog);
+
+            var expected = ancestors != null ? ancestors.Split(';') : null;
+
+            int index = 0;
+
+            foreach (var result in catalog.GetAncestors(docId))
+            {
+                Assert.Equal(expected[index], result);
+                index++;
+            }
+        }
+
+        private static DotNetCatalog GetDotNetCatalog()
+        {
+            const string catalogName = "Microsoft.Fx.Portability.Tests.TestAssets.DummyApiCatalog.json";
+
+            DotNetCatalog catalog = null;
+
+            using (var template = typeof(CloudApiCatalogLookupTests).GetTypeInfo().Assembly.GetManifestResourceStream(catalogName))
+            {
+                catalog = template.Deserialize<DotNetCatalog>();
+            }
+
+            return catalog;
+        }
+    }
+}

--- a/tests/Microsoft.Fx.Portability.Tests/TestData/TestCatalog.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/TestData/TestCatalog.cs
@@ -112,5 +112,10 @@ namespace Microsoft.Fx.Portability.TestData
         {
             throw new NotImplementedException();
         }
+
+        public IEnumerable<string> GetAncestors(string docId)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/tests/Microsoft.Fx.Portability.Tests/TestData/TestDotNetCatalog.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/TestData/TestDotNetCatalog.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.Fx.Portability.ObjectModel;
+using System.Runtime.Versioning;
+
+namespace Microsoft.Fx.Portability.Tests.TestData
+{
+    public class TestDotNetCatalog : DotNetCatalog
+    {
+        private static readonly FrameworkName Windows80 = new FrameworkName("Windows,Version=v8.0");
+        private static readonly FrameworkName Windows81 = new FrameworkName("Windows,Version=v8.1");
+        private static readonly FrameworkName NetCore50 = new FrameworkName(".NET Core,Version=v5.0");
+        private static readonly FrameworkName Net11 = new FrameworkName(".NET Framework,Version=v1.1");
+        private static readonly FrameworkName Net40 = new FrameworkName(".NET Framework,Version=v4.0");
+
+        private static readonly string[] FrameworkIdentities = new[] {
+            "System.Collections, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Collections.Concurrent, PublicKeyToken=b03f5f7f11d50a3a",
+            "System.Collections.NonGeneric, PublicKeyToken=b03f5f7f11d50a3a"
+        };
+
+        private static readonly TargetInfo[] TestSupportedTargets = new[] {
+            new TargetInfo { DisplayName = Windows80, IsReleased = true },
+            new TargetInfo { DisplayName = Windows81, IsReleased = true },
+            new TargetInfo { DisplayName = NetCore50, IsReleased = true },
+            new TargetInfo { DisplayName = Net11, IsReleased = true },
+            new TargetInfo { DisplayName = Net40, IsReleased = true },
+        };
+
+        public TestDotNetCatalog()
+        {
+            BuiltBy = "Test Machine";
+            Apis = GetApis();
+            FrameworkAssemblyIdenties = FrameworkIdentities;
+            SupportedTargets = TestSupportedTargets;
+        }
+
+        private ApiInfoStorage[] GetApis()
+        {
+            var targets11 = new[] { Windows80, NetCore50, Net11 };
+            var targets40 = new[] { Windows80, NetCore50, Net40 };
+
+            var apis = new[] {
+                new ApiInfoStorage {
+                    DocId = "N:System.Collections",
+                    FullName = "System.Collections",
+                    Name = "System.Collections",
+                    Type = "",
+                    Parent = null,
+                    Targets = targets11
+                },
+                new ApiInfoStorage {
+                    DocId = "N:System.Collections.Concurrent",
+                    FullName = "System.Collections.Concurrent",
+                    Name = "System.Collections.Concurrent",
+                    Type = "",
+                    Parent = null,
+                    Targets = targets40
+                },
+                new ApiInfoStorage {
+                    DocId = "T:System.Collections.Concurrent.ConcurrentBag`1",
+                    FullName = "System.Collections.Concurrent.ConcurrentBag<T>",
+                    Name = "ConcurrentBag<T>",
+                    Type = "",
+                    Parent = "N:System.Collections.Concurrent",
+                    Targets = targets40
+                },
+                new ApiInfoStorage {
+                    DocId = "P:System.Collections.Concurrent.ConcurrentBag`1.Count",
+                    FullName = "System.Collections.Concurrent.ConcurrentBag<T>.Count",
+                    Name = "Count",
+                    Type = "Int32",
+                    Parent = "T:System.Collections.Concurrent.ConcurrentBag`1",
+                    Targets = targets40
+                },
+                new ApiInfoStorage {
+                    DocId = "M:System.Collections.Concurrent.ConcurrentBag`1.CopyTo(`0[],System.Int32)",
+                    FullName = "System.Collections.Concurrent.ConcurrentBag<T>.CopyTo(T[], Int32)",
+                    Name = "CopyTo(T[], Int32)",
+                    Type = "Void",
+                    Parent = "T:System.Collections.Concurrent.ConcurrentBag`1",
+                    Targets = targets40
+                },
+                new ApiInfoStorage {
+                    DocId = "M:System.Collections.Concurrent.ConcurrentBag`1.get_Count",
+                    FullName = "System.Collections.Concurrent.ConcurrentBag<T>.Count.get_Count()",
+                    Name = "get_Count()",
+                    Type = "Int32",
+                    Parent = "P:System.Collections.Concurrent.ConcurrentBag`1.Count",
+                    Targets = targets40
+                }
+            };
+
+            return apis;
+        }
+    }
+}


### PR DESCRIPTION
This builds on top of #228 to allow the service to retrieve an API's ancestors.