### PR TITLE
Parsing revision number for Vsix from $(Build.BuildNumber)

### DIFF
--- a/build/Get-BuildTools.ps1
+++ b/build/Get-BuildTools.ps1
@@ -42,6 +42,8 @@ if(Test-Path $destination)
 }
 else
 {
+    Write-Verbose "Trying to download $ToolToFetch from $uri to $destination"
+    
     Invoke-Webrequest $uri -OutFile $destination
 }
 

--- a/build/restore.ps1
+++ b/build/restore.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding(DefaultParameterSetName="All")]
 param(
     [Parameter(Position = 0, Mandatory = "true", ParameterSetName="PublishVsix")]
-    [int]$BuildNumber,
+    [string]$BuildNumber,
 
     [ValidateSet("build","revision")]
     [Parameter(Position = 1, Mandatory = "true", ParameterSetName="PublishVsix")]
@@ -10,6 +10,21 @@ param(
     [Parameter(Mandatory = "true", ParameterSetName="PublishVsix")]
     [switch]$PublishVsix
 )
+
+function Get-BuildNumber
+{
+    # The parsing regex is how our VSTS variables for build number is set
+    $BuildNumberRegex = "dotnet-apiport\.(?<revision>[0-9]+)"
+    
+    if ($BuildNumber -match $BuildNumberRegex) 
+    {
+        return $Matches["revision"]
+    }
+    else 
+    {
+        return $null
+    }
+}
 
 $ErrorActionPreference = "Stop"
 
@@ -35,9 +50,17 @@ else
 # Restore data for offline lib (cannot do this in the csproj due to race conditions)
 & $root\Get-CatalogFile.ps1 $root\..\.data\catalog.bin
 
-if ($IsPublishVsix) {
+if ($IsPublishVsix)
+{
+    $number = Get-BuildNumber
+
+    if ($number -eq $null) 
+    {
+        Write-Error "Could not get a revision from build number [$BuildNumber]"
+        return -1
+    }
 
     . $(& $buildToolScript "vsix")
 
-    Vsix-IncrementVsixVersion -buildNumber $BuildNumber -versionType $VersionType | Vsix-UpdateBuildVersion
+    Vsix-IncrementVsixVersion -buildNumber $number -versionType $VersionType | Vsix-UpdateBuildVersion
 }


### PR DESCRIPTION
Our build is currently failing from the use of $(Rev:.rrr) for a revision number.  This is not a variable we can use, so we could parse it from the $(Build.BuildNumber) variable