### PR TITLE
Consolidate docids for breaking changes

### DIFF
--- a/docs/BreakingChanges/011 System.Net.PeerToPeer.Collaboration unavailable on Windows 8.md
+++ b/docs/BreakingChanges/011 System.Net.PeerToPeer.Collaboration unavailable on Windows 8.md
@@ -19,39 +19,7 @@ The System.Net.PeerToPeer.Collaboration namespace is unavailable on Windows 8 or
 Apps that support Windows 8 or above must be updated to not depend on this namespace or its members.
 
 ### Affected APIs
-* `T:System.Net.PeerToPeer.Collaboration.ContactManager`
-* `T:System.Net.PeerToPeer.Collaboration.CreateContactCompletedEventArgs`
-* `T:System.Net.PeerToPeer.Collaboration.InviteCompletedEventArgs`
-* `T:System.Net.PeerToPeer.Collaboration.NameChangedEventArgs`
-* `T:System.Net.PeerToPeer.Collaboration.ObjectChangedEventArgs`
-* `T:System.Net.PeerToPeer.Collaboration.Peer`
-* `T:System.Net.PeerToPeer.Collaboration.PeerApplication`
-* `T:System.Net.PeerToPeer.Collaboration.PeerApplicationCollection`
-* `T:System.Net.PeerToPeer.Collaboration.PeerApplicationLaunchInfo`
-* `T:System.Net.PeerToPeer.Collaboration.PeerApplicationRegistrationType`
-* `T:System.Net.PeerToPeer.Collaboration.PeerChangeType`
-* `T:System.Net.PeerToPeer.Collaboration.PeerCollaboration`
-* `T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission`
-* `T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermissionAttribute`
-* `T:System.Net.PeerToPeer.Collaboration.PeerContact`
-* `T:System.Net.PeerToPeer.Collaboration.PeerContactCollection`
-* `T:System.Net.PeerToPeer.Collaboration.PeerEndPoint`
-* `T:System.Net.PeerToPeer.Collaboration.PeerEndPointCollection`
-* `T:System.Net.PeerToPeer.Collaboration.PeerInvitationResponse`
-* `T:System.Net.PeerToPeer.Collaboration.PeerInvitationResponseType`
-* `T:System.Net.PeerToPeer.Collaboration.PeerNearMe`
-* `T:System.Net.PeerToPeer.Collaboration.PeerNearMeChangedEventArgs`
-* `T:System.Net.PeerToPeer.Collaboration.PeerNearMeCollection`
-* `T:System.Net.PeerToPeer.Collaboration.PeerObject`
-* `T:System.Net.PeerToPeer.Collaboration.PeerObjectCollection`
-* `T:System.Net.PeerToPeer.Collaboration.PeerPresenceInfo`
-* `T:System.Net.PeerToPeer.Collaboration.PeerPresenceStatus`
-* `T:System.Net.PeerToPeer.Collaboration.PeerScope`
-* `T:System.Net.PeerToPeer.Collaboration.PresenceChangedEventArgs`
-* `T:System.Net.PeerToPeer.Collaboration.RefreshDataCompletedEventArgs`
-* `T:System.Net.PeerToPeer.Collaboration.SubscribeCompletedEventArgs`
-* `T:System.Net.PeerToPeer.Collaboration.SubscriptionListChangedEventArgs`
-* `T:System.Net.PeerToPeer.Collaboration.SubscriptionType`
+* `N:System.Net.PeerToPeer.Collaboration`
 
 ### Category
 Networking

--- a/docs/BreakingChanges/043 HttpRequest.ContentEncoding property prohibits UTF7.md
+++ b/docs/BreakingChanges/043 HttpRequest.ContentEncoding property prohibits UTF7.md
@@ -20,8 +20,6 @@ Ideally, applications should be updated to not use UTF-7 encoding in HttpRequest
 
 ### Affected APIs
 * `P:System.Web.HttpRequest.ContentEncoding`
-* `M:System.Web.HttpRequest.get_ContentEncoding`
-* `M:System.Web.HttpRequest.set_ContentEncoding(System.Text.Encoding)`
 
 ### Category
 ASP.NET

