### PR TITLE
Consider proxy when connecting to service

### DIFF
--- a/src/ApiPort/ApiPort.Core.csproj
+++ b/src/ApiPort/ApiPort.Core.csproj
@@ -101,6 +101,10 @@
     <Compile Include="Modules\DataTransferModule.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="ConsoleProgressReporter.cs" />
+    <Compile Include="Proxy\ConsoleCredentialProvider.cs" />
+    <Compile Include="Proxy\ProxyConstants.cs" />
+    <Compile Include="Proxy\ProxyProvider.cs" />
+    <Compile Include="Proxy\WebProxy.cs" />
     <Compile Include="Resources\LocalizedStrings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -119,6 +123,7 @@
   <!-- NuGet references -->
   <ItemGroup>
     <None Include="ApiPort.Core.project.json" />
+    <None Include="config.json" />
   </ItemGroup>
   <!-- Project references -->
   <ItemGroup>

--- a/src/ApiPort/ApiPort.Core.project.json
+++ b/src/ApiPort/ApiPort.Core.project.json
@@ -15,13 +15,14 @@
     "Autofac.Configuration": "4.0.1",
     "MicroBuild.Core": "0.2.0",
     "Microsoft.Extensions.Configuration.CommandLine": "1.0.0",
-    "Microsoft.Extensions.Configuration.Json": "1.0.0",
     "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0",
+    "Microsoft.Extensions.Configuration.Json": "1.0.0",
     "Microsoft.Extensions.Options.ConfigurationExtensions": "1.0.0",
     "Microsoft.NETCore.App": "1.0.1",
     "Newtonsoft.Json": "9.0.1",
     "System.Diagnostics.FileVersionInfo": "4.0.0",
-    "System.Diagnostics.TraceSource": "4.0.0"
+    "System.Diagnostics.TraceSource": "4.0.0",
+    "System.Security.SecureString": "4.0.0"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/src/ApiPort/ApiPort.csproj
+++ b/src/ApiPort/ApiPort.csproj
@@ -13,7 +13,6 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <DefineConstants>FEATURE_RICH_CONSOLE</DefineConstants>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -38,6 +37,7 @@
     <IntermediateOutputPath>$(OutputIntermediate)\$(AssemblyName)</IntermediateOutputPath>
     <OutputPath>$(OutputDrop)\$(AssemblyName)\net46</OutputPath>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
+    <DefineConstants>$(DefineConstants);FEATURE_RICH_CONSOLE;FEATURE_SYSTEM_PROXY;FEATURE_NETWORK_CREDENTIAL</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Projects default to being signed, but Microsoft.Configuration.* assemblies are not signed -->
@@ -70,6 +70,10 @@
     <Compile Include="ICommandLineOptions.cs" />
     <Compile Include="Modules\DataTransferModule.cs" />
     <Compile Include="Program.cs" />
+    <Compile Include="Proxy\ConsoleCredentialProvider.cs" />
+    <Compile Include="Proxy\ProxyProvider.cs" />
+    <Compile Include="Proxy\ProxyConstants.cs" />
+    <Compile Include="Proxy\WebProxy.cs" />
     <Compile Include="Resources\LocalizedStrings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -88,6 +92,9 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="ApiPort.project.json" />
+    <None Include="config.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <BinPlaceContent Include=".\Assets\KnownSafeBreaks.json" />

--- a/src/ApiPort/ApiPort.csproj
+++ b/src/ApiPort/ApiPort.csproj
@@ -37,7 +37,7 @@
     <IntermediateOutputPath>$(OutputIntermediate)\$(AssemblyName)</IntermediateOutputPath>
     <OutputPath>$(OutputDrop)\$(AssemblyName)\net46</OutputPath>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
-    <DefineConstants>$(DefineConstants);FEATURE_RICH_CONSOLE;FEATURE_SYSTEM_PROXY;FEATURE_NETWORK_CREDENTIAL</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_SYSTEM_PROXY;FEATURE_NETWORK_CREDENTIAL</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Projects default to being signed, but Microsoft.Configuration.* assemblies are not signed -->

