### PR TITLE
Add links to Channel 9 video

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ all of the components that we plan on open sourcing. Make sure to watch this
 repository in order to be notified as we make changes to and expand it.
 
 ## Usage
-To use this tool, please refer to the [documentation](docs/HowTo/Introduction.md).
+
+To use this tool, please refer to the [documentation](docs/HowTo/Introduction.md). For a quick introduction, check out [this video on Channel 9](https://channel9.msdn.com/Blogs/Seth-Juarez/A-Brief-Look-at-the-NET-Portability-Analyzer):
+
+[![A Brief Look at the .NET Portability Analyzer](https://sec.ch9.ms/ch9/031c/f3d7672b-dd71-4a18-a8b4-37573c08031c/DotNetPortabilityAnalyzer_960.jpg)](https://channel9.msdn.com/Blogs/Seth-Juarez/A-Brief-Look-at-the-NET-Portability-Analyzer)
 
 ## Projects
 

--- a/docs/HowTo/Introduction.md
+++ b/docs/HowTo/Introduction.md
@@ -7,6 +7,10 @@ tools is to help identify possible problem areas in an assembly and help direct 
 1. Are not portable to specific platforms
 2. Have breaking changes between 4.x versions
 
+For a quick introduction, check out [this video on Channel 9](https://channel9.msdn.com/Blogs/Seth-Juarez/A-Brief-Look-at-the-NET-Portability-Analyzer):
+
+[![A Brief Look at the .NET Portability Analyzer](https://sec.ch9.ms/ch9/031c/f3d7672b-dd71-4a18-a8b4-37573c08031c/DotNetPortabilityAnalyzer_960.jpg)](https://channel9.msdn.com/Blogs/Seth-Juarez/A-Brief-Look-at-the-NET-Portability-Analyzer)
+
 ## Platform Portability
 
 The first goal of these tools are to help identify APIs that are not portable among the various .NET Platforms. These 


### PR DESCRIPTION
We recently did an interview for Channel 9 that does a good job of providing an overview of API Port and explains generally how the tool should be used and how it works. It also contains a demo.

Unfortunately, GitHub doesn't support embedding videos, so I've cheated by referencing the image and adding a link that allows clicking it. The video must be watched outside of GitHub.

I've added the links in two places:

* The README.md file. This is important as it serves as the landing page on GitHub.

* The documentation. Given that several places will link to it directly, it also makes sense to have the video advertised there as well.

@twsouthwick @conniey @bleroy 