### PR TITLE
Refactor extension analyzer

### DIFF
--- a/src/ApiPort.VisualStudio/Analyze/ApiPortVsAnalyzer.cs
+++ b/src/ApiPort.VisualStudio/Analyze/ApiPortVsAnalyzer.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace ApiPortVS.Analyze
 {
-    public class ApiPortVsAnalyzer
+    public class ApiPortVsAnalyzer : IVsApiPortAnalyzer
     {
         private readonly ApiPortClient _client;
         private readonly OptionsViewModel _optionsViewModel;
@@ -36,7 +36,7 @@ namespace ApiPortVS.Analyze
             _reporter = reporter;
         }
 
-        protected async Task<ReportingResult> WriteAnalysisReportsAsync(
+        public async Task<ReportingResult> WriteAnalysisReportsAsync(
             IEnumerable<string> assemblyPaths,
             IFileWriter reportWriter,
             bool includeJson)

--- a/src/ApiPort.VisualStudio/Analyze/FileListAnalyzer.cs
+++ b/src/ApiPort.VisualStudio/Analyze/FileListAnalyzer.cs
@@ -1,35 +1,26 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ApiPortVS.Contracts;
-using ApiPortVS.ViewModels;
-using Microsoft.Fx.Portability;
 using Microsoft.Fx.Portability.Reporting;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 
 namespace ApiPortVS.Analyze
 {
-    public class FileListAnalyzer : ApiPortVsAnalyzer
+    public class FileListAnalyzer
     {
+        private readonly IVsApiPortAnalyzer _analyzer;
         private readonly IFileWriter _reportWriter;
 
-        public FileListAnalyzer(
-            ApiPortClient client,
-            OptionsViewModel optionsViewModel,
-            OutputWindowWriter outputWindow,
-            IReportViewer viewer,
-            IProgressReporter reporter,
-            IFileWriter reportWriter)
-            : base(client, optionsViewModel, outputWindow, viewer, reporter)
+        public FileListAnalyzer(IVsApiPortAnalyzer analyzer, IFileWriter reportWriter)
         {
+            _analyzer = analyzer;
             _reportWriter = reportWriter;
         }
 
         public async Task AnalyzeProjectAsync(IEnumerable<string> inputAssemblyPaths)
         {
-            await WriteAnalysisReportsAsync(inputAssemblyPaths, _reportWriter, false);
+            await _analyzer.WriteAnalysisReportsAsync(inputAssemblyPaths, _reportWriter, false);
         }
     }
 }

--- a/src/ApiPort.VisualStudio/Analyze/IVsApiPortAnalyzer.cs
+++ b/src/ApiPort.VisualStudio/Analyze/IVsApiPortAnalyzer.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Fx.Portability.Reporting;
+using Microsoft.Fx.Portability.Reporting.ObjectModel;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ApiPortVS.Analyze
+{
+    public interface IVsApiPortAnalyzer
+    {
+        Task<ReportingResult> WriteAnalysisReportsAsync(
+            IEnumerable<string> inputAssemblyPaths,
+            IFileWriter _reportWriter,
+            bool includeJson);
+    }
+}

--- a/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
+++ b/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
@@ -187,6 +187,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AnalysisOptions.cs" />
+    <Compile Include="Analyze\IVsApiPortAnalyzer.cs" />
     <Compile Include="Reporting\IResultToolbar.cs" />
     <Compile Include="Reporting\ToolbarListReportViewer.cs" />
     <Compile Include="ViewModels\OutputViewModel.cs" />

--- a/src/ApiPort.VisualStudio/DteProjectExtensions.cs
+++ b/src/ApiPort.VisualStudio/DteProjectExtensions.cs
@@ -4,6 +4,7 @@
 using ApiPortVS.Resources;
 using EnvDTE;
 using Microsoft.Fx.Portability;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Collections.Generic;
@@ -94,9 +95,9 @@ namespace ApiPortVS
             return false;
         }
 
-        public static IVsHierarchy GetHierarchy(this Project project, IServiceProvider serviceProvider)
+        public static IVsHierarchy GetHierarchy(this Project project)
         {
-            var solution = serviceProvider.GetService(typeof(SVsSolution)) as IVsSolution;
+            var solution = Package.GetGlobalService(typeof(SVsSolution)) as IVsSolution;
             if (solution == null)
             {
                 return null;

--- a/src/ApiPort.VisualStudio/ServiceProvider.cs
+++ b/src/ApiPort.VisualStudio/ServiceProvider.cs
@@ -61,6 +61,10 @@ namespace ApiPortVS
             builder.RegisterType<ApiPortVsAnalyzer>()
                 .As<IVsApiPortAnalyzer>()
                 .InstancePerLifetimeScope();
+            builder.Register(_ => Package.GetGlobalService(typeof(SVsSolutionBuildManager)))
+                .As<IVsSolutionBuildManager>();
+            builder.RegisterType<ProjectBuilder>()
+                .AsSelf();
 
             // Service registration
             builder.RegisterInstance(new ProductInformation("ApiPort_VS"))

--- a/src/ApiPort.VisualStudio/ServiceProvider.cs
+++ b/src/ApiPort.VisualStudio/ServiceProvider.cs
@@ -58,6 +58,9 @@ namespace ApiPortVS
                 .AsSelf()
                 .SingleInstance()
                 .AutoActivate();
+            builder.RegisterType<ApiPortVsAnalyzer>()
+                .As<IVsApiPortAnalyzer>()
+                .InstancePerLifetimeScope();
 
             // Service registration
             builder.RegisterInstance(new ProductInformation("ApiPort_VS"))

--- a/tests/ApiPortVS.Tests/ApiPortVSPackageTests.cs
+++ b/tests/ApiPortVS.Tests/ApiPortVSPackageTests.cs
@@ -5,7 +5,6 @@ using ApiPortVS.Analyze;
 using Microsoft.Fx.Portability.Reporting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
-using NSubstitute.Core;
 using System.IO;
 
 namespace ApiPortVS.Tests
@@ -13,40 +12,12 @@ namespace ApiPortVS.Tests
     [TestClass]
     public class ApiPortVSPackageTests
     {
-        private class TestableApiPortVSPackage : ProjectAnalyzer
-        {
-            public TestableApiPortVSPackage()
-                : base(null, null, null, null, null, null, null, null, null, CreateFileSystem(), null)
-            { }
-
-            private static IFileSystem CreateFileSystem()
-            {
-                var fileSystem = Substitute.For<IFileSystem>();
-
-                fileSystem.GetFileExtension(Arg.Any<string>()).Returns(GetFileExtension);
-
-                return fileSystem;
-            }
-
-            private static string GetFileExtension(CallInfo info)
-            {
-                var path = info.Arg<string>();
-
-                return Path.GetExtension(path);
-            }
-
-            public new bool FileHasAnalyzableExtension(string fileName)
-            {
-                return base.FileHasAnalyzableExtension(fileName);
-            }
-        }
-
         [TestMethod]
         public void FileHasAnalyzableExtension_FileIsExe_ReturnsTrue()
         {
             var filename = "analyzable.exe";
 
-            var package = new TestableApiPortVSPackage();
+            var package = GetProjectAnalyzer();
 
             var result = package.FileHasAnalyzableExtension(filename);
 
@@ -58,7 +29,7 @@ namespace ApiPortVS.Tests
         {
             var filename = "analyzable.dll";
 
-            var package = new TestableApiPortVSPackage();
+            var package = GetProjectAnalyzer();
 
             var result = package.FileHasAnalyzableExtension(filename);
 
@@ -70,11 +41,31 @@ namespace ApiPortVS.Tests
         {
             var filename = "analyzable.vshost.exe";
 
-            var package = new TestableApiPortVSPackage();
+            var package = GetProjectAnalyzer();
 
             var result = package.FileHasAnalyzableExtension(filename);
 
             Assert.IsFalse(result);
+        }
+        private ProjectAnalyzer GetProjectAnalyzer()
+        {
+            var fileSystem = Substitute.For<IFileSystem>();
+
+            fileSystem.GetFileExtension(Arg.Any<string>()).Returns(arg =>
+            {
+                var path = arg.Arg<string>();
+
+                return Path.GetExtension(path);
+            });
+
+            return new ProjectAnalyzer(
+                null,
+                null,
+                null,
+                null,
+                null,
+                fileSystem,
+                null);
         }
     }
 }


### PR DESCRIPTION
ApiPortVsAnalyzer was being used as a base class, which made it very difficult to update anything within it as any dependencies needed to flow through the derived classes. This changes it from using inheritance to using DI to inject the dependency where needed.