### PR TITLE
Fix Console and VSIX links in docs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ For a quick introduction, check out [this video on Channel 9][Channel 9 Video]:
 * [Introduction](docs/HowTo)
 * [Platform Portability](docs/HowTo/PlatformPortability.md)
 * [Breaking Changes](docs/HowTo/BreakingChanges.md)
-* [.NET Portability Analyzer (Console application)](docs/Console)
+* [.NET Portability Analyzer (Console application)](docs/Console/README.md)
     * [.NET Core application](docs/Console/README.md#using-net-core-application)
-* [.NET Portability Analyzer (Visual Studio extension)](docs/VSExtension)
+* [.NET Portability Analyzer (Visual Studio extension)](docs/VSExtension/README.md)
 
 ## Projects
 

--- a/docs/HowTo/README.md
+++ b/docs/HowTo/README.md
@@ -26,6 +26,6 @@ for another. For details please see [here](BreakingChanges.md).
 
 ## .NET Portability Analyzer Tools
 
-* [Console Application (.NET Framework)](../Console)
+* [Console Application (.NET Framework)](../Console/README.md)
 * [.NET Core Application](../Console/README.md#using-net-core-application)
-* [Visual Studio 2015 Extension](../VSExtension)
+* [Visual Studio 2015 Extension](../VSExtension/README.md)


### PR DESCRIPTION
Fixing Console and VSIX links so they go to the README.