### PR TITLE
Fixing build string call to use current directory

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -12,7 +12,7 @@ def branch = GithubBranchName
             def newJobName = Utilities.getFullJobName(project, configuration, isPR)
             
             // Define build string
-            def buildString = "build.ps1 ${configuration} ${platform} -RunTests"
+            def buildString = ".\\build.ps1 ${configuration} ${platform} -RunTests"
 
             // Create a new job with the specified name.  The brace opens a new closure
             // and calls made within that closure apply to the newly created job.


### PR DESCRIPTION
Our [CI builds](https://ci2.dot.net/job/Microsoft_dotnet-apiport/job/master/job/Release_prtest/2/consoleFull#-159439502683554902-aff0-4799-9e92-0ada24ce2a06) are failing because it cannot find `build.ps1`.

Using .\\build.ps1 instead of build.ps1