--- a/src/ApiPort/ConsoleProgressReporter.cs
+++ b/src/ApiPort/ConsoleProgressReporter.cs
@@ -5,7 +5,6 @@ using ApiPort.Resources;
 using Microsoft.Fx.Portability;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,15 +13,22 @@ namespace ApiPort
     public class ConsoleProgressReporter : IProgressReporter
     {
         private readonly List<string> _issuesReported = new List<string>();
+        private readonly List<ConsoleProgressTask> _progressTasks = new List<ConsoleProgressTask>();
+
+        private bool _disposed = false;
 
         public IProgressTask StartTask(string taskName)
         {
-            return new ConsoleProgressTask(taskName, null);
+            var task = new ConsoleProgressTask(taskName, null);
+            _progressTasks.Add(task);
+            return task;
         }
 
         public IProgressTask StartTask(string taskName, int total)
         {
-            return new ConsoleProgressTask(taskName, total);
+            var task = new ConsoleProgressTask(taskName, total);
+            _progressTasks.Add(task);
+            return task;
         }
 
         public IReadOnlyCollection<string> Issues { get { return _issuesReported.AsReadOnly(); } }
@@ -30,6 +36,28 @@ namespace ApiPort
         public void ReportIssue(string issue)
         {
             _issuesReported.Add(issue);
+        }
+
+        /// <summary>
+        /// Suspends all progress tasks.
+        /// </summary>
+        public void SuspendProgressTasks()
+        {
+            foreach (var task in _progressTasks)
+            {
+                task.SuspendAnimation();
+            }
+        }
+
+        /// <summary>
+        /// Resumes all progress tasks.
+        /// </summary>
+        public void ResumeProgressTasks()
+        {
+            foreach (var task in _progressTasks)
+            {
+                task.ResumeAnimation();
+            }
         }
 
         private static void WriteColor(string message, ConsoleColor color)
@@ -58,12 +86,32 @@ namespace ApiPort
             Console.WriteLine();
         }
 
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+
+                foreach (var task in _progressTasks)
+                {
+                    task.Dispose();
+                }
+
+                _progressTasks.Clear();
+            }
+        }
+
         private sealed class ConsoleProgressTask : IProgressTask
         {
+            private static readonly TimeSpan MaxWaitTime = TimeSpan.FromMinutes(10);
+
             private readonly static char[] s_chars = new char[] { '-', '\\', '|', '/' };
 
             private readonly Task _animationTask;
+
             private readonly CancellationTokenSource _cancellationSource = new CancellationTokenSource();
+            private readonly ManualResetEventSlim _animationResetEvent = new ManualResetEventSlim(initialState: true);
+
             private readonly int? _totalCount;
             private readonly string _task;
 
@@ -83,33 +131,51 @@ namespace ApiPort
                 await Task.Delay(1);
 
 #if FEATURE_RICH_CONSOLE
+                var count = 0;
 
+                // 'left' is the last character written after the task name was written.
+                var left = Console.CursorLeft;
+                while (!cancelToken.IsCancellationRequested)
                 {
-                    var count = 0;
+                    _animationResetEvent.Wait(MaxWaitTime, cancelToken);
 
-                    // 'left' is the last character written after the task name was written.
-                    var left = Console.CursorLeft;
-                    while (!cancelToken.IsCancellationRequested)
-                    {
-                        Console.SetCursorPosition(left, Console.CursorTop);
+                    Console.SetCursorPosition(left, Console.CursorTop);
 
-                        WriteColor(string.Format(LocalizedStrings.ProgressReportInProgress, new string('.', ++count % 4).PadRight(3)), ConsoleColor.Yellow);
+                    WriteColor(string.Format(LocalizedStrings.ProgressReportInProgress, new string('.', ++count % 4).PadRight(3)), ConsoleColor.Yellow);
 
-
-                        await Task.Delay(350);
-                    }
-
-                    // Make sure we remove the last characted that we wrote.
-                    Console.SetCursorPosition(0, Console.CursorTop);
-                    Console.Write(" ".PadLeft(Console.WindowWidth - 1));
-                    Console.SetCursorPosition(0, Console.CursorTop);
-                    Console.Write(_task);
+                    await Task.Delay(350);
                 }
+
+                // Make sure we remove the last characted that we wrote.
+                Console.SetCursorPosition(0, Console.CursorTop);
+                Console.Write(" ".PadLeft(Console.WindowWidth - 1));
+                Console.SetCursorPosition(0, Console.CursorTop);
+                Console.Write(_task);
 #endif // FEATURE_RICH_CONSOLE
             }
 
             public void ReportUnitComplete()
             {
+            }
+
+            public void SuspendAnimation()
+            {
+                if (_completed)
+                {
+                    return;
+                }
+                _animationResetEvent.Reset();
+            }
+
+            public void ResumeAnimation()
+            {
+                if (_completed)
+                {
+                    return;
+                }
+
+                Console.Write(_task);
+                _animationResetEvent.Set();
             }
 
             public void Abort()

--- a/src/ApiPort/ConsoleProgressReporter.cs
+++ b/src/ApiPort/ConsoleProgressReporter.cs
@@ -41,7 +41,7 @@ namespace ApiPort
         /// <summary>
         /// Suspends all progress tasks.
         /// </summary>