--- a/docs/BreakingChanges/052 WPF TextBox.Text can be out-of-sync with databinding.md
+++ b/docs/BreakingChanges/052 WPF TextBox.Text can be out-of-sync with databinding.md
@@ -19,8 +19,6 @@ In some cases, the TextBox.Text property reflects a previous value of the databo
 This should have no negative impact. However, you can restore the previous behavior by setting the [FrameworkCompatibilityPreferences.KeepTextBoxDisplaySynchronizedWithTextProperty](https://msdn.microsoft.com/en-us/library/system.windows.frameworkcompatibilitypreferences.keeptextboxdisplaysynchronizedwithtextproperty(v=vs.110).aspx) property to false.
 
 ### Affected APIs
-* `M:System.Windows.Controls.TextBox.get_Text`
-* `M:System.Windows.Controls.TextBox.set_Text(System.String)`
 * `P:System.Windows.Controls.TextBox.Text`
 
 ### Category

--- a/docs/BreakingChanges/068 DbParameter.Precision and DbParameter.Scale are now public virtual members.md
+++ b/docs/BreakingChanges/068 DbParameter.Precision and DbParameter.Scale are now public virtual members.md
@@ -20,11 +20,7 @@ When re-building an ADO.NET database provider, these differences will require th
 
 ### Affected APIs
 * `P:System.Data.Common.DbParameter.Precision`
-* `M:System.Data.Common.DbParameter.get_Precision`
-* `M:System.Data.Common.DbParameter.set_Precision(System.Byte)`
 * `P:System.Data.Common.DbParameter.Scale`
-* `M:System.Data.Common.DbParameter.get_Scale`
-* `M:System.Data.Common.DbParameter.set_Scale(System.Byte)`
 
 ### Category
 ADO.NET

--- a/docs/BreakingChanges/107 Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException.md
+++ b/docs/BreakingChanges/107 Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException.md
@@ -24,7 +24,6 @@ This issue has been fixed in the .NET Framework 4.6 and may be addressed by upgr
 ### Affected APIs
 * `E:System.Windows.Controls.DataGrid.UnloadingRow`
 * `E:System.Windows.Controls.DataGrid.UnloadingRowDetails`
-* `E:System.Windows.Controls.DataGrid.UnloadingRowGroup`
 
 ### Category
 Windows Presentation Foundation (WPF)

--- a/docs/BreakingChanges/114 GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET 4.5.md
+++ b/docs/BreakingChanges/114 GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET 4.5.md
@@ -26,7 +26,6 @@ Be aware that some glyph bounding box sizes have increased. These changes will u
 
 ### Affected APIs
 * `M:System.Windows.Media.GlyphRun.ComputeInkBoundingBox`
-* `M:System.Windows.Media.FormattedText.get_Extent`
 * `P:System.Windows.Media.FormattedText.Extent`
 
 ### Category

--- a/docs/BreakingChanges/115 AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm.md
+++ b/docs/BreakingChanges/115 AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm.md
@@ -19,7 +19,6 @@ Prior to the .NET Framework 4.6, the value of AppDomainSetup.DynamicBase would b
 Be aware that enabling `UseRandomizedStringHashAlgorithm` will not result in `AppDomainSetup.DynamicBase` being randomized. If a random base is needed, it must be produced in your app's code rather than via this API.
 
 ### Affected APIs
-* `M:System.AppDomainSetup.get_DynamicBase`
 * `P:System.AppDomainSetup.DynamicBase`
 
 ### Category

--- a/docs/BreakingChanges/116 GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view.md
+++ b/docs/BreakingChanges/116 GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view.md
@@ -22,7 +22,6 @@ A bug in the .NET Framework 4.5 causes `PageIndexChanging` to sometimes not fire
 This issue has been fixed in the .NET Framework 4.6 and may be addressed by upgrading to that version of the .NET Framework. As a work-around, the app can do an explicit BindGrid on any `Page_Load` that would hit these conditions (the GridView is on the last page and LastPageSize is different from PageSize). Alternatively, the app can be modified to allow paging (instead of custom paging), as that scenario does not demonstrate the problem.
 
 ### Affected APIs
-* `M:System.Web.UI.WebControls.GridView.set_AllowCustomPaging(System.Boolean)`
 * `P:System.Web.UI.WebControls.GridView.AllowCustomPaging`
 
 ### Category

--- a/docs/BreakingChanges/125 ASP.NET MVC now escapes spaces in strings passed in via route parameters.md
+++ b/docs/BreakingChanges/125 ASP.NET MVC now escapes spaces in strings passed in via route parameters.md
@@ -19,7 +19,6 @@ In order to conform to RFC 2396, spaces in route paths are now escaped when popu
 Code should be updated to unescape string parameters from a route. If the original URI is needed, it can be accessed with the Request.RequestUri.OriginalString API.
 
 ### Affected APIs
-* `M:Microsoft.AspNet.Mvc.RouteAttribute.#ctor(System.String)`
 * `M:System.Web.Http.RouteAttribute.#ctor(System.String)`
 
 ### Category

--- a/docs/BreakingChanges/134 Persian calendar now uses the Hijri solar algorithm.md
+++ b/docs/BreakingChanges/134 Persian calendar now uses the Hijri solar algorithm.md
@@ -21,36 +21,6 @@ Also, `PersianCalendar.MinSupportedDateTime` is now `March 22, 0622 instead of M
 Be aware that some early or late dates may be slightly different when using the PersianCalendar in .NET 4.6. Also, when serializing dates between processes which may run on different .NET Framework versions, do not store them as PersianCalendar date strings (since those values may be different).
 
 ### Affected APIs
-* `F:System.Globalization.PersianCalendar.PersianEra`
-* `M:System.Globalization.PersianCalendar.#ctor`
-* `M:System.Globalization.PersianCalendar.AddMonths(System.DateTime,System.Int32)`
-* `M:System.Globalization.PersianCalendar.AddYears(System.DateTime,System.Int32)`
-* `M:System.Globalization.PersianCalendar.get_AlgorithmType`
-* `M:System.Globalization.PersianCalendar.get_Eras`
-* `M:System.Globalization.PersianCalendar.get_MaxSupportedDateTime`
-* `M:System.Globalization.PersianCalendar.get_MinSupportedDateTime`
-* `M:System.Globalization.PersianCalendar.get_TwoDigitYearMax`
-* `M:System.Globalization.PersianCalendar.GetDayOfMonth(System.DateTime)`
-* `M:System.Globalization.PersianCalendar.GetDayOfWeek(System.DateTime)`
-* `M:System.Globalization.PersianCalendar.GetDayOfYear(System.DateTime)`
-* `M:System.Globalization.PersianCalendar.GetDaysInMonth(System.Int32,System.Int32,System.Int32)`
-* `M:System.Globalization.PersianCalendar.GetDaysInYear(System.Int32,System.Int32)`
-* `M:System.Globalization.PersianCalendar.GetEra(System.DateTime)`
-* `M:System.Globalization.PersianCalendar.GetLeapMonth(System.Int32,System.Int32)`
-* `M:System.Globalization.PersianCalendar.GetMonth(System.DateTime)`
-* `M:System.Globalization.PersianCalendar.GetMonthsInYear(System.Int32,System.Int32)`
-* `M:System.Globalization.PersianCalendar.GetYear(System.DateTime)`
-* `M:System.Globalization.PersianCalendar.IsLeapDay(System.Int32,System.Int32,System.Int32,System.Int32)`
-* `M:System.Globalization.PersianCalendar.IsLeapMonth(System.Int32,System.Int32,System.Int32)`
-* `M:System.Globalization.PersianCalendar.IsLeapYear(System.Int32,System.Int32)`
-* `M:System.Globalization.PersianCalendar.set_TwoDigitYearMax(System.Int32)`
-* `M:System.Globalization.PersianCalendar.ToDateTime(System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32)`
-* `M:System.Globalization.PersianCalendar.ToFourDigitYear(System.Int32)`
-* `P:System.Globalization.PersianCalendar.AlgorithmType`
-* `P:System.Globalization.PersianCalendar.Eras`
-* `P:System.Globalization.PersianCalendar.MaxSupportedDateTime`
-* `P:System.Globalization.PersianCalendar.MinSupportedDateTime`
-* `P:System.Globalization.PersianCalendar.TwoDigitYearMax`
 * `T:System.Globalization.PersianCalendar`
 
 ### Category

--- a/docs/BreakingChanges/137 Only Tls 1.0 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream.md
+++ b/docs/BreakingChanges/137 Only Tls 1.0 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream.md
@@ -18,7 +18,7 @@ Starting with the .NET Framework 4.6, the `System.Net.ServicePointManager` and `
 ### Recommended Action
 The recommended mitigation is to upgrade the sever-side app to Tls1.0, Tls1.1, or Tls1.2. If this is not feasible, or if client apps are broken, the AppContext class can be used to opt out of this feature in either of two ways: 
 
-1. By programmatically setting compat switches on the AppContext, as explained [here](TBD)
+1. By programmatically setting compat switches on the AppContext, as explained [here](http://blogs.msdn.com/b/dotnet/archive/2015/04/29/net-announcements-at-build-2015.aspx#dotnet46)
 2. By adding the following line to the `<runtime>` section of the app.config file: `<AppContextSwitchOverrides value="Switch.System.Net.DontEnableSchUseStrongCrypto=true"/>`;
 
 ### Affected APIs

--- a/docs/BreakingChanges/142 WCF Binding with the TransportWithMessageCredential security mode.md
+++ b/docs/BreakingChanges/142 WCF Binding with the TransportWithMessageCredential security mode.md
@@ -30,7 +30,6 @@ Because this is an opt-in feature, it should not affect the behavior of existing
 ### Affected APIs
 * `F:System.ServiceModel.BasicHttpSecurityMode.TransportWithMessageCredential`
 * `F:System.ServiceModel.BasicHttpsSecurityMode.TransportWithMessageCredential`
-* `F:System.ServiceModel.PollingDuplexHttpSecurityMode.TransportWithMessageCredential`
 * `F:System.ServiceModel.SecurityMode.TransportWithMessageCredential`
 * `F:System.ServiceModel.WSFederationHttpSecurityMode.TransportWithMessageCredential`
 


### PR DESCRIPTION
Now that docids can refer to groupings (types/namespaces/etc), this consolidates
the breaking change docids to simplify the listing