### PR TITLE
Add ability to customize output directory and file

### DIFF
--- a/src/ApiPort.VisualStudio/Analyze/ApiPortVsAnalyzer.cs
+++ b/src/ApiPort.VisualStudio/Analyze/ApiPortVsAnalyzer.cs
@@ -44,7 +44,7 @@ namespace ApiPortVS.Analyze
             var paths = assemblyPaths.Select(t => new AssemblyFile(t));
             var dependencyInfo = _dependencyFinder.FindDependencies(paths, _reporter);
 
-            var analysisOptions = await GetApiPortOptions(assemblyPaths, new[] { "json" });
+            var analysisOptions = await GetApiPortOptions(assemblyPaths, new[] { "json" }, AnalysisOptions.DefaultReportFilename);
 
             var request = GenerateRequest(analysisOptions, dependencyInfo);
             var result = await GetResultsAsync(request, dependencyInfo);
@@ -112,11 +112,12 @@ namespace ApiPortVS.Analyze
 
         protected async Task<IEnumerable<string>> WriteAnalysisReportsAsync(
             IEnumerable<string> assemblyPaths,
-            IFileWriter reportWriter,
-            string reportDirectory,
-            string reportFileName)
+            IFileWriter reportWriter)
         {
+            var reportDirectory = _optionsViewModel.OutputDirectory;
             var outputFormats = _optionsViewModel.Formats.Where(f => f.IsSelected).Select(f => f.DisplayName);
+            var reportFileName = _optionsViewModel.Model.DefaultOutputName;
+
             var analysisOptions = await GetApiPortOptions(assemblyPaths, outputFormats, Path.Combine(reportDirectory, reportFileName));
             var issuesBefore = _reporter.Issues.Count;
 
@@ -160,7 +161,7 @@ namespace ApiPortVS.Analyze
             }
         }
 
-        private async Task<IApiPortOptions> GetApiPortOptions(IEnumerable<string> assemblyPaths, IEnumerable<string> formats, string reportFileName = AnalysisOptions.DefaultReportFilename)
+        private async Task<IApiPortOptions> GetApiPortOptions(IEnumerable<string> assemblyPaths, IEnumerable<string> formats, string reportFileName)
         {
             await _optionsViewModel.UpdateAsync();
 

--- a/src/ApiPort.VisualStudio/Analyze/FileListAnalyzer.cs
+++ b/src/ApiPort.VisualStudio/Analyze/FileListAnalyzer.cs
@@ -8,7 +8,6 @@ using Microsoft.Fx.Portability.Analyzer;
 using Microsoft.Fx.Portability.Reporting;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace ApiPortVS.Analyze
@@ -27,11 +26,9 @@ namespace ApiPortVS.Analyze
             _reportViewer = reportViewer;
         }
 
