### PR TITLE
PR 40117: Add .NET 4.6.2 breaking changes

### DIFF
--- a/docs/BreakingChanges/145 CurrentCulture not preserved across WPF dispatcher operations.md
+++ b/docs/BreakingChanges/145 CurrentCulture not preserved across WPF dispatcher operations.md
@@ -6,6 +6,9 @@ Minor
 ### Version Introduced
 4.6
 
+### Version Reverted
+4.6.2
+
 ### Source Analyzer Status
 Planned
 
@@ -21,6 +24,15 @@ This is due to a change in [ExecutionContext](https://msdn.microsoft.com/en-us/l
 
 ### Recommended Action
 Apps affected by this change may work around it by storing the desired CurrentCulture or CurrentUICulture in a field and checking in all Dispatcher operation bodies (including UI event callback handlers) that the correct CurrentCulture and CurrentUICulture are set. Alternatively, because the ExecutionContext change underlying this WPF change only affects apps targeting the .NET Framework 4.6 or newer, this break can be avoided by targeting the .NET Framework 4.5.2.
+
+Apps that target .NET Framework 4.6 or later can also work around this by setting the following compatibility switch: 
+
+    ```
+    AppContext.SetSwitch("Switch.System.Globalization.NoAsyncCurrentCulture", true);
+    ```
+
+This issue has been fixed by WPF in .NET Framework 4.6.2. It has also been fixed in .NET Frameworks 4.6, 4.6.1 through [KB 3139549](https://support.microsoft.com/en-us/kb/3139549). 
+Applications targeting .NET 4.6 or later will automatically get the right behavior in WPF applications - CurrentCulture/CurrentUICulture would be preserved across Dispatcher operations. 
 
 ### Affected APIs
 * Not detectable via API analysis

--- a/docs/BreakingChanges/146 CurrentCulture flows across Tasks.md
+++ b/docs/BreakingChanges/146 CurrentCulture flows across Tasks.md
@@ -6,6 +6,9 @@ Minor
 ### Version Introduced
 4.6
 
+### Version Reverted
+4.6.2
+
 ### Source Analyzer Status
 Planned
 
@@ -22,6 +25,9 @@ Apps affected by this change may work around it by explicitly setting the desire
 ```C#
 AppContext.SetSwitch("Switch.System.Globalization.NoAsyncCurrentCulture", true);
 ```
+
+This issue has been fixed by WPF in .NET Framework 4.6.2. It has also been fixed in .NET Frameworks 4.6, 4.6.1 through [KB 3139549](https://support.microsoft.com/en-us/kb/3139549). 
+Applications targeting .NET 4.6 or later will automatically get the right behavior in WPF applications - CurrentCulture/CurrentUICulture would be preserved across Dispatcher operations. 
 
 ### Affected APIs
 * `M:System.Globalization.CultureInfo.set_CurrentCulture(System.Globalization.CultureInfo)`

--- a/docs/BreakingChanges/149 Remove Ssl3 from the WCF TransportDefaults.md
+++ b/docs/BreakingChanges/149 Remove Ssl3 from the WCF TransportDefaults.md
@@ -1,0 +1,33 @@
+## 149: Remove Ssl3 from the WCF TransportDefaults
+
+### Scope
+Edge
+
+### Version Introduced
+4.6.2
+
+### Source Analyzer Status
+Planned
+
+### Change Description
+When using NetTcp with transport security and a credential type of certificate, the SSL 3 protocol is no longer a default protocol used for negotiating a secure connection. In most cases there should be no impact to existing apps as TLS 1.0 has always been included in the protocol list for NetTcp. All existing clients should be able to negotiate a connection using at least TLS1.0. 
+
+- [ ] Quirked
+- [ ] Build-time break
+
+### Recommended Action
+If Ssl3 is required, use one of the following configuration mechanisms to add Ssl3 to the list of negotiated protocols.
+
+* [SslStreamSecurityBindingElement.SslProtocols Property](https://msdn.microsoft.com/en-us/library/system.servicemodel.channels.sslstreamsecuritybindingelement.sslprotocols%28v=vs.110%29.aspx)  
+* [TcpTransportSecurity.SslProtocols Property](https://msdn.microsoft.com/en-us/library/system.servicemodel.tcptransportsecurity.sslprotocols%28v=vs.110%29.aspx)  
+* [\<transport\> section of \<netTcpBinding\>](https://msdn.microsoft.com/en-us/library/ms731331%28v=vs.110%29.aspx)  
+* [\<sslStreamSecurity\> section of \<customBinding\>](https://msdn.microsoft.com/en-us/library/ms731328%28v=vs.110%29.aspx)
+
+
+### Affected APIs
+* `P:System.ServiceModel.Channels.SslStreamSecurityBindingElement.SslProtocols`
+* `P:System.ServiceModel.TcpTransportSecurity.SslProtocols`
+
+
+### Category
+* Windows Communication Foundation (WCF)

--- a/docs/BreakingChanges/150 Incorrect implementation of MemberDescriptor.Equals.md
+++ b/docs/BreakingChanges/150 Incorrect implementation of MemberDescriptor.Equals.md
@@ -1,0 +1,51 @@
+## 150: Incorrect implementation of MemberDescriptor.Equals
+
+### Scope
+Edge
+
+### Version Introduced
+4.6.2
+
+### Source Analyzer Status
+Planned
+
+### Change Description
+Original implementation of "Equals" method was comparing two different string properties from 
+the objects under comparison: category name to description string. The fix is to compare 
+"category" of first object to "category" of the second one and "description" to "description".  
+MemberDescriptorEqualsReturnsFalseIfEquivalent configuration value can be set to true to opt out of 
+the new behavior if targeting 4.6.2 or to false to enable this fix when targeting framework 
+version is below 4.6.2.
+
+- [x] Quirked
+- [ ] Build-time break
+
+### Recommended Action
+If your application depends on MemberDescriptor.Equals sometimes returning false when descriptors 
+are equivalent, and you are targeting 4.6.2 version of the .NET Framework, you have several options:
+
+1. Make code changes to compare "category" and "description" fields manually in addition to 
+running Equals method.
+2. Opt out from this change by adding the following value to the app.config file:
+
+```xml
+<runtime>
+  <AppContextSwitchOverrides value="Switch.System.MemberDescriptorEqualsReturnsFalseIfEquivalent=true" />
+</runtime>
+```
+
+If your application targets 4.6.1 or lower version of the .NET Framework, and you want this change 
+enabled, you can set the compatibility switch to false by adding the following value to the 
+app.config file:
+
+```xml
+<runtime>
+  <AppContextSwitchOverrides value="Switch.System.MemberDescriptorEqualsReturnsFalseIfEquivalent=false" />
+</runtime>
+```
+
+### Affected APIs
+* `M:System.ComponentModel.MemberDescriptor.Equals(System.Object)`
+
+### Category
+Windows Forms

--- a/docs/BreakingChanges/151 Item-scrolling a flat list with items of different pixel height.md
+++ b/docs/BreakingChanges/151 Item-scrolling a flat list with items of different pixel height.md
@@ -1,0 +1,50 @@
+## 151: Item-scrolling a flat list with items of different pixel-height
+
+### Scope
+Minor
+
+### Version Introduced
+4.6.1
+
+### Version Reverted
+4.6.2
+
+### Source Analyzer Status
+Planned
+
+### Change Description
+When an ItemsControl displays a collection using virtualization (`IsVirtualizing="true"`) and item-scrolling (`ScrollUnit="Item"`),
+and when the control scrolls to display an item whose height in pixels differs from its neighbors, the VirtualizingStackPanel
+iterates over all items in the collection.   The UI is unresponsive during this iteration;  if the collection is
+large, this can be perceived as a hang.
+
+The iteration occurs in other circumstances, even in previous .Net releases.  For example, it occurs when
+pixel-scrolling (`ScrollUnit="Pixel"`) upon encountering an item with different pixel height, and when item-scrolling
+hierarchical data (such as a TreeView or an ItemsControl with grouping enabled) upon encountering an item with
+a different number of descendant items than its neighbors.
+
+For the case of item-scrolling and different pixel height, the iteration was introduced in .Net 4.6.1 to fix
+bugs in the layout of hierarchical data.  It is not needed if the data is flat (no hierarchy), and .Net 4.6.2
+does not do it in that case.
+
+- [ ] Quirked 
+- [ ] Build-time break
+
+### Recommended Action
+If the iteration occurs in .Net 4.6.1 but not in earlier releases - that is, if the ItemsControl is item-scrolling
+a flat list with items of different pixel height - there are two remedies:
+1. Install .Net 4.6.2.
+2. Install hotfix HR 1605 for .Net 4.6.1.
+
+### Affected APIs
+* `T:System.Windows.Controls.VirtualizingStackPanel`
+
+### Category
+Windows Presentation Foundation (WPF)
+
+<!--
+    ### Original Bug
+    202599
+-->
+
+

--- a/docs/BreakingChanges/152 CoerceIsSelectionBoxHighlighted.md
+++ b/docs/BreakingChanges/152 CoerceIsSelectionBoxHighlighted.md
@@ -1,0 +1,36 @@
+## 152: CoerceIsSelectionBoxHighlighted
+
+### Scope
+Minor
+
+### Version Introduced
+4.6
+
+### Version Reverted
+4.6.2
+
+### Source Analyzer Status
+Planned
+
+### Change Description
+Certain sequences of actions involving a ComboBox and its data source can result in a
+NullReferenceException in ComboBox.CoerceIsSelectionBoxHighlighted.
+
+- [ ] Quirked // Uses some mechanism to turn the feature on or off, usually using runtime targeting, AppContext or config files. Needs to be turned on automatically for some situations.
+- [ ] Build-time break // Causes a break if attempted to recompile
+
+### Recommended Action
+If possible, please upgrade to .NET 4.6.2.
+
+### Affected APIs
+* `M:System.Windows.Controls.ComboBox.CoerceIsSelectionBoxHighlighted`
+
+### Category
+Windows Presentation Foundation (WPF)
+
+<!--
+    ### Original Bug
+    125219
+-->
+
+

--- a/docs/BreakingChanges/152 CoerceIsSelectionBoxHighlighted.md
+++ b/docs/BreakingChanges/152 CoerceIsSelectionBoxHighlighted.md
@@ -13,17 +13,16 @@ Minor
 Planned
 
 ### Change Description
-Certain sequences of actions involving a ComboBox and its data source can result in a
-NullReferenceException in ComboBox.CoerceIsSelectionBoxHighlighted.
+Certain sequences of actions involving a ComboBox and its data source can result in a `NullReferenceException`.
 
-- [ ] Quirked // Uses some mechanism to turn the feature on or off, usually using runtime targeting, AppContext or config files. Needs to be turned on automatically for some situations.
-- [ ] Build-time break // Causes a break if attempted to recompile
+- [ ] Quirked
+- [ ] Build-time break
 
 ### Recommended Action
 If possible, please upgrade to .NET 4.6.2.
 
 ### Affected APIs
-* `M:System.Windows.Controls.ComboBox.CoerceIsSelectionBoxHighlighted`
+* `P:System.Windows.Controls.ComboBox.IsSelectionBoxHighlighted`
 
 ### Category
 Windows Presentation Foundation (WPF)

--- a/docs/BreakingChanges/153 Horizontal scrolling and virtualization.md
+++ b/docs/BreakingChanges/153 Horizontal scrolling and virtualization.md
@@ -1,0 +1,62 @@
+## 153: Horizontal scrolling and virtualization
+
+### Scope
+Minor
+
+### Version Introduced
+4.6.2
+
+### Source Analyzer Status
+Planned
+
+### Change Description
+This change applies to an ItemsControl that does its own virtualization in the
+direction orthogonal to the main scrolling direction (the chief example is
+DataGrid with EnableColumnVirtualization="True").  The outcome of certain 
+horizontal scolling operations has been changed to produce results that are more
+intuitive and more analogous to the results of comparable vertical operations.
+
+The operations include "Scroll Here" and "Right Edge", to use the names from the menu
+obtained by right-clicking a horizontal scrollbar.  Both of these compute a 
+candidate offset and call IScrollInfo.SetHorizontalOffset.  After scrolling to the new
+offset, the notion of "here" or "right edge" may have changed because newly
+de-virtualized content has changed the value of IScrollInfo.ExtentWidth.
+
+Prior to .Net 4.6.2, the scroll operation simply uses the candidate offset, even
+though it may not be "here" or at the "right edge" any more.  This results in effects
+like "bouncing" the scroll thumb, best illustrated by example.  Suppose a DataGrid has
+ExtentWidth=1000 and Width=200.  A scroll to "Right Edge" uses candidate offset 
+1000 - 200 = 800.  While scrolling to that offset, new columns are de-virtualized;
+let's suppose they are very wide, so that the ExtentWidth changes to 2000.  The scroll
+ends with HorizontalOffset=800, and the thumb "bounces" back to near the middle of
+the scrollbar - precisely at 800/2000 = 40%.
+
+The change is to recompute a new candidate offset when this situation occurs, and
+try again.  (This is how vertical scrolling works already.)
+
+The change produces a more predictable and intuitive experience for the end user,
+but it could also affect any app that depends on the exact value of HorizontalOffset
+after a horizontal scroll, whether invoked by the end user or by an explicit call
+to SetHorizontalOffset.
+
+- [ ] Quirked // Uses some mechanism to turn the feature on or off, usually using runtime targeting, AppContext or config files. Needs to be turned on automatically for some situations.
+- [ ] Build-time break // Causes a break if attempted to recompile
+
+### Recommended Action
+An app that uses a predicted value for HorizontalOffset should be changed to
+fetch the actual value (and the value of ExtentWidth) after any horizontal
+scroll that could change ExtentWidth due to de-virtualization.
+
+### Affected APIs
+* `T:System.Windows.Controls.Primitives.IScrollInfo`
+
+
+### Category
+Windows Presentation Foundation (WPF)
+
+<!--
+    ### Original Bug
+    123992
+-->
+
+

--- a/docs/BreakingChanges/154 Items.Clear does not remove duplicates from SelectedItems.md
+++ b/docs/BreakingChanges/154 Items.Clear does not remove duplicates from SelectedItems.md
@@ -20,14 +20,14 @@ only the first instance is removed.  Furthermore, subsequent use of SelectedItem
 (e.g. SelectedItems.Clear()) can encounter problems such as ArgumentException, because
 SelectedItems contains items that are no longer in the data source.
 
-- [ ] Quirked // Uses some mechanism to turn the feature on or off, usually using runtime targeting, AppContext or config files. Needs to be turned on automatically for some situations.
-- [ ] Build-time break // Causes a break if attempted to recompile
+- [ ] Quirked
+- [ ] Build-time break
 
 ### Recommended Action
 Upgrade if possible to .NET 4.6.2.
 
 ### Affected APIs
-* `P:System.Windows.Controls.Primitives.Selector.SelectedItems`
+* `P:System.Windows.Controls.Primitives.MultiSelector.SelectedItems`
 
 ### Category
 Windows Presentation Foundation (WPF)

--- a/docs/BreakingChanges/154 Items.Clear does not remove duplicates from SelectedItems.md
+++ b/docs/BreakingChanges/154 Items.Clear does not remove duplicates from SelectedItems.md
@@ -1,0 +1,40 @@
+## 154: Items.Clear does not remove duplicates from SelectedItems
+
+### Scope
+Minor
+
+### Version Introduced
+4.5
+
+### Version Reverted
+4.6.2
+
+### Source Analyzer Status
+NotPlanned
+
+### Change Description
+Suppose a Selector (with multiple selection enabled) has duplicates in its SelectedItems
+collection - the same item appears more than once.  Removing those items from the
+data source (e.g. by calling Items.Clear) fails to remove them from SelectedItems;
+only the first instance is removed.  Furthermore, subsequent use of SelectedItems
+(e.g. SelectedItems.Clear()) can encounter problems such as ArgumentException, because
+SelectedItems contains items that are no longer in the data source.
+
+- [ ] Quirked // Uses some mechanism to turn the feature on or off, usually using runtime targeting, AppContext or config files. Needs to be turned on automatically for some situations.
+- [ ] Build-time break // Causes a break if attempted to recompile
+
+### Recommended Action
+Upgrade if possible to .NET 4.6.2.
+
+### Affected APIs
+* `P:System.Windows.Controls.Primitives.Selector.SelectedItems`
+
+### Category
+Windows Presentation Foundation (WPF)
+
+<!--
+    ### Original Bug
+    154627
+-->
+
+

--- a/docs/BreakingChanges/155 WPF spell checking fail in unexpected ways.md
+++ b/docs/BreakingChanges/155 WPF spell checking fail in unexpected ways.md
@@ -1,0 +1,45 @@
+## 155: WPF Spell Checking fails in unexpected ways
+
+### Scope
+Edge
+
+### Version Introduced
+4.6.1
+
+### Version Reverted
+4.6.2
+
+### Source Analyzer Status
+Not planned
+
+### Change Description
+
+This includes a number of WPF Spell Checker issues:
+- WPF Spell Checker sometimes throws COMException 
+- WPF Spell Checker fails with System.UnauthorizedAccessException when applications are launched using 'run as different user' 
+- WPF Spell Checker incorrectly identifies spelling errors in compound words like 'Hausnummer' in German. 
+
+- [ ] Quirked
+- [ ] Build-time break
+
+### Recommended Action
+
+Issue #1 - This has been fixed in .NET Framework 4.6.2
+Issue #2 - WPF Spell Checker is no longer supported when applications are launched using 'run as different user'. Starting .NET Framework 4.6.2, applications launched in this manner will no longer crash unexpectedly - instead the Spell Checker will be silently disabled. 
+Issue #3 - This has been fixed in .NET Framework 4.6.2. 
+
+
+### Affected APIs
+* Not detectable via API analysis
+
+### Category
+Windows Presentation Foundation (WPF)
+
+<!--
+    ### Original Bug
+    172504
+    173922
+    180203
+-->
+
+

--- a/docs/BreakingChanges/156 Xml documents are now consider invalid if they contains transforms that are not allowed on digital signatures.md
+++ b/docs/BreakingChanges/156 Xml documents are now consider invalid if they contains transforms that are not allowed on digital signatures.md
@@ -1,4 +1,4 @@
-## 151: SignedXml and EncryptedXml Breaking Changes
+## 156: SignedXml and EncryptedXml Breaking Changes
 
 ### Scope
 Minor

--- a/docs/BreakingChanges/157 Unicode data now support standard v8.0 categories.md
+++ b/docs/BreakingChanges/157 Unicode data now support standard v8.0 categories.md
@@ -1,0 +1,35 @@
+## 157: .Net Framework now supports Unicode standard version 8.0 categories
+
+### Scope
+Minor
+
+### Version Introduced
+4.6.2
+
+### Source Analyzer Status
+Planned
+
+### Change Description
+In .NET Framework 4.6.2, Unicode data in the framework has been
+upgraded from Unicode standard version 6.3 to version 8.0.  When
+requesting Unicode character category in .NET Framework 4.6.2, some
+results might not match the results in previous .NET Framework
+versions.  This change mostly affects Cherokee syllables and New Tai
+Lue vowels signs and tone marks.
+
+- [ ] Quirked
+- [ ] Build-time break
+
+### Recommended Action
+Review code and remove/change logic that depends on hard-coded Unicode
+character categories.
+
+### Affected APIs
+* `M:System.Char.GetUnicodeCategory(System.Char)`
+* `M:System.Globalization.CharUnicodeInfo.GetUnicodeCategory(System.Char)`
+* `M:System.Globalization.CharUnicodeInfo.GetUnicodeCategory(System.String,System.Int32)`
+
+### Category
+Globalization
+
+[More information](https://github.com/Microsoft/dotnet/blob/master/releases/net462/dotnet462-changes.md)

--- a/docs/BreakingChanges/158 Path colon checks are stricter.md
+++ b/docs/BreakingChanges/158 Path colon checks are stricter.md
@@ -1,0 +1,36 @@
+## 158: Path colon checks are stricter
+
+### Scope
+Edge
+
+### Version Introduced
+4.6.2
+
+### Source Analyzer Status
+NotPlanned
+
+### Change Description
+In .NET Framework 4.6.2, a number of changes were made to support previously unsupported paths (both in length and format). Checks for proper
+drive separator (colon) syntax were made more correct, which had the side effect of blocking some URI paths in a few select Path APIs where they
+used to be tolerated.
+
+- [x] Quirked
+- [ ] Build-time break
+
+### Recommended Action
+
+If passing a URI to affected APIs, modify the string to be a legal path first.
+
+- Remove the scheme from URLs manually (e.g. remove `file://` from URLs)
+- Pass the URI to the `System.Uri` class and use `System.Uri.LocalPath`
+
+Alternatively, you can opt out of the new path normalization by setting the `Switch.System.IO.UseLegacyPathHandling` AppContext switch to true.
+
+### Affected APIs
+
+* `M:System.IO.Path.GetDirectoryName(System.String)`
+* `M:System.IO.Path.GetPathRoot(System.String)`
+
+### Category
+Core
+

--- a/docs/BreakingChanges/BreakingChangeCategories.json
+++ b/docs/BreakingChanges/BreakingChangeCategories.json
@@ -7,6 +7,7 @@
     "Data",
     "Debugger",
     "Entity Framework",
+    "Globalization",
     "JIT",
     "LINQ",
     "Managed Extensibility Framework (MEF)",


### PR DESCRIPTION
This merges many of the breaking changes from .NET 4.6.2 from the feature teams. This list is still missing a couple.