### PR TITLE
Refactor VS analyzer to only analyze assemblies once

### DIFF
--- a/src/ApiPort.VisualStudio/AnalysisOptions.cs
+++ b/src/ApiPort.VisualStudio/AnalysisOptions.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Fx.Portability;
 using Microsoft.Fx.Portability.ObjectModel;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -11,16 +10,6 @@ namespace ApiPortVS
 {
     public class AnalysisOptions : IApiPortOptions
     {
-        internal const string DefaultReportFilename = "PortabilityAnalysis.html";
-
-        public string Description { get; private set; }
-        public IEnumerable<IAssemblyFile> InputAssemblies { get; private set; }
-        public AnalyzeRequestFlags RequestFlags { get; private set; }
-        public IEnumerable<string> Targets { get; private set; }
-        public IEnumerable<string> OutputFormats { get; private set; }
-        public string OutputFileName { get; private set; }
-        public IEnumerable<string> IgnoredAssemblyFiles { get { return Enumerable.Empty<string>(); } }
-
         public AnalysisOptions(string description, IEnumerable<string> inputAssemblies, IEnumerable<string> targets, IEnumerable<string> formats, bool discardMetadata, string outputFileName)
         {
             Description = description;
@@ -37,16 +26,24 @@ namespace ApiPortVS
             }
         }
 
-        public IEnumerable<string> BreakingChangeSuppressions { get; private set; }
+        public string Description { get; }
 
-        public IEnumerable<string> InvalidInputFiles
-        {
-            get { return Enumerable.Empty<string>(); }
-        }
+        public IEnumerable<IAssemblyFile> InputAssemblies { get; }
 
-        public string ServiceEndpoint
-        {
-            get { throw new NotImplementedException(); }
-        }
+        public AnalyzeRequestFlags RequestFlags { get; }
+
+        public IEnumerable<string> Targets { get; }
+
+        public IEnumerable<string> OutputFormats { get; }
+
+        public string OutputFileName { get; }
+
+        public IEnumerable<string> IgnoredAssemblyFiles { get; } = Enumerable.Empty<string>();
+
+        public IEnumerable<string> BreakingChangeSuppressions { get; } = Enumerable.Empty<string>();
+
+        public IEnumerable<string> InvalidInputFiles { get; } = Enumerable.Empty<string>();
+
+        public string ServiceEndpoint { get; } = string.Empty;
     }
 }

--- a/src/ApiPort.VisualStudio/Analyze/FileListAnalyzer.cs
+++ b/src/ApiPort.VisualStudio/Analyze/FileListAnalyzer.cs
@@ -4,7 +4,6 @@
 using ApiPortVS.Contracts;
 using ApiPortVS.ViewModels;
 using Microsoft.Fx.Portability;
-using Microsoft.Fx.Portability.Analyzer;
 using Microsoft.Fx.Portability.Reporting;
 using System.Collections.Generic;
 using System.IO;
@@ -18,8 +17,8 @@ namespace ApiPortVS.Analyze
         private readonly IReportViewer _reportViewer;
         private readonly IFileWriter _reportWriter;
 
-        public FileListAnalyzer(ApiPortClient client, OptionsViewModel optionsViewModel, IFileSystem fileSystem, IFileWriter reportWriter, IReportViewer reportViewer, TextWriter outputWindow, ITargetMapper targetMapper, IProgressReporter reporter, IDependencyFinder dependencyFinder, IApiPortService service, IReportGenerator reportGenerator)
-            : base(client, optionsViewModel, outputWindow, targetMapper, reporter, dependencyFinder, service, reportGenerator)
+        public FileListAnalyzer(ApiPortClient client, OptionsViewModel optionsViewModel, IFileSystem fileSystem, IFileWriter reportWriter, IReportViewer reportViewer, TextWriter outputWindow, IProgressReporter reporter)
+            : base(client, optionsViewModel, outputWindow, reporter)
         {
             _fileSystem = fileSystem;
             _reportWriter = reportWriter;
@@ -28,15 +27,12 @@ namespace ApiPortVS.Analyze
 
         public async Task AnalyzeProjectAsync(IEnumerable<string> inputAssemblyPaths)
         {
-            var reportPaths = await WriteAnalysisReportsAsync(inputAssemblyPaths, _reportWriter);
+            var reports = await WriteAnalysisReportsAsync(inputAssemblyPaths, _reportWriter, false);
 
-            foreach (var reportPath in reportPaths)
+            foreach (var reportPath in reports.Paths)
             {
                 _reportViewer.View(reportPath);
             }
-
-            // This second call sets the default targets and highlights any source lines.
-            await AnalyzeAssembliesAsync(inputAssemblyPaths);
         }
     }
 }

--- a/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.NET45.csproj
+++ b/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.NET45.csproj
@@ -72,6 +72,7 @@
     <Compile Include="ObjectModel\AncestorApiRecommendations.cs" />
     <Compile Include="ObjectModel\CompatibilityRange.cs" />
     <Compile Include="ObjectModel\DiagnosticAnalyzerInfo.cs" />
+    <Compile Include="Reporting\ObjectModel\ReportingResultPaths.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="BreakingChange.cs" />
     <Compile Include="BreakingChangeDependency.cs" />

--- a/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
+++ b/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Reporting\ObjectModel\MissingTypeInfo.cs" />
     <Compile Include="Reporting\ObjectModel\PlatformUsageInfo.cs" />
     <Compile Include="Reporting\ObjectModel\ReportingResult.cs" />
+    <Compile Include="Reporting\ObjectModel\ReportingResultPaths.cs" />
     <Compile Include="Reporting\ReportFileWriter.cs" />
     <Compile Include="Reporting\ReportGenerator.cs" />
     <Compile Include="Reporting\WindowsFileSystem.cs" />

--- a/src/Microsoft.Fx.Portability/Reporting/ObjectModel/ReportingResultPaths.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/ObjectModel/ReportingResultPaths.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Fx.Portability.Reporting.ObjectModel
+{
+    public struct ReportingResultPaths
+    {
+        public IEnumerable<string> Paths { get; set; }
+
+        public ReportingResult Result { get; set; }
+    }
+}

--- a/tests/ApiPortVS.Tests/ApiPortVSPackageTests.cs
+++ b/tests/ApiPortVS.Tests/ApiPortVSPackageTests.cs
@@ -16,7 +16,7 @@ namespace ApiPortVS.Tests
         private class TestableApiPortVSPackage : ProjectAnalyzer
         {
             public TestableApiPortVSPackage()
-                : base(null, null, null, null, null, null, CreateFileSystem(), null, null, null, null, null, null, null)
+                : base(null, null, null, null, null, null, CreateFileSystem(), null, null, null, null)
             { }
 
             private static IFileSystem CreateFileSystem()


### PR DESCRIPTION
Previously assemblies were being analyzed multiple times; once to generate reports, and again to generate the response for the source line mapping. This change consolidates the analysis so it is only performed once, as well as removing redundant code and calling into ApiPortClient when possible.