### PR TITLE
Updated recommendation for UriSchemeHttp and UriSchemeHttps

### DIFF
--- a/docs/RecommendedChanges/System/Use string literal http.md
+++ b/docs/RecommendedChanges/System/Use string literal http.md
@@ -1,5 +1,5 @@
 ### Recommended Action
-Use string literal of "http://" instead.
+Use string literal of "http" instead.
 
 ### Affected APIs
 * `F:System.Uri.UriSchemeHttp`

--- a/docs/RecommendedChanges/System/Use string literal https.md
+++ b/docs/RecommendedChanges/System/Use string literal https.md
@@ -1,5 +1,5 @@
 ### Recommended Action
-Use string literal of "https://" instead.
+Use string literal of "https" instead.
 
 ### Affected APIs
 * `F:System.Uri.UriSchemeHttps`


### PR DESCRIPTION
The `://` is from `Uri.SchemeDelimiter` and not included in `Uri.UriSchemeHttp(s)`