### PR TITLE
Update BreakingChangeParser

### DIFF
--- a/src/Microsoft.Fx.Portability/BreakingChangeParser.cs
+++ b/src/Microsoft.Fx.Portability/BreakingChangeParser.cs
@@ -178,6 +178,23 @@ namespace Microsoft.Fx.Portability
                             state = ParseState.None;
                         }
 
+                        // Comments.
+                        else if (currentLine.StartsWith("<!--", StringComparison.Ordinal))
+                        {
+                            var contents = currentLine.Replace("<!--", "").Replace("-->", "");
+                            var startIndex = contents.IndexOf(":");
+                            int id;
+
+                            // <!-- breaking change id: 144 -->
+                            if (contents.IndexOf("breaking change id", StringComparison.OrdinalIgnoreCase) != -1
+                                && startIndex != -1
+                                && int.TryParse(contents.Substring(startIndex + 1), out id))
+                            {
+                                currentBreak.Id = id.ToString();
+                            }
+
+                            state = ParseState.None;
+                        }
                         // Otherwise, process according to our current state
                         else
                         {

--- a/tests/Microsoft.Fx.Portability.Tests/BreakingChangeParserTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/BreakingChangeParserTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -68,6 +69,34 @@ namespace Microsoft.Fx.Portability.Tests
             bc.ApplicableApis = bc.ApplicableApis.Concat(new[] { "##" }).ToList();
             bc.Suggestion = "\\0\0\0\0\0" + bc.Suggestion + "\u0001\u0002";
             ValidateParse(GetBreakingChangeMarkdown("CorruptData.md"), bc);
+        }
+
+        [Fact]
+        public void IdInComments()
+        {
+            BreakingChange bc = new BreakingChange
+            {
+                Id = "144",
+                Title = "Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage",
+                VersionBroken = Version.Parse("4.6.1"),
+                ImpactScope = BreakingChangeImpact.Edge,
+                SourceAnalyzerStatus = BreakingChangeAnalyzerStatus.Planned,
+                Details = "Prior to the .NET Framework 4.6.1, calling Application.FilterMessage with an IMessageFilter.PreFilterMessage which called AddMessageFilter or RemoveMessageFilter (while also calling Application.DoEvents) would cause an IndexOutOfRangeException."
+                + "\n\n"
+                + "Beginning with applications targeting the .NET Framework 4.6.1, this exception is no longer thrown, and re-entrant filters as described above may be used.",
+                IsQuirked = true,
+                Suggestion = "Be aware that Application.FilterMessage will no longer throw for the re-entrant IMessageFilter.PreFilterMessage behavior described above. This only affects applications targeting the .NET Framework 4.6.1.",
+                Categories = new List<string> { "Windows Forms" },
+                Link = "https://msdn.microsoft.com/en-us/library/mt620031%28v=vs.110%29.aspx#WinForms",
+                ApplicableApis = new List<string> {
+                    "M:System.Windows.Forms.Application.FilterMessage(System.Windows.Forms.Message@)"
+                },
+                Notes = "It's unclear if this one will be better analyzed by Application.FilterMessage callers (who would have seen the exception previously)"
+                + "\n" + "or the IMessageFilter.PreFilterMessage implementers (who caused the exception previously). Unfortunately, the analyzer on the caller is probably"
+                + "\n" + "more useful, even though it would be easier to be 'precise' if we analyzed the interface implementer."
+            };
+
+            ValidateParse(GetBreakingChangeMarkdown("Application.FilterMessage.md"), bc);
         }
 
         [Fact]

--- a/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
@@ -84,6 +84,7 @@
     <EmbeddedResource Include="TestAssets\RandomText.md" />
     <EmbeddedResource Include="TestAssets\RandomText2.md" />
     <EmbeddedResource Include="TestAssets\Template.md" />
+    <EmbeddedResource Include="TestAssets\Application.FilterMessage.md" />
     <None Include="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/Microsoft.Fx.Portability.Tests/TestAssets/Application.FilterMessage.md
+++ b/tests/Microsoft.Fx.Portability.Tests/TestAssets/Application.FilterMessage.md
@@ -1,0 +1,38 @@
+## Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage
+
+### Scope
+Edge
+
+### Version Introduced
+4.6.1
+
+### Source Analyzer Status
+Planned
+
+### Change Description
+Prior to the .NET Framework 4.6.1, calling Application.FilterMessage with an IMessageFilter.PreFilterMessage which called AddMessageFilter or RemoveMessageFilter (while also calling Application.DoEvents) would cause an IndexOutOfRangeException.
+
+Beginning with applications targeting the .NET Framework 4.6.1, this exception is no longer thrown, and re-entrant filters as described above may be used.
+
+- [x] Quirked
+- [ ] Build-time break
+
+### Recommended Action
+Be aware that Application.FilterMessage will no longer throw for the re-entrant IMessageFilter.PreFilterMessage behavior described above. This only affects applications targeting the .NET Framework 4.6.1.
+
+### Affected APIs
+* `M:System.Windows.Forms.Application.FilterMessage(System.Windows.Forms.Message@)`
+
+### Category
+Windows Forms
+
+[More information](https://msdn.microsoft.com/en-us/library/mt620031%28v=vs.110%29.aspx#WinForms)
+
+<!--
+    ### Notes
+    It's unclear if this one will be better analyzed by Application.FilterMessage callers (who would have seen the exception previously)
+    or the IMessageFilter.PreFilterMessage implementers (who caused the exception previously). Unfortunately, the analyzer on the caller is probably
+    more useful, even though it would be easier to be 'precise' if we analyzed the interface implementer.
+-->
+
+<!-- breaking change id: 144 -->


### PR DESCRIPTION
Considers breaking change id in comment section now to support ids in microsoft/dotnet.

Example:
<!-- breaking change id: 144 -->

/cc: @twsouthwick 