### PR TITLE
Exposing CatalogLastUpdated to AnalyzeResponse and fixing HTML report formatting

### DIFF
--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/ReportTemplate.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/ReportTemplate.cshtml
@@ -36,7 +36,7 @@
                 <i>
                     @LocalizedStrings.SubmissionId&nbsp;
                     @submissionId
-
+                    <br />
                     @LocalizedStrings.CatalogLastUpdated&nbsp;
                     @catalogLastUpdated
 

--- a/src/Microsoft.Fx.Portability/Analysis/AnalysisEngine.cs
+++ b/src/Microsoft.Fx.Portability/Analysis/AnalysisEngine.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Fx.Portability.Analysis
         private readonly IApiCatalogLookup _catalog;
         private readonly IApiRecommendations _recommendations;
 
+        public DateTimeOffset CatalogLastUpdated { get { return _catalog.LastModified; } }
+
         public AnalysisEngine(IApiCatalogLookup catalog, IApiRecommendations recommendations)
         {
             _catalog = catalog;

--- a/src/Microsoft.Fx.Portability/Analyzer/RequestAnalyzer.cs
+++ b/src/Microsoft.Fx.Portability/Analyzer/RequestAnalyzer.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Fx.Portability.Analyzer
 
             return new AnalyzeResponse
             {
+                CatalogLastUpdated = _analysisEngine.CatalogLastUpdated,
                 ApplicationName = request.ApplicationName,
                 MissingDependencies = notInAnyTarget,
                 UnresolvedUserAssemblies = missingUserAssemblies,

--- a/src/Microsoft.Fx.Portability/IAnalysisEngine.cs
+++ b/src/Microsoft.Fx.Portability/IAnalysisEngine.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Fx.Portability
 {
     public interface IAnalysisEngine
     {
+        DateTimeOffset CatalogLastUpdated { get; }
         IEnumerable<string> FindUnreferencedAssemblies(IEnumerable<string> unreferencedAssemblies, IEnumerable<AssemblyInfo> specifiedUserAssemblies);
         IList<MemberInfo> FindMembersNotInTargets(IEnumerable<FrameworkName> targets, IDictionary<MemberInfo, ICollection<AssemblyInfo>> dependencies);
         IEnumerable<AssemblyInfo> FindBreakingChangeSkippedAssemblies(IEnumerable<FrameworkName> targets, IEnumerable<AssemblyInfo> userAssemblies, IEnumerable<IgnoreAssemblyInfo> assembliesToIgnore);

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Fx.Portability.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to API Catalog last updated on: &apos;{0}&apos;.
+        ///   Looks up a localized string similar to API Catalog last updated on: {0}.
         /// </summary>
         public static string CatalogLastUpdated {
             get {

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
@@ -338,6 +338,6 @@
     <value>Unhandled breaking change parse state: {0}</value>
   </data>
   <data name="CatalogLastUpdated" xml:space="preserve">
-    <value>API Catalog last updated on: '{0}'</value>
+    <value>API Catalog last updated on</value>
   </data>
 </root>


### PR DESCRIPTION
* Setting CatalogLastUpdated in AnalyzeResponse
* Fixing formatting for HTML report:
![image](https://cloud.githubusercontent.com/assets/10136526/13232037/31fb55dc-d962-11e5-8910-1c6ac2ad774c.png)
