### PR TITLE
Restoring packages in package directory in solution

### DIFF
--- a/build/restore.ps1
+++ b/build/restore.ps1
@@ -1,7 +1,14 @@
 $root = $PSScriptRoot
+$packages = "$root\..\packages"
+
 $nuget = & "$root\Get-Nuget.ps1"
 
-& $nuget restore $root\..\PortabilityTools.sln
+New-Item $packages -ItemType Directory -ErrorAction Ignore
+
+# Restoring NuGet packages into this specific directory because the automated
+# build definition needs to be able to find the Visual Studio Test Adapter 
+# (xunit.runner.visualstudio) in a known location
+& $nuget restore $root\..\PortabilityTools.sln -PackagesDirectory $packages
 
 # Restore data for offline lib (cannot do this in the csproj due to race conditions)
 & $root\Get-CatalogFile.ps1 $root\..\.data\catalog.bin


### PR DESCRIPTION
* Allows us to get the xUnit VS test adapter from a known location.

Reference: [How to run xunit test with vNext Build](http://www.donovanbrown.com/post/2015/06/15/how-to-run-xunit-test-with-vnext-build)