-        public void SuspendProgressTasks()
+        public void Suspend()
         {
             foreach (var task in _progressTasks)
             {
@@ -52,7 +52,7 @@ namespace ApiPort
         /// <summary>
         /// Resumes all progress tasks.
         /// </summary>
-        public void ResumeProgressTasks()
+        public void Resume()
         {
             foreach (var task in _progressTasks)
             {

--- a/src/ApiPort/ConsoleProgressReporter.cs
+++ b/src/ApiPort/ConsoleProgressReporter.cs
@@ -129,8 +129,6 @@ namespace ApiPort
             private async Task RunBusyAnimation(CancellationToken cancelToken)
             {
                 await Task.Delay(1);
-
-#if FEATURE_RICH_CONSOLE
                 var count = 0;
 
                 // 'left' is the last character written after the task name was written.
@@ -151,7 +149,6 @@ namespace ApiPort
                 Console.Write(" ".PadLeft(Console.WindowWidth - 1));
                 Console.SetCursorPosition(0, Console.CursorTop);
                 Console.Write(_task);
-#endif // FEATURE_RICH_CONSOLE
             }
 
             public void ReportUnitComplete()

--- a/src/ApiPort/Program.cs
+++ b/src/ApiPort/Program.cs
@@ -62,6 +62,10 @@ namespace ApiPort
                 {
                     WriteException(ex);
                 }
+                catch (ProxyAuthenticationRequiredException ex)
+                {
+                    WriteException(ex);
+                }
                 catch (AggregateException ex)
                 {
                     Trace.TraceError(ex.ToString());

--- a/src/ApiPort/Proxy/ConsoleCredentialProvider.cs
+++ b/src/ApiPort/Proxy/ConsoleCredentialProvider.cs
@@ -1,0 +1,154 @@
+﻿using ApiPort.Resources;
+using Microsoft.Fx.Portability;
+using Microsoft.Fx.Portability.Proxy;
+using System;
+using System.Net;
+using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ApiPort
+{
+    /// <summary>
+    /// Credential provider for console input.
+    /// Taken from: https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.CommandLine/Common/ConsoleCredentialProvider.cs
+    /// </summary>
+    public class ConsoleCredentialProvider : ICredentialProvider
+    {
+        private readonly IProgressReporter _progressReporter;
+
+        public ConsoleCredentialProvider(IProgressReporter progressReporter)
+        {
+            _progressReporter = progressReporter;
+        }
+
+        /// <summary>
+        /// Fetches credentials for the given uri and proxy.
+        /// </summary>
+        public Task<NetworkCredential> GetCredentialsAsync(Uri uri, IWebProxy proxy, CredentialRequestType type, CancellationToken cancellationToken)
+        {
+            string message;
+
+            switch (type)
+            {
+                case CredentialRequestType.Proxy:
+                    message = LocalizedStrings.Credentials_ProxyCredentials;
+                    break;
+
+                case CredentialRequestType.Forbidden:
+                    message = LocalizedStrings.Credentials_ForbiddenCredentials;
+                    break;
+
+                default:
+                    message = LocalizedStrings.Credentials_RequestCredentials;
+                    break;
+            }
+
+            try
+            {
+                _progressReporter.SuspendProgressTasks();
+
+                Console.WriteLine();
+                Console.WriteLine(message, uri.OriginalString);
+                Console.Write(LocalizedStrings.Credentials_UserName);
+                cancellationToken.ThrowIfCancellationRequested();
+
+                string username = Console.ReadLine();
+                Console.Write(LocalizedStrings.Credentials_Password);
+
+#if FEATURE_NETWORK_CREDENTIAL
+                using (SecureString password = new SecureString())
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    ReadSecureStringFromConsole(password);
+
+                    var credentials = new NetworkCredential
+                    {
+                        UserName = username,
+                        SecurePassword = password
+                    };
+
+                    return Task.FromResult(credentials);
+                }
+#else
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var credentials = new NetworkCredential
+                {
+                    UserName = username,
+                    Password = ReadUnsecureStringFromConsole()
+                };
+
+                return Task.FromResult(credentials);
+#endif
+            }
+            finally
+            {
+                _progressReporter.ResumeProgressTasks();
+            }
+        }
+
+        /// <summary>
+        /// Using Console input, retrieves a SecureString
+        /// </summary>
+        private static void ReadSecureStringFromConsole(SecureString secureString)
+        {
+            ConsoleKeyInfo keyInfo;
+            while ((keyInfo = Console.ReadKey(intercept: true)).Key != ConsoleKey.Enter)
+            {
+                if (keyInfo.Key == ConsoleKey.Backspace)
+                {
+                    if (secureString.Length < 1)
+                    {
+                        continue;
+                    }
+                    Console.SetCursorPosition(Console.CursorLeft - 1, Console.CursorTop);
+                    Console.Write(' ');
+                    Console.SetCursorPosition(Console.CursorLeft - 1, Console.CursorTop);
+                    secureString.RemoveAt(secureString.Length - 1);
+                }
+                else
+                {
+                    secureString.AppendChar(keyInfo.KeyChar);
+                    Console.Write('*');
+                }
+            }
+            Console.WriteLine();
+        }
+
+#if !FEATURE_NETWORK_CREDENTIAL
+        /// <summary>
+        /// NOTE: Remove this when NetworkCredential.SecurePassword is
+        /// available in .NET Standard 2.0.
+        /// </summary>
+        private static string ReadUnsecureStringFromConsole()
+        {
+            var builder = new System.Text.StringBuilder();
+
+            ConsoleKeyInfo keyInfo;
+            while ((keyInfo = Console.ReadKey(intercept: true)).Key != ConsoleKey.Enter)
+            {
+                if (keyInfo.Key == ConsoleKey.Backspace)
+                {
+                    if (builder.Length < 1)
+                    {
+                        continue;
+                    }
+                    Console.SetCursorPosition(Console.CursorLeft - 1, Console.CursorTop);
+                    Console.Write(' ');
+                    Console.SetCursorPosition(Console.CursorLeft - 1, Console.CursorTop);
+                    builder.Remove(builder.Length - 1, 1);
+                }
+                else
+                {
+                    builder.Append(keyInfo.KeyChar);
+                    Console.Write('*');
+                }
+            }
+            Console.WriteLine();
+
+            return builder.ToString();
+        }
+#endif
+    }
+}

--- a/src/ApiPort/Proxy/ConsoleCredentialProvider.cs
+++ b/src/ApiPort/Proxy/ConsoleCredentialProvider.cs
@@ -46,7 +46,7 @@ namespace ApiPort
 
             try
             {
-                _progressReporter.SuspendProgressTasks();
+                _progressReporter.Suspend();
 
                 Console.WriteLine();
                 Console.WriteLine(message, uri.OriginalString);
@@ -84,7 +84,7 @@ namespace ApiPort
             }
             finally
             {
-                _progressReporter.ResumeProgressTasks();
+                _progressReporter.Resume();
             }
         }
 

--- a/src/ApiPort/Proxy/ProxyConstants.cs
+++ b/src/ApiPort/Proxy/ProxyConstants.cs
@@ -1,0 +1,33 @@
+﻿namespace Microsoft.Fx.Portability.Proxy
+{
+    /// <summary>
+    /// Constants used to fetch proxy settings.
+    /// </summary>
+    internal class ProxyConstants
+    {
+        /// Configuration keys for config.json
+        public const string ProxySection = "proxy";
+        public const string Username = nameof(Username);
+        public const string Address = nameof(Address);
+        public const string Password = nameof(Password);
+        public const string IsEnabled = nameof(IsEnabled);
+
+        /// <summary>
+        /// Environment variable key to specify the value to use as the HTTP proxy
+        /// for all connections.For example, HTTP_PROXY="http://proxy.mycompany.com:8080/"
+        /// </summary>
+        /// <remarks>
+        /// https://msdn.microsoft.com/en-us/library/hh272656(v=vs.120).aspx
+        /// </remarks>
+        public const string HttpProxy = "http_proxy";
+
+        /// <summary>
+        /// Environment variable key to determine hosts that should bypass the
+        /// proxy. For example, NO_PROXY="localhost,.mycompany.com,192.168.0.10:80"
+        /// </summary>
+        /// <remarks>
+        /// https://msdn.microsoft.com/en-us/library/hh272656(v=vs.120).aspx
+        /// </remarks>
+        public const string NoProxy = "no_proxy";
+    }
+}

--- a/src/ApiPort/Proxy/ProxyProvider.cs
+++ b/src/ApiPort/Proxy/ProxyProvider.cs
@@ -1,0 +1,265 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Linq;
+using System.Net;
+
+namespace Microsoft.Fx.Portability.Proxy
+{
+    /// <summary>
+    /// Looks for a proxy in the following order:
+    /// 1. From a configuration file <see cref="ProxyConstants.ConfigurationFile"/>
+    /// 2. From an environment variable <see cref="ProxyConstants.HttpProxy"/>
+    /// 3. System provided proxy
+    /// 
+    /// Looks for the one in the configuration file because the user would
+    /// explicitly want to override their current proxy settings in order 
+    /// for the configuration value to be set.
+    /// </summary>
+    /// <remarks>
+    /// Adapted from: https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
+    /// </remarks>
+    public class ProxyProvider : IProxyProvider
+    {
+#if FEATURE_SYSTEM_PROXY
+        /// <summary>
+        /// Capture the default System Proxy so that it can be re-used.  Cannot rely on
+        /// WebRequest.DefaultWebProxy since someone can modify the DefaultWebProxy
+        /// property and we can't tell if it was modified and if we are still using System Proxy Settings or not.
+        /// One limitation of this method is that it does not look at the config file to get the defined proxy
+        /// settings.
+        /// </summary>
+        private static readonly IWebProxy _originalSystemProxy = WebRequest.GetSystemWebProxy();
+#endif
+        private readonly IConfigurationRoot _configuration;
+        private readonly CredentialsWrapper _credentialsWrapper;
+
+        public ProxyProvider(string configurationDirectory, string configurationFile, ICredentialProvider credentialProvider)
+        {
+            _configuration = new ConfigurationBuilder()
+                 .SetBasePath(configurationDirectory)
+                 .AddJsonFile(configurationFile, optional: true, reloadOnChange: true)
+                 .Build();
+
+            _credentialsWrapper = new CredentialsWrapper(CredentialCache.DefaultNetworkCredentials);
+            CredentialProvider = credentialProvider;
+        }
+
+        public ICredentialProvider CredentialProvider { get; }
+
+        public IWebProxy GetProxy(Uri sourceUri)
+        {
+            // Check if the user has configured proxy details in settings or in the environment.
+            IWebProxy proxy = GetUserConfiguredProxy();
+
+            if (proxy != null)
+            {
+                if (proxy.Credentials != null)
+                {
+                    _credentialsWrapper.UpdateCredentials(proxy.Credentials);
+                }
+
+                proxy.Credentials = _credentialsWrapper;
+                return proxy;
+            }
+
+#if FEATURE_SYSTEM_PROXY
+            if (IsSystemProxySet(sourceUri))
+            {
+                proxy = GetSystemProxy(sourceUri);
+
+                if (proxy.Credentials != null)
+                {
+                    _credentialsWrapper.UpdateCredentials(proxy.Credentials);
+                }
+
+                proxy.Credentials = _credentialsWrapper;
+
+                return proxy;
+            }
+#endif
+
+            return null;
+        }
+
+        /// <summary>
+        /// Tries to get user configured proxy in the following order:
+        /// 1. Environment (configured in http_proxy, no proxy)
+        /// 2. Configuration file passed in.
+        /// </summary>
+        /// <returns>A web proxy or null if none was found.</returns>
+        public IWebProxy GetUserConfiguredProxy()
+        {
+            var proxy = GetWebProxyFromEnvironment();
+
+            if (proxy != null)
+            {
+                return proxy;
+            }
+
+            return GetWebProxyFromConfiguration();
+        }
+
+        /// <summary>
+        /// Update existing proxy credential
+        /// </summary>
+        /// <param name="credentials">New credential object</param>
+        public void UpdateProxyCredentials(NetworkCredential credentials)
+        {
+            _credentialsWrapper.UpdateCredentials(credentials);
+        }
+
+        /// <summary>
+        /// Gets the proxy from environment variables.
+        /// </summary>
+        private IWebProxy GetWebProxyFromEnvironment()
+        {
+            // Try reading from the environment variable http_proxy. This would be specified as http://<username>:<password>@proxy.com
+            var host = Environment.GetEnvironmentVariable(ProxyConstants.HttpProxy);
+            Uri uri;
+            if (!string.IsNullOrEmpty(host)
+                && Uri.TryCreate(host, UriKind.Absolute, out uri))
+            {
+                var webProxy = new ApiPort.Proxy.WebProxy(uri.GetComponents(UriComponents.HttpRequestUrl, UriFormat.SafeUnescaped));
+
+                if (!string.IsNullOrEmpty(uri.UserInfo))
+                {
+                    var credentials = uri.UserInfo.Split(':');
+
+                    if (credentials.Length > 1)
+                    {
+                        webProxy.Credentials = new NetworkCredential(
+                            userName: credentials[0],
+                            password: credentials[1]
+                        );
+                    }
+                }
+
+                var noProxy = Environment.GetEnvironmentVariable(ProxyConstants.NoProxy);
+                if (!string.IsNullOrEmpty(noProxy))
+                {
+                    // split comma-separated list of domains
+                    webProxy.BypassList = noProxy.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                }
+
+                return webProxy;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Tries to create a proxy by reading values from <see cref="_configuration"/>.
+        /// </summary>
+        private IWebProxy GetWebProxyFromConfiguration()
+        {
+            string host;
+            bool isEnabled;
+
+            string isEnabledString = GetValueFromProxyConfiguration<string>(_configuration, ProxyConstants.IsEnabled);
+
+            if (!bool.TryParse(isEnabledString, out isEnabled) || !isEnabled)
+            {
+                return null;
+            }
+
+            // Try to get Proxy from config.json
+            host = GetValueFromProxyConfiguration<string>(_configuration, ProxyConstants.Address);
+            string username = GetValueFromProxyConfiguration<string>(_configuration, ProxyConstants.Username);
+            string password = GetValueFromProxyConfiguration<string>(_configuration, ProxyConstants.Password);
+
+            if (!string.IsNullOrEmpty(host))
+            {
+                var proxy = new ApiPort.Proxy.WebProxy(host);
+
+                if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
+                {
+                    proxy.Credentials = new NetworkCredential(username, password);
+                }
+
+                return proxy;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private T GetValueFromProxyConfiguration<T>(IConfigurationRoot configuration, params string[] pathSegments)
+            where T : class
+        {
+            var concatonatedWithProxy = new[] { ProxyConstants.ProxySection }.Concat(pathSegments);
+            var key = ConfigurationPath.Combine(concatonatedWithProxy);
+
+            return configuration.GetValue<T>(key);
+        }
+
+#if FEATURE_SYSTEM_PROXY
+        private static ApiPort.Proxy.WebProxy GetSystemProxy(Uri uri)
+        {
+            // WebRequest.DefaultWebProxy seems to be more capable in terms of getting the default
+            // proxy settings instead of the WebRequest.GetSystemProxy()
+            var proxyUri = _originalSystemProxy.GetProxy(uri);
+            return new ApiPort.Proxy.WebProxy(proxyUri);
+        }
+
+        /// <summary>
+        /// Return true or false if connecting through a proxy server
+        /// </summary>
+        /// <param name="uri"></param>
+        /// <returns></returns>
+        private static bool IsSystemProxySet(Uri uri)
+        {
+            // The reason for not calling the GetSystemProxy is because the object
+            // that will be returned is no longer going to be the proxy that is set by the settings
+            // on the users machine only the Address is going to be the same.
+            // Not sure why the .NET team did not want to expose all of the useful settings like
+            // ByPass list and other settings that we can't get because of it.
+            // Anyway the reason why we need the DefaultWebProxy is to see if the uri that we are
+            // getting the proxy for to should be bypassed or not. If it should be bypassed then
+            // return that we don't need a proxy and we should try to connect directly.
+            var proxy = WebRequest.DefaultWebProxy;
+            if (proxy != null)
+            {
+                var proxyUri = proxy.GetProxy(uri);
+                if (proxyUri != null)
+                {
+                    var proxyAddress = new Uri(proxyUri.AbsoluteUri);
+                    if (string.Equals(proxyAddress.AbsoluteUri, uri.AbsoluteUri))
+                    {
+                        return false;
+                    }
+                    return !proxy.IsBypassed(uri);
+                }
+            }
+
+            return false;
+        }
+#endif
+
+        /// <summary>
+        /// Helper class that wraps NetworkCredentials so the proxy always
+        /// has a reference to the same class.
+        /// </summary>
+        private class CredentialsWrapper : ICredentials
+        {
+            private ICredentials _currentCredentials;
+
+            public CredentialsWrapper(NetworkCredential credentials)
+            {
+                _currentCredentials = credentials;
+            }
+
+            public NetworkCredential GetCredential(Uri uri, string authType)
+            {
+                return _currentCredentials?.GetCredential(uri, authType);
+            }
+
+            public void UpdateCredentials(ICredentials credential)
+            {
+                _currentCredentials = credential;
+            }
+        }
+    }
+}

--- a/src/ApiPort/Proxy/WebProxy.cs
+++ b/src/ApiPort/Proxy/WebProxy.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace ApiPort.Proxy
+{
+    /// <summary>
+    /// Internal implementation of <see cref="IWebProxy"/> mirroring default desktop one.
+    /// </summary>
+    /// <remarks>Remove when WebProxy is brought to .NET Standard 2.0.</remarks>
+    public class WebProxy : IWebProxy
+    {
+        private IReadOnlyList<string> _bypassList = new string[] { };
+        private Regex[] _regExBypassList; // can be null
+
+        public WebProxy(string proxyAddress)
+        {
+            if (proxyAddress == null)
+            {
+                throw new ArgumentNullException(nameof(proxyAddress));
+            }
+
+            ProxyAddress = CreateProxyUri(proxyAddress);
+        }
+
+        public WebProxy(Uri proxyAddress)
+        {
+            if (proxyAddress == null)
+            {
+                throw new ArgumentNullException(nameof(proxyAddress));
+            }
+
+            ProxyAddress = proxyAddress;
+        }
+
+        public Uri ProxyAddress { get; }
+
+        public ICredentials Credentials { get; set; }
+
+        public IReadOnlyList<string> BypassList
+        {
+            get
+            {
+                return _bypassList;
+            }
+            set
+            {
+                _bypassList = value ?? new string[] { };
+                UpdateRegExList();
+            }
+        }
+
+        public Uri GetProxy(Uri destination) => ProxyAddress;
+
+        public bool IsBypassed(Uri uri)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (_regExBypassList != null && _regExBypassList.Length > 0)
+            {
+                var normalizedUri = uri.Scheme + "://" + uri.Host + ((!uri.IsDefaultPort) ? (":" + uri.Port) : "");
+                return _regExBypassList.Any(r => r.IsMatch(normalizedUri));
+            }
+
+            return false;
+        }
+
+        private void UpdateRegExList()
+        {
+            _regExBypassList = _bypassList?
+                .Select(x => WildcardToRegex(x))
+                .Select(x => new Regex(x, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+                .ToArray();
+        }
+
+        private static string WildcardToRegex(string pattern)
+        {
+            return Regex.Escape(pattern)
+                .Replace(@"\*", ".*?")
+                .Replace(@"\?", ".");
+        }
+
+        private static Uri CreateProxyUri(string address)
+        {
+            if (address == null)
+            {
+                return null;
+            }
+
+            if (address.IndexOf("://") == -1)
+            {
+                address = "http://" + address;
+            }
+
+            return new Uri(address);
+        }
+    }
+}

--- a/src/ApiPort/Resources/LocalizedStrings.Designer.cs
+++ b/src/ApiPort/Resources/LocalizedStrings.Designer.cs
@@ -199,6 +199,51 @@ namespace ApiPort.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The remote server indicated that the previous request was forbidden. Please provide credentials for: {0}.
+        /// </summary>
+        public static string Credentials_ForbiddenCredentials {
+            get {
+                return ResourceManager.GetString("Credentials_ForbiddenCredentials", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password:.
+        /// </summary>
+        public static string Credentials_Password {
+            get {
+                return ResourceManager.GetString("Credentials_Password", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please provide proxy credentials:.
+        /// </summary>
+        public static string Credentials_ProxyCredentials {
+            get {
+                return ResourceManager.GetString("Credentials_ProxyCredentials", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please provide credentials for: {0}.
+        /// </summary>
+        public static string Credentials_RequestCredentials {
+            get {
+                return ResourceManager.GetString("Credentials_RequestCredentials", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Username:.
+        /// </summary>
+        public static string Credentials_UserName {
+            get {
+                return ResourceManager.GetString("Credentials_UserName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Description.
         /// </summary>
         public static string Description {

--- a/src/ApiPort/Resources/LocalizedStrings.resx
+++ b/src/ApiPort/Resources/LocalizedStrings.resx
@@ -294,4 +294,19 @@ In order to specify a version, please specify a target and a version with the fo
 
 Versions marked with an asterisk (*) implies that these are default targets if none are submitted.</value>
   </data>
+  <data name="Credentials_ForbiddenCredentials" xml:space="preserve">
+    <value>The remote server indicated that the previous request was forbidden. Please provide credentials for: {0}</value>
+  </data>
+  <data name="Credentials_ProxyCredentials" xml:space="preserve">
+    <value>Please provide proxy credentials:</value>
+  </data>
+  <data name="Credentials_RequestCredentials" xml:space="preserve">
+    <value>Please provide credentials for: {0}</value>
+  </data>
+  <data name="Credentials_Password" xml:space="preserve">
+    <value>Password:</value>
+  </data>
+  <data name="Credentials_UserName" xml:space="preserve">
+    <value>Username:</value>
+  </data>
 </root>

--- a/src/ApiPort/config.json
+++ b/src/ApiPort/config.json
@@ -1,0 +1,8 @@
+﻿{
+  "proxy": {
+    "isEnabled": "false",
+    "address": "http://localhost:8888",
+    "username": "1",
+    "password": "1"
+  }
+}

--- a/src/Microsoft.Fx.Portability/CompressedHttpClient.cs
+++ b/src/Microsoft.Fx.Portability/CompressedHttpClient.cs
@@ -23,7 +23,12 @@ namespace Microsoft.Fx.Portability
         /// <param name="productName">Product name that will be displayed in the User Agent string of requests</param>
         /// <param name="productVersion">Product version that will be displayed in the User Agent string of requests</param>
         public CompressedHttpClient(ProductInformation info)
-            : base(new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate })
+            : this(info, new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate })
+        {
+        }
+
+        public CompressedHttpClient(ProductInformation info, HttpMessageHandler handler)
+            : base(handler)
         {
             DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             DefaultRequestHeaders.AcceptLanguage.TryParseAdd(CultureInfo.CurrentCulture.ToString());
@@ -214,6 +219,8 @@ namespace Microsoft.Fx.Portability
                                 throw new NotFoundException();
                             case HttpStatusCode.Unauthorized:
                                 throw new UnauthorizedEndpointException();
+                            case HttpStatusCode.ProxyAuthenticationRequired:
+                                throw new ProxyAuthenticationRequiredException(request.RequestUri);
                         }
 
                         throw new PortabilityAnalyzerException(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.UnknownErrorCodeMessage, response.StatusCode));

--- a/src/Microsoft.Fx.Portability/IProgressReporter.cs
+++ b/src/Microsoft.Fx.Portability/IProgressReporter.cs
@@ -1,15 +1,19 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Fx.Portability
 {
-    public interface IProgressReporter
+    public interface IProgressReporter : IDisposable
     {
         void ReportIssue(string issue);
         IProgressTask StartTask(string taskName, int totalUnits);
         IProgressTask StartTask(string taskName);
         IReadOnlyCollection<string> Issues { get; }
+
+        void SuspendProgressTasks();
+        void ResumeProgressTasks();
     }
 }

--- a/src/Microsoft.Fx.Portability/IProgressReporter.cs
+++ b/src/Microsoft.Fx.Portability/IProgressReporter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Fx.Portability
         IProgressTask StartTask(string taskName);
         IReadOnlyCollection<string> Issues { get; }
 
-        void SuspendProgressTasks();
-        void ResumeProgressTasks();
+        void Suspend();
+        void Resume();
     }
 }

--- a/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
+++ b/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
@@ -38,6 +38,7 @@
     <IntermediateOutputPath>$(OutputIntermediate)\$(AssemblyName)\$(NugetTarget)</IntermediateOutputPath>
     <OutputPath>$(OutputDrop)\$(AssemblyName)\$(NugetTarget)</OutputPath>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
+    <DefineConstants>FEATURE_NETCORE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <None Include="Microsoft.Fx.Portability.project.json" />
@@ -62,6 +63,11 @@
     <Compile Include="ApiPortService.cs" />
     <Compile Include="ApiPortServiceSearcher.cs" />
     <Compile Include="BreakingChangeAnalyzerStatus.cs" />
+    <Compile Include="Proxy\ProxyAuthenticationRequiredException.cs" />
+    <Compile Include="Proxy\CredentialRequestType.cs" />
+    <Compile Include="Proxy\ICredentialProvider.cs" />
+    <Compile Include="Proxy\IProxyProvider.cs" />
+    <Compile Include="Proxy\ProxyAuthenticationHandler.cs" />
     <Compile Include="ObjectModel\AncestorApiRecommendations.cs" />
     <Compile Include="ObjectModel\AssemblyReferenceInformation.cs" />
     <Compile Include="IAssemblyFile.cs" />

--- a/src/Microsoft.Fx.Portability/Proxy/CredentialRequestType.cs
+++ b/src/Microsoft.Fx.Portability/Proxy/CredentialRequestType.cs
@@ -1,0 +1,28 @@
+﻿namespace Microsoft.Fx.Portability.Proxy
+{
+    /// <summary>
+    /// Taken from: https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Configuration/Credential/CredentialRequestType.cs
+    /// </summary>
+    public enum CredentialRequestType
+    {
+        /// <summary>
+        /// Indicates that the request credentials are to be used to access a proxy.
+        /// </summary>
+        Proxy,
+
+        /// <summary>
+        /// Indicates that the remote server rejected the previous request as unauthorized. This 
+        /// suggests that the server does not know who the caller is (i.e. the caller is not
+        /// authenticated).
+        /// </summary>
+        Unauthorized,
+
+        /// <summary>
+        /// Indicates that the remote server rejected the previous request as forbidden. This
+        /// suggests that the server knows who the caller is (i.e. the caller is authorized) but
+        /// is not allowed to access the request resource. A different set of credentials could
+        /// solve this failure.
+        /// </summary>
+        Forbidden
+    }
+}

--- a/src/Microsoft.Fx.Portability/Proxy/ICredentialProvider.cs
+++ b/src/Microsoft.Fx.Portability/Proxy/ICredentialProvider.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Fx.Portability.Proxy
+{
+    /// <summary>
+    /// Provides NetworkCredentials for a given address and proxy.
+    /// </summary>
+    public interface ICredentialProvider
+    {
+        /// <summary>
+        /// Fetches credentials for the given uri and proxy.
+        /// </summary>
+        Task<NetworkCredential> GetCredentialsAsync(Uri uri, IWebProxy proxy, CredentialRequestType type, CancellationToken cancellationToken);
+    }
+}

--- a/src/Microsoft.Fx.Portability/Proxy/IProxyProvider.cs
+++ b/src/Microsoft.Fx.Portability/Proxy/IProxyProvider.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Net;
+
+namespace Microsoft.Fx.Portability.Proxy
+{
+    /// <summary>
+    /// Coordinates the proxy settings and credentials
+    /// </summary>
+    public interface IProxyProvider
+    {
+        /// <summary>
+        /// The credential provider to fetch credentials
+        /// </summary>
+        ICredentialProvider CredentialProvider { get; }
+
+        /// <summary>
+        /// The resolved proxy based on the destination Uri.
+        /// </summary>
+        IWebProxy GetProxy(Uri sourceUri);
+
+        /// <summary>
+        /// Updates the existing credentials in the proxy.
+        /// </summary>
+        void UpdateProxyCredentials(NetworkCredential credentials);
+    }
+}

--- a/src/Microsoft.Fx.Portability/Proxy/IProxyProvider.cs
+++ b/src/Microsoft.Fx.Portability/Proxy/IProxyProvider.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Fx.Portability.Proxy
 {
@@ -9,9 +11,10 @@ namespace Microsoft.Fx.Portability.Proxy
     public interface IProxyProvider
     {
         /// <summary>
-        /// The credential provider to fetch credentials
+        /// True if it can get updated credentials (if the existing ones for
+        /// the proxy are not sufficient).
         /// </summary>
-        ICredentialProvider CredentialProvider { get; }
+        bool CanUpdateCredentials { get; }
 
         /// <summary>
         /// The resolved proxy based on the destination Uri.
@@ -19,8 +22,8 @@ namespace Microsoft.Fx.Portability.Proxy
         IWebProxy GetProxy(Uri sourceUri);
 
         /// <summary>
-        /// Updates the existing credentials in the proxy.
+        /// True if it was possible to update the credentials and false otherwise.
         /// </summary>
-        void UpdateProxyCredentials(NetworkCredential credentials);
+        Task<bool> TryUpdateCredentialsAsync(Uri uri, IWebProxy proxy, CredentialRequestType type, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Fx.Portability/Proxy/ProxyAuthenticationHandler.cs
+++ b/src/Microsoft.Fx.Portability/Proxy/ProxyAuthenticationHandler.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Fx.Portability.Proxy
+{
+    /// <summary>
+    /// DelegatingHandler that coordinates passing in credentials and fetching
+    /// new credentials from user when authorization is required.
+    /// </summary>
+    /// <remarks>
+    /// Taken from: https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/ProxyAuthenticationHandler.cs
+    /// </remarks>
+    public class ProxyAuthenticationHandler : DelegatingHandler
+    {
+        public static readonly int MaxAttempts = 3;
+        private const string BasicAuthenticationType = "Basic";
+
+        private readonly HttpClientHandler _clientHandler;
+        private int _authRetries = 0;
+        private readonly IProxyProvider _proxyProvider;
+
+        public ProxyAuthenticationHandler(HttpClientHandler httpClientHandler, IProxyProvider proxyProvider)
+            : base(httpClientHandler)
+        {
+            if (httpClientHandler == null)
+            {
+                throw new ArgumentNullException(nameof(httpClientHandler));
+            }
+            if (proxyProvider == null)
+            {
+                throw new ArgumentNullException(nameof(proxyProvider));
+            }
+
+            _clientHandler = httpClientHandler;
+            _proxyProvider = proxyProvider;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            int maxAttempts = 0;
+            HttpResponseMessage response = default(HttpResponseMessage);
+
+            while (maxAttempts < MaxAttempts)
+            {
+                try
+                {
+                    response = await base.SendAsync(request, cancellationToken);
+
+                    if (response.StatusCode != HttpStatusCode.ProxyAuthenticationRequired)
+                    {
+                        return response;
+                    }
+
+                    if (_clientHandler.Proxy == null)
+                    {
+                        return response;
+                    }
+
+                    if (_proxyProvider.CredentialProvider == null)
+                    {
+                        return response;
+                    }
+
+                    if (!await AcquireCredentialsAsync(request.RequestUri, cancellationToken))
+                    {
+                        return response;
+                    }
+                }
+                catch (Exception ex)
+                when (ProxyAuthenticationRequired(ex) && _clientHandler.Proxy != null && _proxyProvider.CredentialProvider != null)
+                {
+                    if (!await AcquireCredentialsAsync(request.RequestUri, cancellationToken))
+                    {
+                        throw;
+                    }
+                }
+
+                maxAttempts++;
+            }
+
+            return response;
+        }
+
+        private async Task<bool> AcquireCredentialsAsync(Uri requestUri, CancellationToken cancellationToken)
+        {
+            // Limit the number of retries
+            _authRetries++;
+            if (_authRetries >= MaxAttempts)
+            {
+                // user prompting no more
+                return false;
+            }
+
+            var proxyAddress = _clientHandler.Proxy.GetProxy(requestUri);
+
+            // prompt user for proxy credentials.
+            var credentials = await _proxyProvider.CredentialProvider?.GetCredentialsAsync(proxyAddress, _clientHandler.Proxy, CredentialRequestType.Proxy, cancellationToken);
+
+            if (credentials == null)
+            {
+                return false;
+            }
+
+            _proxyProvider.UpdateProxyCredentials(credentials);
+
+            // use the user provided credential to send the request again.
+            return true;
+        }
+
+#if FEATURE_NETCORE
+        // Returns true if the cause of the exception is proxy authentication failure
+        private static bool ProxyAuthenticationRequired(Exception ex)
+        {
+            return true;
+        }
+#else
+        // Returns true if the cause of the exception is proxy authentication failure
+        private static bool ProxyAuthenticationRequired(Exception ex)
+        {
+            if (ex is ProxyAuthenticationRequiredException)
+            {
+                return true;
+            }
+
+            var response = ExtractResponse(ex);
+            return response?.StatusCode == HttpStatusCode.ProxyAuthenticationRequired;
+        }
+
+        private static HttpWebResponse ExtractResponse(Exception ex)
+        {
+            var webException = ex.InnerException as WebException;
+            var response = webException?.Response as HttpWebResponse;
+            return response;
+        }
+#endif
+    }
+}

--- a/src/Microsoft.Fx.Portability/Proxy/ProxyAuthenticationRequiredException.cs
+++ b/src/Microsoft.Fx.Portability/Proxy/ProxyAuthenticationRequiredException.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Fx.Portability.Resources;
+using System;
+using System.Net;
+
+namespace Microsoft.Fx.Portability
+{
+    /// <summary>
+    /// Thrown when trying to call the <see cref="Endpoint"/> resulted in <see cref="HttpStatusCode.ProxyAuthenticationRequired"/> 
+    /// </summary>
+    public class ProxyAuthenticationRequiredException : Exception
+    {
+        /// <summary>
+        /// Endpoint that was accessed when thrown.
+        /// </summary>
+        public Uri Endpoint { get; }
+
+        public ProxyAuthenticationRequiredException(Uri uri)
+            : this(uri, null, null)
+        { }
+
+        public ProxyAuthenticationRequiredException(Uri uri, string message)
+            : this(uri, message, null)
+        { }
+
+        public ProxyAuthenticationRequiredException(Uri uri, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            Endpoint = uri;
+        }
+
+        public override string ToString()
+        {
+            var formatted = string.Format(LocalizedStrings.ProxyAuthenticationRequiredMessage, Endpoint);
+
+            return formatted + Environment.NewLine + base.ToString();
+        }
+    }
+}

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
@@ -459,6 +459,15 @@ namespace Microsoft.Fx.Portability.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Proxy authentication required to access: {0}. To resolve, try setting proxy in config.json.
+        /// </summary>
+        public static string ProxyAuthenticationRequiredMessage {
+            get {
+                return ResourceManager.GetString("ProxyAuthenticationRequiredMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Recommended changes.
         /// </summary>
         public static string RecommendedChanges {

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
@@ -341,4 +341,7 @@
   <data name="CatalogLastUpdated" xml:space="preserve">
     <value>API Catalog last updated on</value>
   </data>
+  <data name="ProxyAuthenticationRequiredMessage" xml:space="preserve">
+    <value>Proxy authentication required to access: {0}. To resolve, try setting proxy in config.json.</value>
+  </data>
 </root>

--- a/src/Microsoft.Fx.Portability/TextWriterProgressReporter.cs
+++ b/src/Microsoft.Fx.Portability/TextWriterProgressReporter.cs
@@ -34,10 +34,10 @@ namespace Microsoft.Fx.Portability
             _issuesReported.Add(issue);
         }
 
-        public void SuspendProgressTasks()
+        public void Suspend()
         { }
 
-        public void ResumeProgressTasks()
+        public void Resume()
         { }
 
         public void Dispose()

--- a/src/Microsoft.Fx.Portability/TextWriterProgressReporter.cs
+++ b/src/Microsoft.Fx.Portability/TextWriterProgressReporter.cs
@@ -34,6 +34,15 @@ namespace Microsoft.Fx.Portability
             _issuesReported.Add(issue);
         }
 
+        public void SuspendProgressTasks()
+        { }
+
+        public void ResumeProgressTasks()
+        { }
+
+        public void Dispose()
+        { }
+
         private sealed class TextWriterProgressTask : IProgressTask
         {
             private readonly TextWriter _textWriter;


### PR DESCRIPTION
* Adding support for proxies since we do not consider them.  This feature is modeled after the architecture NuGet uses where it tries to find a proxy in the following order:

    1. Configuration file (config.json)
    2. Environment variable ([http_proxy](https://msdn.microsoft.com/en-us/library/hh272656(v=vs.120).aspx))
    3. System configured

    If none exists, it behaves normally.

* If a 407 is encountered, it has a ProxyAuthenticationHandler to try and fetch the NetworkCredentials from the user.
* Updates IProgressReporter so that asking users for credentials does not conflict with the [Loading...] animations.

Example usage below:

![example](https://cloud.githubusercontent.com/assets/10136526/22779133/61513bae-ee6e-11e6-9a26-c523b839f1f4.png)

__TODOs__

* Update HELP command
* Add documentation
* Add Unit Tests

I am not sure if I should move these tasks to a new PR or keep adding to this one.