### PR TITLE
Adding Warnings As Errors for release builds

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -14,4 +14,10 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\PortabilityTools.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  <!-- Trying to mitigate the number of warnings that the solution contains by
+    adding this into our Release builds.  As a result, it should be caught in
+    our PRs because of the CI builds -->
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
 </Project>

--- a/tests/Microsoft.Fx.Portability.Cci.Tests/app.config
+++ b/tests/Microsoft.Fx.Portability.Cci.Tests/app.config
@@ -15,6 +15,10 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>

--- a/tests/Microsoft.Fx.Portability.Cci.Tests/project.json
+++ b/tests/Microsoft.Fx.Portability.Cci.Tests/project.json
@@ -1,9 +1,9 @@
 ﻿{
   "dependencies": {
     "Microsoft.CodeAnalysis.CSharp": "1.3.2",
-    "System.Reflection.Metadata": "1.2.0",
     "Newtonsoft.Json": "9.0.1",
     "NSubstitute": "1.10.0",
+    "System.Reflection.Metadata": "1.4.1-beta-24227-04",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },


### PR DESCRIPTION
Want to mitigate as many warnings as possible by performing this check during release builds. (It should be caught during our CI builds in a PR)

Fixes #323 .