### PR TITLE
Fix ordering of signature modifiers to be in metadata order

### DIFF
--- a/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfo.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfo.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Fx.Portability.Analyzer
         {
             Kind = MemberKind.Type;
             Names = new List<string>();
+            Modifiers = new StackCollection<string>();
         }
 
         public MemberMetadataInfo(MemberMetadataInfo other)
@@ -30,6 +31,8 @@ namespace Microsoft.Fx.Portability.Analyzer
             Kind = other.Kind;
             IsGenericInstance = other.IsGenericInstance;
             IsEnclosedType = other.IsEnclosedType;
+            IsPointer = other.IsPointer;
+            Modifiers = new StackCollection<string>(other.Modifiers);
             Name = other.Name;
             Namespace = other.Namespace;
             DefinedInAssembly = other.DefinedInAssembly;
@@ -92,6 +95,10 @@ namespace Microsoft.Fx.Portability.Analyzer
 
         public AssemblyReference? DefinedInAssembly { get; set; }
 
+        public ICollection<string> Modifiers { get; }
+
+        public bool IsPointer { get; set; }
+
         public override string ToString()
         {
             if (Kind == MemberKind.Method || Kind == MemberKind.Field)
@@ -123,6 +130,17 @@ namespace Microsoft.Fx.Portability.Analyzer
             if (IsArrayType)
             {
                 sb.Append(ArrayTypeInfo);
+            }
+
+            if (Modifiers.Any())
+            {
+                sb.Append(' ');
+                sb.Append(string.Join(" ", Modifiers));
+            }
+
+            if (IsPointer)
+            {
+                sb.Append('*');
             }
 
             return sb.ToString();
@@ -311,6 +329,22 @@ namespace Microsoft.Fx.Portability.Analyzer
             }
 
             return int.TryParse(displayName.Substring(pos, offsetStringAfterGenericMarker - pos), out numGenericArgs);
+        }
+
+        private class StackCollection<T> : Stack<T>, ICollection<T>
+        {
+            public StackCollection()
+            { }
+
+            public StackCollection(IEnumerable<T> other)
+                : base(other)
+            { }
+
+            public bool IsReadOnly { get; } = false;
+
+            public void Add(T item) => Push(item);
+
+            public bool Remove(T item) => false;
         }
     }
 }

--- a/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfoTypeProvider.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfoTypeProvider.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Fx.Portability.Analyzer
         {
             return new MemberMetadataInfo(elementType)
             {
-                Name = $"{elementType.Name}*"
+                IsPointer = true
             };
         }
 
@@ -399,9 +399,8 @@ namespace Microsoft.Fx.Portability.Analyzer
         public MemberMetadataInfo GetModifiedType(MetadataReader reader, bool isRequired, EntityHandle modifierTypeHandle, MemberMetadataInfo unmodifiedType)
         {
             var builder = new StringBuilder();
-            builder.Append(unmodifiedType.Name);
 
-            builder.Append(isRequired ? " reqmod " : " optmod ");
+            builder.Append(isRequired ? "reqmod " : "optmod ");
 
             MemberMetadataInfo info = null;
 
@@ -428,7 +427,8 @@ namespace Microsoft.Fx.Portability.Analyzer
                     throw new NotSupportedException("This kind is not supported!");
             }
 
-            unmodifiedType.Name = builder.ToString();
+            unmodifiedType.Modifiers.Add(builder.ToString());
+
             return unmodifiedType;
         }
 


### PR DESCRIPTION
A recent fix in the beta of S.R.Metadata signature decoder returns the IL syntactic order instead of the metadata order we need for doc id generation. This will defer the name generation until we have all the modifiers.

Fixes #236