-        public async Task AnalyzeProjectAsync(IEnumerable<string> inputAssemblyPaths, string reportFileName)
+        public async Task AnalyzeProjectAsync(IEnumerable<string> inputAssemblyPaths)
         {
-            // write report to same directory as input
-            var dirForReport = _fileSystem.GetDirectoryNameFromPath(inputAssemblyPaths.First());
-            var reportPaths = await WriteAnalysisReportsAsync(inputAssemblyPaths, _reportWriter, dirForReport, reportFileName);
+            var reportPaths = await WriteAnalysisReportsAsync(inputAssemblyPaths, _reportWriter);
 
             foreach (var reportPath in reportPaths)
             {

--- a/src/ApiPort.VisualStudio/Analyze/ProjectAnalyzer.cs
+++ b/src/ApiPort.VisualStudio/Analyze/ProjectAnalyzer.cs
@@ -36,7 +36,7 @@ namespace ApiPortVS.Analyze
             _errorList = errorList;
         }
 
-        public async Task AnalyzeProjectAsync(Project project, string reportFileName)
+        public async Task AnalyzeProjectAsync(Project project)
         {
             var buildSucceeded = await BuildProjectAsync(project);
             if (!buildSucceeded)
@@ -51,7 +51,7 @@ namespace ApiPortVS.Analyze
             var targetAssemblies = project.GetAssemblyPaths();
 
             // This call writes the portability reports
-            var reportPaths = await WriteAnalysisReportsAsync(targetAssemblies, _reportWriter, project.GetProjectFileDirectory(), reportFileName);
+            var reportPaths = await WriteAnalysisReportsAsync(targetAssemblies, _reportWriter);
 
             foreach (var reportPath in reportPaths)
             {

--- a/src/ApiPort.VisualStudio/AnalyzeMenu.cs
+++ b/src/ApiPort.VisualStudio/AnalyzeMenu.cs
@@ -44,7 +44,7 @@ namespace ApiPortVS
                 {
                     var projectAnalyzer = innerScope.Resolve<ProjectAnalyzer>();
 
-                    await projectAnalyzer.AnalyzeProjectAsync(selectedProject, AnalysisOptions.DefaultReportFilename);
+                    await projectAnalyzer.AnalyzeProjectAsync(selectedProject);
                 }
             }
             catch (PortabilityAnalyzerException ex)
@@ -93,7 +93,7 @@ namespace ApiPortVS
                 {
                     var fileListAnalyzer = innerScope.Resolve<FileListAnalyzer>();
 
-                    await fileListAnalyzer.AnalyzeProjectAsync(inputAssemblyPaths, AnalysisOptions.DefaultReportFilename);
+                    await fileListAnalyzer.AnalyzeProjectAsync(inputAssemblyPaths);
                 }
             }
             catch (PortabilityAnalyzerException ex)

--- a/src/ApiPort.VisualStudio/Models/OptionsModel.cs
+++ b/src/ApiPort.VisualStudio/Models/OptionsModel.cs
@@ -23,6 +23,8 @@ namespace ApiPortVS.Models
 
         private IList<SelectedResultFormat> _formats;
         private IList<TargetPlatform> _platforms;
+        private string _outputDirectory;
+        private string _defaultOutputName;
 
         static OptionsModel()
         {
@@ -36,6 +38,9 @@ namespace ApiPortVS.Models
         {
             _platforms = Array.Empty<TargetPlatform>();
             _formats = Array.Empty<SelectedResultFormat>();
+            _defaultOutputName = "ApiPortAnalysis";
+
+            OutputDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Portability Analysis");
         }
 
         public IList<SelectedResultFormat> Formats
@@ -48,6 +53,29 @@ namespace ApiPortVS.Models
         {
             get { return _platforms; }
             set { UpdateProperty(ref _platforms, value.ToList()); }
+        }
+
+        public string OutputDirectory
+        {
+            get { return _outputDirectory; }
+            set
+            {
+                UpdateProperty(ref _outputDirectory, value);
+
+                if (!Directory.Exists(_outputDirectory))
+                {
+                    Directory.CreateDirectory(_outputDirectory);
+                }
+            }
+        }
+
+        public string DefaultOutputName
+        {
+            get { return _defaultOutputName; }
+            set
+            {
+                UpdateProperty(ref _defaultOutputName, value);
+            }
         }
 
         public static OptionsModel Load()

--- a/src/ApiPort.VisualStudio/Resources/LocalizedStrings.Designer.cs
+++ b/src/ApiPort.VisualStudio/Resources/LocalizedStrings.Designer.cs
@@ -143,6 +143,24 @@ namespace ApiPortVS.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Default output name.
+        /// </summary>
+        public static string DefaultFileName {
+            get {
+                return ResourceManager.GetString("DefaultFileName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Default output directory.
+        /// </summary>
+        public static string DefaultOutputDirectory {
+            get {
+                return ResourceManager.GetString("DefaultOutputDirectory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Details.
         /// </summary>
         public static string DetailsPageTitle {
@@ -175,6 +193,15 @@ namespace ApiPortVS.Resources {
         public static string FindingSourceLineInformationFor {
             get {
                 return ResourceManager.GetString("FindingSourceLineInformationFor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to General.
+        /// </summary>
+        public static string GeneralSettings {
+            get {
+                return ResourceManager.GetString("GeneralSettings", resourceCulture);
             }
         }
         

--- a/src/ApiPort.VisualStudio/Resources/LocalizedStrings.resx
+++ b/src/ApiPort.VisualStudio/Resources/LocalizedStrings.resx
@@ -273,4 +273,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.</value>
   <data name="RefreshingOutputFormats" xml:space="preserve">
     <value>Refreshing output formats...</value>
   </data>
+  <data name="DefaultFileName" xml:space="preserve">
+    <value>Default output name</value>
+  </data>
+  <data name="DefaultOutputDirectory" xml:space="preserve">
+    <value>Default output directory</value>
+  </data>
+  <data name="GeneralSettings" xml:space="preserve">
+    <value>General</value>
+  </data>
 </root>

--- a/src/ApiPort.VisualStudio/ViewModels/OptionsViewModel.cs
+++ b/src/ApiPort.VisualStudio/ViewModels/OptionsViewModel.cs
@@ -69,6 +69,26 @@ namespace ApiPortVS.ViewModels
             set { UpdateProperty(ref _updating, value); }
         }
 
+        public string OutputDirectory
+        {
+            get { return _optionsModel.OutputDirectory; }
+            set
+            {
+                _optionsModel.OutputDirectory = value;
+                OnPropertyUpdated();
+            }
+        }
+
+        public string DefaultOutputName
+        {
+            get { return _optionsModel.DefaultOutputName; }
+            set
+            {
+                _optionsModel.DefaultOutputName = value;
+                OnPropertyUpdated();
+            }
+        }
+
         public bool HasError
         {
             get { return _hasError; }

--- a/src/ApiPort.VisualStudio/Views/OptionsPageControl.xaml
+++ b/src/ApiPort.VisualStudio/Views/OptionsPageControl.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:const="clr-namespace:ApiPortVS.Resources"
              xmlns:utils="clr-namespace:ApiPortVS.Utils"
-             mc:Ignorable="d" 
+             mc:Ignorable="d"
              d:DesignHeight="283.5" d:DesignWidth="640" >
 
     <UserControl.Resources>
@@ -16,9 +16,9 @@
     <DockPanel LastChildFill="True" HorizontalAlignment="Stretch" KeyboardNavigation.ControlTabNavigation="Local">
 
         <TextBlock DockPanel.Dock="Top" FontSize="11" Foreground="Red"
-                   Text="{x:Static const:LocalizedStrings.UnableToContactService}" 
+                   Text="{x:Static const:LocalizedStrings.UnableToContactService}"
                    Visibility="{Binding HasError, Converter={StaticResource BoolToVisibility}}"/>
-        
+
         <Grid Margin="0,10,10,5" DockPanel.Dock="Bottom" MinHeight="10" HorizontalAlignment="Stretch" KeyboardNavigation.IsTabStop="False">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
@@ -46,9 +46,32 @@
             </TextBlock>
         </Grid>
 
+        <GroupBox Header="{x:Static const:LocalizedStrings.GeneralSettings}" BorderBrush="LightGray" IsTabStop="False" DockPanel.Dock="Top">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="10" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="10" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <TextBlock Grid.Column="0" Grid.Row="0" Text="{x:Static const:LocalizedStrings.DefaultOutputDirectory}" />
+                <TextBlock Grid.Column="2" Grid.Row="0" AutomationProperties.HelpText="{Binding OutputDirectory}" Text="{Binding OutputDirectory}" />
+                <Button Grid.Column="4" Grid.Row="0" Content="..." Click="UpdateDirectoryClick" />
+
+                <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static const:LocalizedStrings.DefaultFileName}" />
+                <TextBox Grid.Column="2" Grid.ColumnSpan="2" Grid.Row="2" Text="{Binding DefaultOutputName, Mode=TwoWay}" />
+            </Grid>
+        </GroupBox>
+
         <GroupBox Header="{x:Static const:LocalizedStrings.OutputFormats}" BorderBrush="LightGray" IsTabStop="False" DockPanel.Dock="Top">
             <DockPanel>
-                <TextBlock Visibility="{Binding UpdatingPlatforms, Converter={StaticResource BoolToVisibility}}" 
+                <TextBlock Visibility="{Binding UpdatingPlatforms, Converter={StaticResource BoolToVisibility}}"
                        Text="{x:Static const:LocalizedStrings.RefreshingOutputFormats}"
                        KeyboardNavigation.IsTabStop="false" KeyboardNavigation.TabIndex="0" Margin="0,5,0,5"/>
 
@@ -83,7 +106,7 @@
 
         <GroupBox Header="{x:Static const:LocalizedStrings.TargetPlatforms}" BorderBrush="LightGray" IsTabStop="False" DockPanel.Dock="Top">
             <DockPanel>
-                <TextBlock Visibility="{Binding UpdatingPlatforms, Converter={StaticResource BoolToVisibility}}" 
+                <TextBlock Visibility="{Binding UpdatingPlatforms, Converter={StaticResource BoolToVisibility}}"
                        Text="{x:Static const:LocalizedStrings.RefreshingPlatforms}"
                        KeyboardNavigation.IsTabStop="false" KeyboardNavigation.TabIndex="0" Margin="0,5,0,5"/>
 

--- a/src/ApiPort.VisualStudio/Views/OptionsPageControl.xaml.cs
+++ b/src/ApiPort.VisualStudio/Views/OptionsPageControl.xaml.cs
@@ -43,5 +43,20 @@ namespace ApiPortVS.Views
         {
             await ViewModel.UpdateAsync();
         }
+
+        private void UpdateDirectoryClick(object sender, RoutedEventArgs e)
+        {
+            using (var dialog = new System.Windows.Forms.FolderBrowserDialog())
+            {
+                dialog.SelectedPath = ViewModel.OutputDirectory;
+
+                var result = dialog.ShowDialog();
+
+                if (result == System.Windows.Forms.DialogResult.OK)
+                {
+                    ViewModel.OutputDirectory = dialog.SelectedPath;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Currently, the default is the directory of the assembly to analyze and the output file is "ApiPortAnalysis". This adds the ability to change both of those, while switching the default output directory to `%USERPROFILE%\Documents\Portability Analysis`.