### PR TITLE
Fix a few e2e scenarios

### DIFF
--- a/src/ApiPort.VisualStudio/Analyze/ApiPortVsAnalyzer.cs
+++ b/src/ApiPort.VisualStudio/Analyze/ApiPortVsAnalyzer.cs
@@ -43,6 +43,8 @@ namespace ApiPortVS.Analyze
         {
             _outputWindow.ShowWindow();
 
+            await _optionsViewModel.UpdateAsync();
+
             var reportDirectory = _optionsViewModel.OutputDirectory;
             var outputFormats = _optionsViewModel.Formats.Where(f => f.IsSelected).Select(f => f.DisplayName);
             var reportFileName = _optionsViewModel.DefaultOutputName;

--- a/src/ApiPort.VisualStudio/AnalyzeMenu.cs
+++ b/src/ApiPort.VisualStudio/AnalyzeMenu.cs
@@ -71,6 +71,10 @@ namespace ApiPortVS
 
                 Trace.WriteLine(ex);
             }
+            finally
+            {
+                _output.WriteLine();
+            }
         }
 
 
@@ -128,6 +132,10 @@ namespace ApiPortVS
                 _output.WriteLine(LocalizedStrings.UnknownError);
 
                 Trace.WriteLine(ex);
+            }
+            finally
+            {
+                _output.WriteLine();
             }
         }
 

--- a/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
+++ b/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
@@ -190,6 +190,7 @@
     <Compile Include="Analyze\IVsApiPortAnalyzer.cs" />
     <Compile Include="Reporting\IResultToolbar.cs" />
     <Compile Include="Reporting\ToolbarListReportViewer.cs" />
+    <Compile Include="Utils\PathToFileNameConverter.cs" />
     <Compile Include="ViewModels\OutputViewModel.cs" />
     <Compile Include="Views\AnalysisOutputToolWindow.cs" />
     <Compile Include="Views\AnalysisOutputToolWindowControl.xaml.cs">

--- a/src/ApiPort.VisualStudio/Models/OptionsModel.cs
+++ b/src/ApiPort.VisualStudio/Models/OptionsModel.cs
@@ -82,16 +82,19 @@ namespace ApiPortVS.Models
         {
             try
             {
-                var bytes = File.ReadAllBytes(OptionsFilePath);
+                if (File.Exists(OptionsFilePath))
+                {
+                    var bytes = File.ReadAllBytes(OptionsFilePath);
 
-                return bytes.Deserialize<OptionsModel>();
+                    return bytes.Deserialize<OptionsModel>();
+                }
             }
             catch (Exception e)
             {
                 Trace.WriteLine(e.ToString());
-
-                return new OptionsModel();
             }
+
+            return new OptionsModel();
         }
 
         public bool Save()

--- a/src/ApiPort.VisualStudio/Utils/PathToFileNameConverter.cs
+++ b/src/ApiPort.VisualStudio/Utils/PathToFileNameConverter.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Windows.Data;
+
+namespace ApiPortVS.Utils
+{
+    public class PathToFileNameConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var path = value as string;
+
+            if (path == null)
+            {
+                return string.Empty;
+            }
+
+            try
+            {
+                return Path.GetFileName(path);
+            }
+            catch (ArgumentException)
+            {
+                return string.Empty;
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/ApiPort.VisualStudio/ViewModels/OutputViewModel.cs
+++ b/src/ApiPort.VisualStudio/ViewModels/OutputViewModel.cs
@@ -18,14 +18,17 @@ namespace ApiPortVS.ViewModels
 
         public ICommand SaveAs { get; }
 
+        public ICommand OpenDirectory { get; }
+
         public OutputViewModel()
         {
             Paths = new ObservableCollection<string>();
             OpenFile = new DelegateCommand<string>(path => Process.Start(path));
+            OpenDirectory = new DelegateCommand<string>(path => Process.Start(Path.GetDirectoryName(path)));
             SaveAs = new DelegateCommand<string>(SaveFileAs);
         }
 
-        private void SaveFileAs(string path)
+        private static void SaveFileAs(string path)
         {
             try
             {

--- a/src/ApiPort.VisualStudio/Views/AnalysisOutputToolWindowControl.xaml
+++ b/src/ApiPort.VisualStudio/Views/AnalysisOutputToolWindowControl.xaml
@@ -8,11 +8,17 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:utils="clr-namespace:ApiPortVS.Utils"
              Background="{DynamicResource VsBrush.Window}"
              Foreground="{DynamicResource VsBrush.WindowText}"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="300"
              Name="PortabilityResultsToolbar">
+
+    <UserControl.Resources>
+        <utils:PathToFileNameConverter x:Key="PathToFileName" />
+    </UserControl.Resources>
+
     <Grid>
         <StackPanel>
             <TextBlock FontWeight="Bold" Text="Available reports:" />
@@ -24,12 +30,18 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
 
-                            <TextBlock Grid.Column="0" Text="{Binding}" Margin="5,0,5,0" />
+                            <TextBlock Grid.Column="0" Text="{Binding Path=., Converter={StaticResource PathToFileName}}" Margin="5,0,5,0" />
                             <TextBlock Grid.Column="1" Margin="5,0,5,0">
                                 <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=DataContext.OpenFile}" CommandParameter="{Binding}">
-                                    <TextBlock Text="Open" />
+                                    <TextBlock Text="Open Report" />
+                                </Hyperlink>
+                            </TextBlock>
+                            <TextBlock Grid.Column="3" Margin="5,0,5,0">
+                                <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=DataContext.OpenDirectory}" CommandParameter="{Binding}">
+                                    <TextBlock Text="Open directory" />
                                 </Hyperlink>
                             </TextBlock>
                             <TextBlock Grid.Column="2" Margin="5,0,5,0">


### PR DESCRIPTION
This fixes the following in the VSIX:

1. If no options could be found, no update was being performed before analysis
2. The output window did not get a new line between runs so the text ran together
3. The Portability Reports window now includes a link to open the directory, as well as only shows the name