### PR TITLE
Set task completion for build in single location

### DIFF
--- a/src/ApiPort.VisualStudio/Analyze/ProjectAnalyzer.cs
+++ b/src/ApiPort.VisualStudio/Analyze/ProjectAnalyzer.cs
@@ -28,8 +28,7 @@ namespace ApiPortVS.Analyze
             ISourceLineMapper sourceLineMapper,
             IFileWriter reportWriter,
             IFileSystem fileSystem,
-            ProjectBuilder builder,
-            ITargetMapper targetMapper)
+            ProjectBuilder builder)
         {
             _analyzer = analyzer;
             _sourceLineMapper = sourceLineMapper;
@@ -42,10 +41,10 @@ namespace ApiPortVS.Analyze
         public async Task AnalyzeProjectAsync(ICollection<Project> projects)
         {
             var buildSucceeded = await _builder.BuildAsync(projects);
+
             if (!buildSucceeded)
             {
-                var message = string.Format(LocalizedStrings.UnableToBuildProject);
-                throw new InvalidOperationException(message);
+                throw new PortabilityAnalyzerException(LocalizedStrings.UnableToBuildProject);
             }
 
             // TODO: Add option to include everything in output, not just build artifacts

--- a/src/ApiPort.VisualStudio/ProjectBuilder.cs
+++ b/src/ApiPort.VisualStudio/ProjectBuilder.cs
@@ -2,13 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using EnvDTE;
-using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+
+using static Microsoft.VisualStudio.VSConstants;
 
 namespace ApiPortVS
 {
@@ -24,16 +23,23 @@ namespace ApiPortVS
         public Task<bool> BuildAsync(ICollection<Project> projects)
         {
             var projectHierarchy = projects.Select(project => project.GetHierarchy()).ToArray();
-            var suppressUI = 0;
             var buildUpdateFlags = Enumerable.Repeat((uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD, projectHierarchy.Length).ToArray();
 
-            // launches an asynchronous build operation, returns S_OK immediately if the build begins
-            // => S_OK does not indicate completion or success of the build
-            var updateErrorCode = _buildManager.StartUpdateSpecificProjectConfigurations((uint)projects.Count, projectHierarchy, null, null, buildUpdateFlags, null, (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD, suppressUI);
+            // Launches an asynchronous build operation and returns S_OK immediately if the build begins.
+            // The result does not indicate completion or success of the build
+            var updateErrorCode = _buildManager.StartUpdateSpecificProjectConfigurations(
+                (uint)projects.Count,
+                projectHierarchy,
+                null,
+                null,
+                buildUpdateFlags,
+                null,
+                (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD,
+                0);
 
             var tcs = new TaskCompletionSource<bool>();
 
-            if (updateErrorCode == VSConstants.S_OK)
+            if (updateErrorCode == S_OK)
             {
                 var builder = new ProjectAsyncBuilder(_buildManager, tcs);
                 _buildManager.AdviseUpdateSolutionEvents(builder, out builder.UpdateSolutionEventsCookie);
@@ -46,11 +52,14 @@ namespace ApiPortVS
             return tcs.Task;
         }
 
-        private class ProjectAsyncBuilder : TaskCompletionSource<bool>, IVsUpdateSolutionEvents
+        private class ProjectAsyncBuilder : IVsUpdateSolutionEvents
         {
             private readonly TaskCompletionSource<bool> _completionSource;
             private readonly IVsSolutionBuildManager _buildManager;
 
+            /// <summary>
+            /// A cookie used to track this instance in IVsSolutionBuildManager solution events.
+            /// </summary>
             public uint UpdateSolutionEventsCookie;
 
             public ProjectAsyncBuilder(IVsSolutionBuildManager manager, TaskCompletionSource<bool> completionSource)
@@ -59,38 +68,61 @@ namespace ApiPortVS
                 _completionSource = completionSource;
             }
 
-            public int OnActiveProjectCfgChange(IVsHierarchy pIVsHierarchy)
-            {
-                return VSConstants.S_OK;
-            }
+            /// <summary>
+            /// Called when the active project configuration for a project in the solution has changed.
+            /// </summary>
+            /// <param name="pIVsHierarchy">Pointer to an IVsHierarchy object.</param>
+            /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code.</returns>
+            public int OnActiveProjectCfgChange(IVsHierarchy pIVsHierarchy) => S_OK;
 
-            public int UpdateSolution_Begin(ref int pfCancelUpdate)
-            {
-                return VSConstants.S_OK;
-            }
+            /// <summary>
+            /// Called before any build actions have begun. This is the last chance to cancel the build before any building begins.
+            /// </summary>
+            /// <param name="pfCancelUpdate">Pointer to a flag indicating cancel update.</param>
+            /// <returns></returns>
+            public int UpdateSolution_Begin(ref int pfCancelUpdate) => S_OK;
 
-            public int UpdateSolution_Cancel()
-            {
-                _buildManager.UnadviseUpdateSolutionEvents(UpdateSolutionEventsCookie);
-                _completionSource.SetResult(false);
+            /// <summary>
+            /// Called when a build is being cancelled.
+            /// </summary>
+            /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code.</returns>
+            public int UpdateSolution_Cancel() => S_OK;
 
-                return VSConstants.S_OK;
-            }
-
-            // called when entire solution is done building
+            /// <summary>
+            /// Called when entire solution is done building
+            /// </summary>
+            /// <param name="fSucceeded">true if no update actions failed</param>
+            /// <param name="fModified">true if any update actions succeeded</param>
+            /// <param name="fCancelCommand">true if update actions were canceled</param>
+            /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code.</returns>
             public int UpdateSolution_Done(int fSucceeded, int fModified, int fCancelCommand)
             {
+                const int True = 1;
+
                 _buildManager.UnadviseUpdateSolutionEvents(UpdateSolutionEventsCookie);
-                var buildSucceeded = fSucceeded == 1; // no update actions failed
-                _completionSource.SetResult(buildSucceeded);
 
-                return VSConstants.S_OK;
+                if (fCancelCommand == True)
+                {
+                    _completionSource.SetResult(false);
+                }
+                else if (fSucceeded == True)
+                {
+                    _completionSource.SetResult(true);
+                }
+                else
+                {
+                    _completionSource.SetResult(false);
+                }
+
+                return S_OK;
             }
 
-            public int UpdateSolution_StartUpdate(ref int pfCancelUpdate)
-            {
-                return VSConstants.S_OK;
-            }
+            /// <summary>
+            /// Called before the first project configuration is about to be built.
+            /// </summary>
+            /// <param name="pfCancelUpdate">Pointer to a flag indicating cancel update.</param>
+            /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code.</returns>
+            public int UpdateSolution_StartUpdate(ref int pfCancelUpdate) => S_OK;
         }
     }
 }

--- a/src/ApiPort.VisualStudio/Resources/LocalizedStrings.Designer.cs
+++ b/src/ApiPort.VisualStudio/Resources/LocalizedStrings.Designer.cs
@@ -458,7 +458,7 @@ namespace ApiPortVS.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to build..
+        ///   Looks up a localized string similar to Project was either canceled or could not be built. Please look at the erorr window for any build errors..
         /// </summary>
         public static string UnableToBuildProject {
             get {

--- a/src/ApiPort.VisualStudio/Resources/LocalizedStrings.resx
+++ b/src/ApiPort.VisualStudio/Resources/LocalizedStrings.resx
@@ -196,7 +196,7 @@
     <value>No analyzable assemblies found in {0}.</value>
   </data>
   <data name="UnableToBuildProject" xml:space="preserve">
-    <value>Unable to build.</value>
+    <value>Project was either canceled or could not be built. Please look at the erorr window for any build errors.</value>
   </data>
   <data name="UnableToLoad" xml:space="preserve">
     <value>Unable to load {0}.</value>

--- a/tests/ApiPortVS.Tests/ApiPortVSPackageTests.cs
+++ b/tests/ApiPortVS.Tests/ApiPortVSPackageTests.cs
@@ -64,7 +64,6 @@ namespace ApiPortVS.Tests
                 null,
                 null,
                 fileSystem,
-                null,
                 null);
         }
     }


### PR DESCRIPTION
IVsUpdateSolutionEvents.UpdateSolution_Done is called anytime a solution is done building. If the TaskCompletionSource is set in both UpdateSolution_Cancel as well as in UpdateSolution_Done, it will end up throwing (a TrySet call should be used in that case). However, the UpdateSolution_Done method receives a parameter indicating if there was a cancel, so we should just use that.