### PR TITLE
Use :// for Uri.SchemeDelimeter instead for dnxcore50

### DIFF
--- a/docs/RecommendedChanges/System/use string literal colon slash.md
+++ b/docs/RecommendedChanges/System/use string literal colon slash.md
@@ -1,0 +1,5 @@
+### Recommended Action
+Use string literal of "://" instead.
+
+### Affected APIs
+* `F:System.Uri.SchemeDelimiter`


### PR DESCRIPTION
This tries to add docs for the missing Uri.SchemeDelimeter in dnxcore50 and adds advice to use `://` string literal instead