### PR TITLE
Fixed nuget feed from dotnet-corefx to dotnet-core; update Metadata package

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <add key="nuget" value="https://www.nuget.org/api/v2/" />
-    <add key="myget.org dotnet-corefx" value="https://www.myget.org/F/dotnet-corefx/" />
+    <add key="myget.org dotnet-core" value="https://www.myget.org/F/dotnet-core/" />
   </packageSources>
 </configuration>

--- a/src/ApiPort/ApiPort.Core.project.json
+++ b/src/ApiPort/ApiPort.Core.project.json
@@ -13,7 +13,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-*",
     "Newtonsoft.Json": "6.0.8",
     "System.Collections.Immutable": "1.1.38-*",
-    "System.Reflection.Metadata": "1.2.0-alpha-00017",
+    "System.Reflection.Metadata": "1.2.0-rc2-23713",
     "Unity": "3.5.1404-*"
   },
   "frameworks": {

--- a/src/ApiPort/ApiPort.project.json
+++ b/src/ApiPort/ApiPort.project.json
@@ -9,7 +9,7 @@
     "Microsoft.Framework.OptionsModel": "1.0.0-beta5",
     "Newtonsoft.Json": "6.0.8",
     "System.Collections.Immutable": "1.1.38-*",
-    "System.Reflection.Metadata": "1.2.0-alpha-00017",
+    "System.Reflection.Metadata": "1.2.0-rc2-23713",
     "Unity": "3.5.1404"
   },
   "frameworks": {

--- a/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfo.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfo.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Decoding;
 using System.Text;
 
 namespace Microsoft.Fx.Portability.Analyzer

--- a/src/Microsoft.Fx.Portability.MetadataReader/MetadataReaderExtensions.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MetadataReaderExtensions.cs
@@ -62,7 +62,8 @@ namespace Microsoft.Fx.Portability
             }
 
             var ctor = metadataReader.GetMemberReference((MemberReferenceHandle)customAttribute.Constructor);
-            var signature = SignatureDecoder.DecodeMethodSignature(ctor.Signature, new StringParameterValueTypeProvider(metadataReader, customAttribute.Value));
+            var provider = new StringParameterValueTypeProvider(metadataReader, customAttribute.Value);
+            var signature = ctor.DecodeMethodSignature(provider);
 
             return signature.ParameterTypes;
         }

--- a/src/Microsoft.Fx.Portability.MetadataReader/MethodSignatureExtensions.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MethodSignatureExtensions.cs
@@ -4,7 +4,7 @@
 using Microsoft.Fx.Portability.Analyzer;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Reflection.Metadata;
+using System.Reflection.Metadata.Decoding;
 
 namespace Microsoft.Fx.Portability
 {

--- a/src/Microsoft.Fx.Portability.MetadataReader/Microsoft.Fx.Portability.MetadataReader.NET45.project.json
+++ b/src/Microsoft.Fx.Portability.MetadataReader/Microsoft.Fx.Portability.MetadataReader.NET45.project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "MicroBuild.Core": "0.1.1",
     "System.Collections.Immutable": "1.1.37",
-    "System.Reflection.Metadata": "1.2.0-alpha-00017"
+    "System.Reflection.Metadata": "1.2.0-rc2-23713"
   },
   "frameworks": {
     "net45": { }

--- a/src/Microsoft.Fx.Portability.MetadataReader/Microsoft.Fx.Portability.MetadataReader.project.json
+++ b/src/Microsoft.Fx.Portability.MetadataReader/Microsoft.Fx.Portability.MetadataReader.project.json
@@ -7,7 +7,7 @@
     "MicroBuild.Core": "0.1.1",
     "Microsoft.NETCore": "5.0.0",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
-    "System.Reflection.Metadata": "1.2.0-alpha-00017",
+    "System.Reflection.Metadata": "1.2.0-rc2-23713",
     "System.Security.Cryptography.Algorithms": "4.0.0-beta-23225"
   },
   "frameworks": {

--- a/src/Microsoft.Fx.Portability.MetadataReader/StringParameterValueTypeProvider.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/StringParameterValueTypeProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Fx.Portability
             return string.Empty;
         }
 
-        public string GetModifiedType(string unmodifiedType, ImmutableArray<CustomModifier<string>> customModifiers)
+        public string GetModifiedType(MetadataReader reader, bool isRequired, EntityHandle modifierTypeHandle, string unmodifiedType)
         {
             return string.Empty;
         }
@@ -98,12 +98,22 @@ namespace Microsoft.Fx.Portability
             return string.Empty;
         }
 
+        public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, SignatureTypeHandleCode code)
+        {
+            return string.Empty;
+        }
+
         public string GetTypeFromReference(TypeReferenceHandle handle)
         {
             return string.Empty;
         }
 
         public string GetTypeFromReference(TypeReferenceHandle handle, bool? isValueType)
+        {
+            return string.Empty;
+        }
+
+        public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, SignatureTypeHandleCode code)
         {
             return string.Empty;
         }

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ReflectionMetadataInfoTests.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ReflectionMetadataInfoTests.cs
@@ -60,8 +60,8 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
 
         private static readonly IEnumerable<string> s_expectedResult = new[]
         {
-            "Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
-            "Microsoft.CodeAnalysis.CSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+            "Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
+            "Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35",
             typeof(ApiPortClient).Assembly.ToString(),
             typeof(ReflectionMetadataDependencyFinder).Assembly.ToString(),
             "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/project.json
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/project.json
@@ -4,7 +4,7 @@
     "Microsoft.CodeAnalysis.Csharp": "1.0.0",
     "Newtonsoft.Json": "6.0.8",
     "NSubstitute": "1.9.2",
-    "System.Reflection.Metadata": "1.2.0-alpha-00017",
+    "System.Reflection.Metadata": "1.2.0-rc2-23713",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/project.json
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "MicroBuild.Core": "0.1.1",
-    "Microsoft.CodeAnalysis.Csharp": "1.0.0",
+    "Microsoft.CodeAnalysis.CSharp": "1.1.0",
     "Newtonsoft.Json": "6.0.8",
     "NSubstitute": "1.9.2",
     "System.Reflection.Metadata": "1.2.0-rc2-23713",


### PR DESCRIPTION
- Move dotnet-corefx myget feed to dotnet-core
- Update Microsoft.CodeAnalysis because of TypeInitializationException in previous version
- Update System.Reflection.Metadata since it does not exist on the dotnet-core feed