### PR TITLE
Update README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ For a quick introduction, check out [this video on Channel 9][Channel 9 Video]:
 
 ## Using this Repository
 
-* Install [Visual Studio 2015 with Update 3][Visual Studio 2015]
-* Install [.NET Core 1.0.1](https://dot.net/core)
+* Install [Visual Studio 2017 with .NET Core Workload][Visual Studio 2017]
 
 ## Documentation
 
@@ -27,9 +26,9 @@ For a quick introduction, check out [this video on Channel 9][Channel 9 Video]:
 
 | Project | Description |
 | :------ | :---------- |
-| ApiPort | Console tool to access portability webservice | 
-| ApiPort.Core | Cross-platform .NET Core application | 
-| ApiPort.Vsix | Visual Studio Extension | 
+| ApiPort | Console tool to access portability webservice |
+| ApiPort.Core | Cross-platform .NET Core application |
+| ApiPort.Vsix | Visual Studio Extension |
 | Microsoft.Fx.Portability | Provides common types for API Port |
 | Microsoft.Fx.Portability.MetadataReader | Implements a dependency finder based off of [System.Reflection.Metadata][System.Reflection.Metadata]. The library  will generate DocIds that conform to [these specifications][DocId]. |
 | Microsoft.Fx.Portability.Offline | Provides access to data in an offline setting so network calls are not needed |
@@ -54,8 +53,8 @@ Want to get more familiar with what's going on in the code?
 Looking for something to work on? The list of [up-for-grabs issues][Issues-Open]
 is a great place to start.
 
-We're re-using the same contributing approach as .NET Core. You can check out 
-the .NET Core [contributing guide][Contributing Guide] at the corefx repo wiki 
+We're re-using the same contributing approach as .NET Core. You can check out
+the .NET Core [contributing guide][Contributing Guide] at the corefx repo wiki
 for more details.
 
 * [How to Contribute][Contributing Guide]
@@ -84,5 +83,5 @@ This project is licensed under the [MIT license](LICENSE).
 [PR-Open]: https://github.com/Microsoft/dotnet-apiport/pulls?q=is%3Aopen+is%3Apr
 [myget]: https://dotnet.myget.org/gallery/dotnet-apiport
 [System.Reflection.Metadata]: https://github.com/dotnet/corefx/tree/master/src/System.Reflection.Metadata
-[Visual Studio 2015]: http://www.visualstudio.com/en-us/downloads/visual-studio-2015-downloads-vs.aspx
+[Visual Studio 2017]: https://www.microsoft.com/net/core#windowsvs2017
 [VSIX Gallery]: http://vsixgallery.com/extension/55d15546-28ca-40dc-af23-dfa503e9c5fe

--- a/docs/Console/README.md
+++ b/docs/Console/README.md
@@ -1,6 +1,6 @@
 # .NET Portability Analyzer (Console application)
 
-The console tool helps you determine how flexible your application.  The tool 
+The console tool helps you determine how flexible your application.  The tool
 understands the following commands:
 
   * `ApiPort.exe analyze <options>`
@@ -15,14 +15,14 @@ understands the following commands:
 
 ## `ApiPort.exe analyze` Scenarios
 
-Arguably the most important function of the tool is its ability to analyze an 
-assembly. This can take in a file, collection of files, or a directory of 
-assemblies.  
+Arguably the most important function of the tool is its ability to analyze an
+assembly. This can take in a file, collection of files, or a directory of
+assemblies.
 
 **Analyzing a file against specific targets and outputting an HTML report**
 
 ```
-ApiPort.exe analyze -f Foo.dll -t ".NET Framework, Version=4.6.2" -t 
+ApiPort.exe analyze -f Foo.dll -t ".NET Framework, Version=4.6.2" -t
 ".NET Standard, Version=1.6" -r HTML -o AnalysisReport.html
 ```
 
@@ -30,13 +30,13 @@ The `-f` flag followed by a path represents the file or directory that the
 analysis should be performed on; in this case, it is `Foo.dll`.  The multiple
 uses of `-t` followed by target names tells the tool what .NET platforms we want
 to analyze the input assembly(ies) against. `-r` is the output format of the
-report. `-o` is the output name for that report.  
+report. `-o` is the output name for that report.
 
-So, our analysis will be performed on `Foo.dll` against 
+So, our analysis will be performed on `Foo.dll` against
 `.NET Framework, Version=4.6.2` and `.NET Standard, Version=1.6` and output as
 an HTML file, `AnalysisReport.html`.
 
-**Analyzing a directory against the default targets and outputting default 
+**Analyzing a directory against the default targets and outputting default
 report format**
 
 ```
@@ -44,8 +44,8 @@ ApiPort.exe analyze -f C:\git\Application\bin\Debug
 ```
 
 This will analyze all assemblies that exist under `C:\git\Application\bin\Debug`
-recursively, and analyzes those assemblies against the default .NET platforms. 
-(**Note:** The default platforms can be obtained by running `ApiPort.exe 
+recursively, and analyzes those assemblies against the default .NET platforms.
+(**Note:** The default platforms can be obtained by running `ApiPort.exe
 listTargets` and looking for targets that have an (\*) in them.)
 
 **Analyzing a directory and show breaking changes**
@@ -54,10 +54,10 @@ listTargets` and looking for targets that have an (\*) in them.)
 ApiPort.exe analyze -f C:\git\Application\bin\Debug -b
 ```
 
-The `-b` flag will show any APIs that may have different behavior between 
-versions of .NET Framework due to breaking changes that have been made.  The 
-entire list of breaking changes in .NET Framework can be found by examining 
-[Application Compatibility in the .NET Framework][Breaking Changes]. For the 
+The `-b` flag will show any APIs that may have different behavior between
+versions of .NET Framework due to breaking changes that have been made.  The
+entire list of breaking changes in .NET Framework can be found by examining
+[Application Compatibility in the .NET Framework][Breaking Changes]. For the
 list of breaking changes we analyze against, look [here](BreakingChanges.md).
 
 **Analyzing a directory and show any non-portable APIs**
@@ -83,34 +83,24 @@ for using the .NET Core application include:
 **From Commandline**
 
 1. Execute `build.cmd`
-2. Go to `bin\Release\ApiPort.Core\netcoreapp1.0`
-3. Go to either `x64` or `x86` folder
-4. Execute `dotnet.exe ApiPort.exe`
+2. Execute `dotnet.exe .\bin\Release\ApiPort\netcoreapp1.0\ApiPort.dll [Any other arguments to ApiPort]`
 
-**In Visual Studio 2015**
+**In Visual Studio 2017**
 
-1. Change **Platform** to `x64` or `x86`
-2. Compile solution
-3. Set `ApiPort.Core` as Start-up Project
-4. Start debugging (F5)
-
-### Troubleshooting
-
-**Problem: The program can't start because api-ms-win-crt-runtime-l1-1-0.dll is missing
-from your computer.**
-
-Solution: Install [Visual Studio 2015 C++ Redistributable][VS2015 C++ Redistributable].
+1. Compile solution
+2. Set `ApiPort` as Start-up Project
+3. Start debugging (F5)
 
 ## Alternate modes
 
 The tool by default will gather the results and submit to a webservice that will
 analyze the data to determine which APIs need to be addressed. For full details
-on this process, please read the [privacy policy][Privacy Policy].  There are 
-two alternate modes that can be used to alter this workflow. 
+on this process, please read the [privacy policy][Privacy Policy].  There are
+two alternate modes that can be used to alter this workflow.
 
 ### See the data being transmitted
 
-The first option is to output the request to a file. This will result in an 
+The first option is to output the request to a file. This will result in an
 output that shows what data is being transmitted to the service, but provides no
 details as to API portability or breaking changes. This is a good option if you
 would like to see what data will be collected.
@@ -129,31 +119,31 @@ same directory as `ApiPort.exe`. Add the following contents:
 }
 ```
 
-Now, when you run, it will output a file (ie. `ApiPortAnalysis.json`) with the information that is sent to 
+Now, when you run, it will output a file (ie. `ApiPortAnalysis.json`) with the information that is sent to
 the .NET Portability service.
 
 ### Run the tool in an offline mode
 
-Another option is to enable full offline access. This mode will not get 
+Another option is to enable full offline access. This mode will not get
 automatic updates and no official releases of it are available. In order to use
 this mode, the solution must be manually built. To do so, please follow these
 steps:
 
 1. Clone the project: `git clone https://github.com/Microsoft/dotnet-apiport`
-2. Build the project: `build.cmd`. 
+2. Build the project: `build.cmd`.
 
     *Note: This command must be used as it gathers the correct assemblies for offline mode. Building in VS does not do this.*
-    
+
 3. Go to `bin\release\ApiPort.Offline`
 4. Run `ApiPort.exe` from this directory as normal.
 
 If you have issues with proxies, please add your proxy information to the catalog script:
 
 1. Edit [`.\build\Get-CatalogFile.ps1` at line 24](https://github.com/Microsoft/dotnet-apiport/blob/master/build/Get-CatalogFile.ps1#L24)
-2. Replace Line 24 with: 
+2. Replace Line 24 with:
   - If your proxy uses your default credentials: `Invoke-WebRequest $url -OutFile $OutputPath -Proxy [Proxy Address] -ProxyUseDefaultCredentials`
-  - Otherwise: `Invoke-WebRequest $url -OutFile $OutputPath -Proxy [Proxy Address] -ProxyCredential [Credentials]` 
-3. Run `build.cmd` 
+  - Otherwise: `Invoke-WebRequest $url -OutFile $OutputPath -Proxy [Proxy Address] -ProxyCredential [Credentials]`
+3. Run `build.cmd`
 
 Additional reports can be generated in offline mode. Any implementation of `Microsoft.Fx.Portability.Reporting.IReportWriter` can be
 used. An assembly with the name of `Microsoft.Fx.Portability.Writers.[NAME].dll` will be searched for any available implementations.


### PR DESCRIPTION
Updates README documentation to reference VS2017 instead of VS2015.
Most of the line changes are removing trailing spaces.