### PR TITLE
Removing false recommendation for P:System.Environment.Is64BitOperatingSystem

### DIFF
--- a/docs/RecommendedChanges/System/Use Marshal.SizeOf IntPtr.md
+++ b/docs/RecommendedChanges/System/Use Marshal.SizeOf IntPtr.md
@@ -1,7 +1,0 @@
-### Recommended Action
-Use Marshal.SizeOf(new IntPtr()) if needed.
-
-### Affected APIs
-* `P:System.Environment.Is64BitOperatingSystem`
-* `P:System.Environment.Is64BitProcess`
-* `M:System.Environment.get_Is64BitOperatingSystem`


### PR DESCRIPTION
A recommendation for System.Environment.Is64BitOperatingSystem already exists "[Use RuntimeInformation.OSArchitecture](docs\RecommendedChanges\System\Use RuntimeInformation.OSArchitecture.md)". Removing this bad recommendation.