### PR TITLE
Add "API catalog last updated" field to portability reports

### DIFF
--- a/src/Microsoft.Fx.Portability.Reports.Html/RazorHtmlObject.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/RazorHtmlObject.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Fx.Portability.Reports
     {
         private readonly ITargetMapper _targetMapper;
 
+        public DateTimeOffset CatalogBuiltOn { get; private set; }
+
         public ReportingResult ReportingResult { get; private set; }
 
         public IEnumerable<MissingTypeInfo> MissingTypes { get; private set; }
@@ -38,6 +40,7 @@ namespace Microsoft.Fx.Portability.Reports
 
         public RazorHtmlObject(AnalyzeResponse response, ITargetMapper targetMapper)
         {
+            CatalogBuiltOn = response.CatalogLastUpdated;
             _targetMapper = targetMapper;
             RequestFlags = response.ReportingResult.RequestFlags;
             ReportingResult = response.ReportingResult;

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/ReportTemplate.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/ReportTemplate.cshtml
@@ -15,6 +15,7 @@
 @{
     ViewBag.Title = LocalizedStrings.HtmlReportTitle;
     var submissionId = Model.ReportingResult.SubmissionId;
+    var catalogLastUpdated = Model.CatalogBuiltOn.ToString("D", System.Globalization.CultureInfo.CurrentCulture);
     var includeBreakingChanges = Model.RequestFlags.HasFlag(Microsoft.Fx.Portability.ObjectModel.AnalyzeRequestFlags.ShowBreakingChanges);
     var includePortabilityReport = Model.RequestFlags.HasFlag(Microsoft.Fx.Portability.ObjectModel.AnalyzeRequestFlags.ShowNonPortableApis);
 }
@@ -35,6 +36,9 @@
                 <i>
                     @LocalizedStrings.SubmissionId&nbsp;
                     @submissionId
+
+                    @LocalizedStrings.CatalogLastUpdated&nbsp;
+                    @catalogLastUpdated
 
                     @* TODO: Add back in logic to create URIs when finished abstracting IReportWriter. *@
                     @*

--- a/src/Microsoft.Fx.Portability/ObjectModel/AnalyzeResponse.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/AnalyzeResponse.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         public string ApplicationName { get; set; }
 
+        public DateTimeOffset CatalogLastUpdated { get; set; }
+
         public IList<MemberInfo> MissingDependencies { get; set; }
 
         public IList<string> UnresolvedUserAssemblies { get; set; }

--- a/src/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
         private const string RecommendedChangeKey = "Recommended Changes";
         private const string SourceCompatibleEquivalent = "SourceCompatibleEquivalent";
 
+        private readonly DateTimeOffset _lastModified;
         private readonly string _builtBy;
         private readonly Dictionary<string, Dictionary<string, Version>> _apiMapping;
         private readonly Dictionary<string, Dictionary<string, string>> _apiMetadata;
@@ -29,6 +30,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         public CloudApiCatalogLookup(DotNetCatalog catalog)
         {
+            _lastModified = catalog.LastModified;
             _builtBy = catalog.BuiltBy;
 
             // we want to recreate the fast look-up data structures.
@@ -210,6 +212,8 @@ namespace Microsoft.Fx.Portability.ObjectModel
                 parent = api.Parent;
             }
         }
+
+        public DateTimeOffset LastModified { get { return _lastModified; } }
 
         public string BuiltBy { get { return _builtBy; } }
 

--- a/src/Microsoft.Fx.Portability/ObjectModel/DotNetCatalog.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/DotNetCatalog.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Fx.Portability.ObjectModel
 {
     public class DotNetCatalog
     {
+        public DateTimeOffset LastModified { get; set; }
         public string BuiltBy { get; set; }
         public IReadOnlyCollection<ApiInfoStorage> Apis { get; set; }
         public IReadOnlyCollection<string> FrameworkAssemblyIdenties { get; set; }

--- a/src/Microsoft.Fx.Portability/ObjectModel/IApiCatalogLookup.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/IApiCatalogLookup.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
 {
     public interface IApiCatalogLookup
     {
+        DateTimeOffset LastModified { get; }
         string BuiltBy { get; }
         ApiDefinition GetApiDefinition(string docId);
         IEnumerable<string> DocIds { get; }

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
@@ -9,9 +9,7 @@
 //------------------------------------------------------------------------------
 
 namespace Microsoft.Fx.Portability.Resources {
-    using System;
     using System.Reflection;
-
 
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
@@ -112,6 +110,15 @@ namespace Microsoft.Fx.Portability.Resources {
         public static string BreakingChangeDisclaimer {
             get {
                 return ResourceManager.GetString("BreakingChangeDisclaimer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to API Catalog last updated on: &apos;{0}&apos;.
+        /// </summary>
+        public static string CatalogLastUpdated {
+            get {
+                return ResourceManager.GetString("CatalogLastUpdated", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
@@ -337,4 +337,7 @@
   <data name="InvalidBreakingChangeParserState" xml:space="preserve">
     <value>Unhandled breaking change parse state: {0}</value>
   </data>
+  <data name="CatalogLastUpdated" xml:space="preserve">
+    <value>API Catalog last updated on: '{0}'</value>
+  </data>
 </root>

--- a/tests/Microsoft.Fx.Portability.Tests/TestData/TestCatalog.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/TestData/TestCatalog.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Fx.Portability.TestData
 {
     public class TestCatalog : IApiCatalogLookup
     {
+        public DateTimeOffset LastModified { get { return DateTimeOffset.UtcNow; } }
+
         public string BuiltBy
         {
             get { return "Test catalog"; }

--- a/tests/Microsoft.Fx.Portability.Tests/TestData/TestDotNetCatalog.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/TestData/TestDotNetCatalog.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Fx.Portability.ObjectModel;
+using System;
 using System.Runtime.Versioning;
 
 namespace Microsoft.Fx.Portability.Tests.TestData
@@ -27,6 +28,7 @@ namespace Microsoft.Fx.Portability.Tests.TestData
 
         public TestDotNetCatalog()
         {
+            LastModified = new DateTimeOffset(2015, 12, 2, 11, 23, 01, TimeSpan.FromHours(7));
             BuiltBy = "Test Machine";
             Apis = GetApis();
             FrameworkAssemblyIdenties = FrameworkIdentities;


### PR DESCRIPTION
Adding a build date to API catalog, so users know how up-to-date their results are.
Fixes #247.

@twsouthwick 