### PR TITLE
Fix locating project output paths

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <add key="nuget" value="https://www.nuget.org/api/v2/" />
-    <add key="myget.org dotnet-core" value="https://www.myget.org/F/dotnet-core/" />
+    <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/ApiPort.VisualStudio/Analyze/FileListAnalyzer.cs
+++ b/src/ApiPort.VisualStudio/Analyze/FileListAnalyzer.cs
@@ -20,7 +20,7 @@ namespace ApiPortVS.Analyze
 
         public async Task AnalyzeProjectAsync(IEnumerable<string> inputAssemblyPaths)
         {
-            await _analyzer.WriteAnalysisReportsAsync(inputAssemblyPaths, _reportWriter, false);
+            await _analyzer.WriteAnalysisReportsAsync(inputAssemblyPaths, _reportWriter, false).ConfigureAwait(false);
         }
     }
 }

--- a/src/ApiPort.VisualStudio/Analyze/ProjectAnalyzer.cs
+++ b/src/ApiPort.VisualStudio/Analyze/ProjectAnalyzer.cs
@@ -77,7 +77,7 @@ namespace ApiPortVS.Analyze
 
             var sourceItems = await Task.Run(() => _sourceLineMapper.GetSourceInfo(targetAssemblies, result));
 
-            DisplaySourceItemsInErrorList(sourceItems, projects);
+            await DisplaySourceItemsInErrorList(sourceItems, projects);
         }
 
         public bool FileHasAnalyzableExtension(string fileName)
@@ -102,12 +102,14 @@ namespace ApiPortVS.Analyze
             }
         }
 
-        private void DisplaySourceItemsInErrorList(IEnumerable<ISourceMappedItem> items, ICollection<Project> projects)
+        private async Task DisplaySourceItemsInErrorList(IEnumerable<ISourceMappedItem> items, ICollection<Project> projects)
         {
             if (!items.Any())
             {
                 return;
             }
+
+            await Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             _errorList.Tasks.Clear();
             _errorList.Refresh();

--- a/src/ApiPort.VisualStudio/Analyze/ProjectAnalyzer.cs
+++ b/src/ApiPort.VisualStudio/Analyze/ProjectAnalyzer.cs
@@ -57,7 +57,7 @@ namespace ApiPortVS.Analyze
 
             foreach (var project in projects)
             {
-                var output = await project.GetBuildOutputFilesAsync();
+                var output = await project.GetBuildOutputFilesAsync().ConfigureAwait(false);
 
                 // Could not find any output files for this. Skip it.
                 if (output == null)
@@ -122,7 +122,7 @@ namespace ApiPortVS.Analyze
 
             foreach (var project in projects)
             {
-                var outputs = await project.GetBuildOutputFilesAsync();
+                var outputs = await project.GetBuildOutputFilesAsync().ConfigureAwait(false);
 
                 if (outputs == null)
                 {

--- a/src/ApiPort.VisualStudio/AnalyzeMenu.cs
+++ b/src/ApiPort.VisualStudio/AnalyzeMenu.cs
@@ -58,7 +58,7 @@ namespace ApiPortVS
                 {
                     var projectAnalyzer = innerScope.Resolve<ProjectAnalyzer>();
 
-                    await projectAnalyzer.AnalyzeProjectAsync(projects);
+                    await projectAnalyzer.AnalyzeProjectAsync(projects).ConfigureAwait(false);
                 }
             }
             catch (PortabilityAnalyzerException ex)

--- a/src/ApiPort.VisualStudio/AnalyzeMenu.cs
+++ b/src/ApiPort.VisualStudio/AnalyzeMenu.cs
@@ -20,11 +20,11 @@ namespace ApiPortVS
 {
     internal class AnalyzeMenu
     {
-        private readonly TextWriter _output;
+        private readonly OutputWindowWriter _output;
         private readonly DTE _dte;
         private readonly ILifetimeScope _scope;
 
-        public AnalyzeMenu(ILifetimeScope scope, DTE dte, TextWriter output)
+        public AnalyzeMenu(ILifetimeScope scope, DTE dte, OutputWindowWriter output)
         {
             _scope = scope;
             _dte = dte;
@@ -52,7 +52,7 @@ namespace ApiPortVS
 
             try
             {
-                WriteHeader();
+                await WriteHeaderAsync().ConfigureAwait(false);
 
                 using (var innerScope = _scope.BeginLifetimeScope())
                 {
@@ -122,7 +122,7 @@ namespace ApiPortVS
 
             try
             {
-                WriteHeader();
+                await WriteHeaderAsync().ConfigureAwait(false);
 
                 using (var innerScope = _scope.BeginLifetimeScope())
                 {
@@ -163,8 +163,10 @@ namespace ApiPortVS
             return (bool)openDialog.ShowDialog() ? openDialog.FileNames : null;
         }
 
-        private void WriteHeader()
+        private async Task WriteHeaderAsync()
         {
+            await _output.ClearWindowAsync();
+
             var header = new StringBuilder();
             var assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version;
             header.AppendLine(string.Format(LocalizedStrings.CopyrightFormat, assemblyVersion));

--- a/src/ApiPort.VisualStudio/AnalyzeMenu.cs
+++ b/src/ApiPort.VisualStudio/AnalyzeMenu.cs
@@ -31,16 +31,16 @@ namespace ApiPortVS
             _output = output;
         }
 
-        public async Task AnalyzeSelectedProjectsAsync(bool includeDependencies)
+        public async void AnalyzeSelectedProjectsAsync(bool includeDependencies)
         {
             var projects = GetSelectedProjects();
 
-            await AnalyzeProjectsAsync(includeDependencies ? GetTransitiveReferences(projects, new HashSet<Project>()) : projects);
+            await AnalyzeProjectsAsync(includeDependencies ? GetTransitiveReferences(projects, new HashSet<Project>()) : projects).ConfigureAwait(false);
         }
 
         public async void SolutionContextMenuItemCallback(object sender, EventArgs e)
         {
-            await AnalyzeProjectsAsync(_dte.Solution.GetProjects().Where(x => x.IsDotNetProject()).ToList());
+            await AnalyzeProjectsAsync(_dte.Solution.GetProjects().Where(x => x.IsDotNetProject()).ToList()).ConfigureAwait(false);
         }
 
         private async Task AnalyzeProjectsAsync(ICollection<Project> projects)
@@ -128,7 +128,7 @@ namespace ApiPortVS
                 {
                     var fileListAnalyzer = innerScope.Resolve<FileListAnalyzer>();
 
-                    await fileListAnalyzer.AnalyzeProjectAsync(inputAssemblyPaths);
+                    await fileListAnalyzer.AnalyzeProjectAsync(inputAssemblyPaths).ConfigureAwait(false);
                 }
             }
             catch (PortabilityAnalyzerException ex)
@@ -165,7 +165,7 @@ namespace ApiPortVS
 
         private async Task WriteHeaderAsync()
         {
-            await _output.ClearWindowAsync();
+            await _output.ClearWindowAsync().ConfigureAwait(false);
 
             var header = new StringBuilder();
             var assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version;

--- a/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
+++ b/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
@@ -272,6 +272,7 @@
     <Compile Include="AnalysisOptions.cs" />
     <Compile Include="Analyze\IVsApiPortAnalyzer.cs" />
     <Compile Include="AssemblyRedirectResolver.cs" />
+    <Compile Include="IVsHierarchyExtensions.cs" />
     <Compile Include="Properties\Properties.cs" />
     <Compile Include="Reporting\IResultToolbar.cs" />
     <Compile Include="Reporting\ToolbarListReportViewer.cs" />

--- a/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
+++ b/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Microsoft.CodeQuality.Analyzers.2.0.0-beta2\build\Microsoft.CodeQuality.Analyzers.props" Condition="Exists('..\..\packages\Microsoft.CodeQuality.Analyzers.2.0.0-beta2\build\Microsoft.CodeQuality.Analyzers.props')" />
   <Import Project="..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props')" />
   <Import Project="..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" Condition="Exists('..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" />
   <PropertyGroup>
@@ -9,6 +10,8 @@
     <UseCodebase>true</UseCodebase>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <!--Enables Microsoft.CodeQuality.Analyzers -->
+    <Features>IOperation</Features>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
@@ -433,7 +436,11 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\Microsoft.CodeQuality.Analyzers.2.0.0-beta2\analyzers\dotnet\cs\Analyzer.Utilities.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeQuality.Analyzers.2.0.0-beta2\analyzers\dotnet\cs\Microsoft.CodeQuality.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeQuality.Analyzers.2.0.0-beta2\analyzers\dotnet\cs\Microsoft.CodeQuality.CSharp.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
@@ -448,6 +455,7 @@
     <Error Condition="!Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.SDK.VsixSuppression.14.1.32\build\Microsoft.VisualStudio.SDK.VsixSuppression.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VisualStudio.SDK.VsixSuppression.14.1.32\build\Microsoft.VisualStudio.SDK.VsixSuppression.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.CodeQuality.Analyzers.2.0.0-beta2\build\Microsoft.CodeQuality.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeQuality.Analyzers.2.0.0-beta2\build\Microsoft.CodeQuality.Analyzers.props'))" />
   </Target>
   <Import Project="..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
   <Import Project="..\..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.4\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.4\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />

--- a/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
+++ b/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
@@ -7,6 +7,8 @@
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <UseCodebase>true</UseCodebase>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
@@ -91,6 +93,12 @@
     <Reference Include="Microsoft.Net.Http.Headers, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Net.Http.Headers.1.1.1\lib\netstandard1.1\Microsoft.Net.Http.Headers.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Composition, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Composition.15.0.70\lib\net45\Microsoft.VisualStudio.Composition.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Composition.Configuration, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Composition.15.0.70\lib\net45\Microsoft.VisualStudio.Composition.Configuration.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.CoreUtility.15.0.26201\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
       <Private>True</Private>
@@ -102,6 +110,16 @@
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6070\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.ProjectSystem, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.ProjectSystem.15.0.751\lib\net46\Microsoft.VisualStudio.ProjectSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.ProjectSystem.Interop, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.ProjectSystem.15.0.751\lib\net46\Microsoft.VisualStudio.ProjectSystem.Interop.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.ProjectSystem.VS, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.ProjectSystem.15.0.751\lib\net46\Microsoft.VisualStudio.ProjectSystem.VS.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.14.0.14.3.25407\lib\Microsoft.VisualStudio.Shell.14.0.dll</HintPath>
@@ -194,10 +212,29 @@
     <Reference Include="System.Buffers, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Buffers.4.3.0\lib\netstandard1.1\System.Buffers.dll</HintPath>
     </Reference>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Collections.NonGeneric, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.NonGeneric.4.3.0\lib\net46\System.Collections.NonGeneric.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.Convention, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.Hosting, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.Runtime, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.TypedParts, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
+    </Reference>
     <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
     </Reference>
@@ -252,6 +289,10 @@
     </Reference>
     <Reference Include="System.Text.Encodings.Web, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Text.Encodings.Web.4.3.0\lib\netstandard1.0\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.24.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
@@ -351,6 +392,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
@@ -405,8 +447,10 @@
     <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.4\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.4\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudio.SDK.VsixSuppression.14.1.32\build\Microsoft.VisualStudio.SDK.VsixSuppression.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VisualStudio.SDK.VsixSuppression.14.1.32\build\Microsoft.VisualStudio.SDK.VsixSuppression.targets'))" />
   </Target>
   <Import Project="..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
   <Import Project="..\..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.4\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets" Condition="Exists('..\..\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.4\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets')" />
   <Import Project="..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\..\packages\Microsoft.VSSDK.BuildTools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets')" />
+  <Import Project="..\..\packages\Microsoft.VisualStudio.SDK.VsixSuppression.14.1.32\build\Microsoft.VisualStudio.SDK.VsixSuppression.targets" Condition="Exists('..\..\packages\Microsoft.VisualStudio.SDK.VsixSuppression.14.1.32\build\Microsoft.VisualStudio.SDK.VsixSuppression.targets')" />
 </Project>

--- a/src/ApiPort.VisualStudio/ApiPortVSPackage.cs
+++ b/src/ApiPort.VisualStudio/ApiPortVSPackage.cs
@@ -68,7 +68,7 @@ namespace ApiPortVS
                 mcs.AddCommand(analyzeMenuOptionsItem);
 
                 CommandID analyzeMenuToolbarCommandID = new CommandID(Guids.AnalyzeMenuItemCmdSet, (int)PkgCmdIDList.CmdIdAnalyzeToolbarMenuItem);
-                MenuCommand analyzeMenuToolbarItem = new MenuCommand((_, __) => ShowToolbar(), analyzeMenuToolbarCommandID);
+                MenuCommand analyzeMenuToolbarItem = new MenuCommand(async (_, __) => await ShowToolbarAsync(), analyzeMenuToolbarCommandID);
                 mcs.AddCommand(analyzeMenuToolbarItem);
 
                 // Add menu items for Project context menus
@@ -100,8 +100,12 @@ namespace ApiPortVS
             }
         }
 
-        public void ShowToolbar()
+        public async System.Threading.Tasks.Task ShowToolbarAsync()
         {
+            // Calls to UI elements should use the main task thread.
+            // https://blogs.msdn.microsoft.com/andrewarnottms/2014/05/07/asynchronous-and-multithreaded-programming-within-vs-using-the-joinabletaskfactory/
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
             ToolWindowPane window = FindToolWindow(typeof(AnalysisOutputToolWindow), 0, true);
             if ((null == window) || (null == window.Frame))
             {

--- a/src/ApiPort.VisualStudio/ApiPortVSPackage.cs
+++ b/src/ApiPort.VisualStudio/ApiPortVSPackage.cs
@@ -68,17 +68,17 @@ namespace ApiPortVS
                 mcs.AddCommand(analyzeMenuOptionsItem);
 
                 CommandID analyzeMenuToolbarCommandID = new CommandID(Guids.AnalyzeMenuItemCmdSet, (int)PkgCmdIDList.CmdIdAnalyzeToolbarMenuItem);
-                MenuCommand analyzeMenuToolbarItem = new MenuCommand(async (_, __) => await ShowToolbarAsync(), analyzeMenuToolbarCommandID);
+                MenuCommand analyzeMenuToolbarItem = new MenuCommand(async (_, __) => await ShowToolbarAsync().ConfigureAwait(false), analyzeMenuToolbarCommandID);
                 mcs.AddCommand(analyzeMenuToolbarItem);
 
                 // Add menu items for Project context menus
                 CommandID projectContextMenuCmdId = new CommandID(Guids.ProjectContextMenuItemCmdSet, (int)PkgCmdIDList.CmdIdProjectContextMenuItem);
-                OleMenuCommand contextMenuItem = new OleMenuCommand(async (_, __) => await menuInitializer.AnalyzeSelectedProjectsAsync(false), projectContextMenuCmdId);
+                OleMenuCommand contextMenuItem = new OleMenuCommand((_, __) => menuInitializer.AnalyzeSelectedProjectsAsync(false), projectContextMenuCmdId);
                 contextMenuItem.BeforeQueryStatus += menuInitializer.ProjectContextMenuItemBeforeQueryStatus;
                 mcs.AddCommand(contextMenuItem);
 
                 CommandID projectContextMenuDependentsCmdId = new CommandID(Guids.ProjectContextMenuItemCmdSet, (int)PkgCmdIDList.CmdIdProjectContextDependentsMenuItem);
-                OleMenuCommand contextMenuDependentsItem = new OleMenuCommand(async (_, __) => await menuInitializer.AnalyzeSelectedProjectsAsync(true), projectContextMenuDependentsCmdId);
+                OleMenuCommand contextMenuDependentsItem = new OleMenuCommand((_, __) => menuInitializer.AnalyzeSelectedProjectsAsync(true), projectContextMenuDependentsCmdId);
                 contextMenuDependentsItem.BeforeQueryStatus += menuInitializer.ProjectContextMenuDependenciesItemBeforeQueryStatus;
                 mcs.AddCommand(contextMenuDependentsItem);
 

--- a/src/ApiPort.VisualStudio/Constants.cs
+++ b/src/ApiPort.VisualStudio/Constants.cs
@@ -25,5 +25,52 @@
             public const string vsCMLanguageVB = "{B5E9BD33-6D3E-4B5D-925E-8A43B79820B4}";
             public const string vsCMLanguageCSharp = "{B5E9BD34-6D3E-4B5D-925E-8A43B79820B4}";
         }
+
+        /// <summary>
+        /// A set of well-known output group names.
+        /// </summary>
+        internal static class OutputGroups
+        {
+            /// <summary>
+            /// MSBuild .targets file string for BuiltProjectOutputGroup.
+            /// </summary>
+            internal const string BuiltProject = "Built";
+        }
+
+        /// <summary>
+        /// A set of well-known output group item metadata names.
+        /// </summary>
+        internal static class MetadataNames
+        {
+            /// <summary>
+            /// MSBuild .targets file string for FinalOutputPath.
+            /// </summary>
+            internal const string FinalOutputPath = nameof(FinalOutputPath);
+
+            /// <summary>
+            /// Metadata name for file output location
+            /// </summary>
+            internal const string OutputLocation = "OUTPUTLOC";
+        }
+
+        /// <summary>
+        /// Well-known project capabilities from:
+        /// https://github.com/Microsoft/VSProjectSystem/blob/master/doc/overview/project_capabilities.md
+        /// </summary>
+        internal static class ProjectCapabilities
+        {
+            /// <summary>
+            ///  Project is based on the Project System Extensibility SDK
+            /// </summary>
+            internal const string CPS = nameof(CPS);
+
+            /// <summary>
+            /// Indicates that the project is a typical MSBuild project (not DNX)
+            /// in that it declares source items in the project itself (rather
+            /// than a project.json file that assumes all files in the directory
+            /// are part of a compilation).
+            /// </summary>
+            internal const string DeclaredSourceItems = nameof(DeclaredSourceItems);
+        }
     }
 }

--- a/src/ApiPort.VisualStudio/Contracts/IReportViewer.cs
+++ b/src/ApiPort.VisualStudio/Contracts/IReportViewer.cs
@@ -2,11 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace ApiPortVS.Contracts
 {
     public interface IReportViewer
     {
-        void View(IEnumerable<string> urls);
+        Task ViewAsync(IEnumerable<string> urls);
     }
 }

--- a/src/ApiPort.VisualStudio/Contracts/ISourceMappedItem.cs
+++ b/src/ApiPort.VisualStudio/Contracts/ISourceMappedItem.cs
@@ -9,6 +9,8 @@ namespace ApiPortVS.Contracts
 {
     public interface ISourceMappedItem
     {
+        string Assembly { get; }
+
         MissingInfo Item { get; }
 
         IEnumerable<FrameworkName> UnsupportedTargets { get; }

--- a/src/ApiPort.VisualStudio/DteProjectExtensions.cs
+++ b/src/ApiPort.VisualStudio/DteProjectExtensions.cs
@@ -32,7 +32,12 @@ namespace ApiPortVS
         /// <returns>null if it is unable to retrieve VS configuration objects</returns>
         public static async Task<IEnumerable<string>> GetBuildOutputFilesAsync(this Project project, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var output = await project?.GetBuildOutputFilesFromCPSAsync(cancellationToken);
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            var output = await project.GetBuildOutputFilesFromCPSAsync(cancellationToken).ConfigureAwait(false);
 
             if (output != null)
             {

--- a/src/ApiPort.VisualStudio/DteProjectExtensions.cs
+++ b/src/ApiPort.VisualStudio/DteProjectExtensions.cs
@@ -1,15 +1,21 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using ApiPortVS.Resources;
 using EnvDTE;
-using Microsoft.Fx.Portability;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ApiPortVS
 {
@@ -17,58 +23,167 @@ namespace ApiPortVS
     {
         private const string FSharpProjectKindString = "{f2a71f9b-5d33-465a-a702-920d77279786}";
 
-        public static string GetBuildOutputFileName(this Project project)
+        /// <summary>
+        /// Tries to fetch output items if it uses Common Project System then
+        /// tries to fetch output items by retrieving FinalBuildOutput
+        /// location using code snippet from:
+        /// https://github.com/Microsoft/visualfsharp/blob/master/vsintegration/tests/unittests/Tests.ProjectSystem.Miscellaneous.fs#L168-L182
+        /// </summary>
+        /// <returns>null if it is unable to retrieve VS configuration objects</returns>
+        public static async Task<IEnumerable<string>> GetBuildOutputFilesAsync(this Project project, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var fileName = project.Properties.Item("OutputFileName").Value.ToString();
+            var output = await project?.GetBuildOutputFilesFromCPSAsync(cancellationToken);
 
-            return Path.Combine(project.GetBuildOutputPath(), fileName);
+            if (output != null)
+            {
+                return output;
+            }
+
+            var configuration = GetVsProjectConfiguration(project);
+
+            if (configuration == null)
+            {
+                return null;
+            }
+            if (!(configuration is IVsProjectCfg2))
+            {
+                Trace.TraceError($"IVsCfg returned {configuration.GetType()} is not of the right type. Expected: {nameof(IVsProjectCfg2)}");
+                return null;
+            }
+
+            var configuration2 = configuration as IVsProjectCfg2;
+
+            if (ErrorHandler.Failed(configuration2.OpenOutputGroup(Constants.OutputGroups.BuiltProject, out IVsOutputGroup outputGroup)))
+            {
+                Trace.TraceError($"Could not retrieve {nameof(IVsOutputGroup)} from project: {project.Name}");
+                return null;
+            }
+            if (!(outputGroup is IVsOutputGroup2))
+            {
+                Trace.TraceError($"Could not retrieve {nameof(IVsOutputGroup2)} from project: {project.Name}");
+                return null;
+            }
+
+            var outputGroup2 = (IVsOutputGroup2)outputGroup;
+
+            if (ErrorHandler.Failed(outputGroup2.get_KeyOutputObject(out IVsOutput2 keyGroup)))
+            {
+                Trace.TraceError($"Could not retrieve {nameof(IVsOutput2)} from project: {project.Name}");
+                return null;
+            }
+
+            if (ErrorHandler.Succeeded(keyGroup.get_Property(Constants.MetadataNames.OutputLocation, out object outputLoc)))
+            {
+                return new[] { outputLoc as string };
+            }
+
+            if (ErrorHandler.Succeeded(keyGroup.get_Property(Constants.MetadataNames.FinalOutputPath, out object finalOutputPath)))
+            {
+                return new[] { finalOutputPath as string };
+            }
+
+            return null;
         }
 
-        public static IEnumerable<string> GetAssemblyPaths(this Project project, Func<string, IEnumerable<string>> getAllDirectories = null)
+        public static IVsCfg GetVsProjectConfiguration(this Project project)
         {
-            if (getAllDirectories == null)
+            object browseObject = null;
+
+            project.GetHierarchy()?.GetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_BrowseObject, out browseObject);
+
+            var getConfigurationProvider = browseObject as IVsGetCfgProvider;
+
+            if (getConfigurationProvider == null)
             {
-                return new[] { project.GetBuildOutputFileName() };
+                Trace.TraceError($"Could not retrieve {nameof(IVsGetCfgProvider)} from project: {project.Name}");
+                return null;
             }
-            else
+
+            if (ErrorHandler.Failed(getConfigurationProvider.GetCfgProvider(out IVsCfgProvider provider)))
             {
-                var buildDir = project.GetBuildOutputPath();
-
-                var targetAssemblies = getAllDirectories(buildDir) ?? Enumerable.Empty<string>();
-
-                if (!targetAssemblies.Any())
-                {
-                    var message = string.Format(LocalizedStrings.NoAnalyzableAssemblies, buildDir);
-                    throw new FileNotFoundException(message);
-                }
-
-                return targetAssemblies;
+                Trace.TraceError($"Could not retrieve {nameof(IVsCfgProvider)} from project: {project.Name}");
+                return null;
             }
+            if (!(provider is IVsCfgProvider2))
+            {
+                Trace.TraceError($"IVsCfgProvider returned {provider.GetType()} is not of the right type. Expected: {nameof(IVsCfgProvider2)}");
+                return null;
+            }
+
+            var provider2 = (IVsCfgProvider2)provider;
+            var activeConfiguration = project.ConfigurationManager.ActiveConfiguration;
+
+            if (ErrorHandler.Failed(provider2.GetCfgOfName(activeConfiguration.ConfigurationName, activeConfiguration.PlatformName, out IVsCfg configuration)))
+            {
+                Trace.TraceError($"Could not retrieve {nameof(IVsCfg)} from project: {project.Name}");
+                return null;
+            }
+
+            return configuration;
         }
 
-        public static string GetBuildOutputPath(this Project project)
+        /// <summary>
+        /// Tries to fetch files if it is a project that uses the Common
+        /// Project System (CPS) extensibility model.
+        /// </summary>
+        /// <returns>null if it is unable to find any output items or this
+        /// project is not a CPS project.</returns>
+        private static async Task<IEnumerable<string>> GetBuildOutputFilesFromCPSAsync(
+            this Project project,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            try
+            if (project == null)
             {
-                var configMgr = project.ConfigurationManager as ConfigurationManager;
-                var activeCfg = configMgr.ActiveConfiguration as Configuration;
-
-                // This is the path displayed in project's Properties->Build->Output->Output path
-                // and may not be correct if the user's customized the build process elsewhere
-                var outputPath = activeCfg.Properties.Item("OutputPath").Value.ToString();
-
-                return Path.IsPathRooted(outputPath) ? outputPath
-                                                     : Path.Combine(project.GetProjectFileDirectory(), outputPath);
+                throw new ArgumentNullException(nameof(project));
             }
-            catch (Exception ex)
+
+            if (!project.GetHierarchy()?.IsCpsProject() ?? true)
             {
-                if (ex is NullReferenceException || ex is ArgumentException)
+                return null;
+            }
+
+            var unconfigured = project.GetUnconfiguredProject();
+
+            if (unconfigured == null)
+            {
+                return null;
+            }
+
+            // There are multiple loaded configurations for this project.
+            // This is true for .NET Core projects that multi-target.
+            // We'll return all those builds so APIPort can analyze them all.
+            var configuredProjects = unconfigured.LoadedConfiguredProjects;
+
+            if (configuredProjects?.Count() > 1)
+            {
+                var bag = new ConcurrentBag<string>();
+
+                foreach (var proj in configuredProjects)
                 {
-                    throw new PortabilityAnalyzerException(LocalizedStrings.FailedToLocateBuildOutputDir);
+                    var keyOutput = await proj.Services.OutputGroups.GetKeyOutputAsync(cancellationToken).ConfigureAwait(false);
+                    bag.Add(keyOutput);
                 }
 
-                throw;
+                return bag;
             }
+
+            // This is a typical CPS project that builds one component at a time.
+            var configured = await unconfigured.GetSuggestedConfiguredProjectAsync().ConfigureAwait(false);
+
+            if (configured == null)
+            {
+                return null;
+            }
+
+            var outputGroupsService = configured.Services.OutputGroups;
+            var keyOutputFile = await outputGroupsService.GetKeyOutputAsync(cancellationToken).ConfigureAwait(false);
+
+            return new[] { keyOutputFile };
+        }
+
+        private static UnconfiguredProject GetUnconfiguredProject(this Project project)
+        {
+            return (project as IVsBrowseObjectContext)?.UnconfiguredProject;
         }
 
         public static string GetProjectFileDirectory(this Project project)

--- a/src/ApiPort.VisualStudio/DteProjectExtensions.cs
+++ b/src/ApiPort.VisualStudio/DteProjectExtensions.cs
@@ -50,26 +50,24 @@ namespace ApiPortVS
             {
                 return null;
             }
-            if (!(configuration is IVsProjectCfg2))
+
+            if (!(configuration is IVsProjectCfg2 configuration2))
             {
                 Trace.TraceError($"IVsCfg returned {configuration.GetType()} is not of the right type. Expected: {nameof(IVsProjectCfg2)}");
                 return null;
             }
-
-            var configuration2 = configuration as IVsProjectCfg2;
 
             if (ErrorHandler.Failed(configuration2.OpenOutputGroup(Constants.OutputGroups.BuiltProject, out IVsOutputGroup outputGroup)))
             {
                 Trace.TraceError($"Could not retrieve {nameof(IVsOutputGroup)} from project: {project.Name}");
                 return null;
             }
-            if (!(outputGroup is IVsOutputGroup2))
+
+            if (!(outputGroup is IVsOutputGroup2 outputGroup2))
             {
                 Trace.TraceError($"Could not retrieve {nameof(IVsOutputGroup2)} from project: {project.Name}");
                 return null;
             }
-
-            var outputGroup2 = (IVsOutputGroup2)outputGroup;
 
             if (ErrorHandler.Failed(outputGroup2.get_KeyOutputObject(out IVsOutput2 keyGroup)))
             {

--- a/src/ApiPort.VisualStudio/IVsHierarchyExtensions.cs
+++ b/src/ApiPort.VisualStudio/IVsHierarchyExtensions.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+
+namespace ApiPortVS
+{
+    internal static class IVsHierarchyExtensions
+    {
+        /// <summary>
+        /// Detects if a project uses the Common Project System Extension model.
+        /// https://github.com/Microsoft/VSProjectSystem/blob/master/doc/automation/detect_whether_a_project_is_a_CPS_project.md
+        /// </summary>
+        internal static bool IsCpsProject(this IVsHierarchy project)
+        {
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            return project.IsCapabilityMatch(Constants.ProjectCapabilities.CPS);
+        }
+
+        /// <summary>
+        /// Capability inferring that the project uses project.json to manage its source items.
+        /// https://github.com/Microsoft/VSProjectSystem/blob/master/doc/overview/project_capabilities.md
+        /// </summary>
+        private static bool IsDnxProject(this IVsHierarchy project)
+        {
+            return !project.IsCapabilityMatch(Constants.ProjectCapabilities.DeclaredSourceItems);
+        }
+    }
+}

--- a/src/ApiPort.VisualStudio/OutputWindowWriter.cs
+++ b/src/ApiPort.VisualStudio/OutputWindowWriter.cs
@@ -8,6 +8,9 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
+
+using VisualStudio = Microsoft.VisualStudio.Shell;
 
 namespace ApiPortVS
 {
@@ -26,8 +29,10 @@ namespace ApiPortVS
 
         public override Encoding Encoding { get { return Encoding.UTF8; } }
 
-        public void ShowWindow()
+        public async Task ShowWindowAsync()
         {
+            await VisualStudio.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
             _outputWindow.Activate();
 
             try

--- a/src/ApiPort.VisualStudio/OutputWindowWriter.cs
+++ b/src/ApiPort.VisualStudio/OutputWindowWriter.cs
@@ -43,6 +43,12 @@ namespace ApiPortVS
             catch (Exception) { }
         }
 
+        public async Task ClearWindowAsync()
+        {
+            await VisualStudio.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            _outputWindow.Clear();
+        }
+
         public override void Write(char text)
         {
             var errCode = _outputWindow.OutputStringThreadSafe(text.ToString());

--- a/src/ApiPort.VisualStudio/Reporting/IResultToolbar.cs
+++ b/src/ApiPort.VisualStudio/Reporting/IResultToolbar.cs
@@ -1,7 +1,9 @@
-﻿namespace ApiPortVS.Reporting
+﻿using System.Threading.Tasks;
+
+namespace ApiPortVS.Reporting
 {
     internal interface IResultToolbar
     {
-        void ShowToolbar();
+        Task ShowToolbarAsync();
     }
 }

--- a/src/ApiPort.VisualStudio/Reporting/ToolbarListReportViewer.cs
+++ b/src/ApiPort.VisualStudio/Reporting/ToolbarListReportViewer.cs
@@ -4,6 +4,9 @@
 using ApiPortVS.Contracts;
 using ApiPortVS.ViewModels;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using VisualStudio = Microsoft.VisualStudio.Shell;
 
 namespace ApiPortVS.Reporting
 {
@@ -18,9 +21,11 @@ namespace ApiPortVS.Reporting
             _toolbar = toolbar;
         }
 
-        public void View(IEnumerable<string> urls)
+        public async Task ViewAsync(IEnumerable<string> urls)
         {
-            _toolbar.ShowToolbar();
+            await _toolbar.ShowToolbarAsync().ConfigureAwait(false);
+
+            await VisualStudio.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             foreach (var url in urls)
             {

--- a/src/ApiPort.VisualStudio/Reporting/VsBrowserReportViewer.cs
+++ b/src/ApiPort.VisualStudio/Reporting/VsBrowserReportViewer.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace ApiPortVS.Reporting
 {
@@ -25,13 +26,13 @@ namespace ApiPortVS.Reporting
             _browserService = webBrowsingService;
         }
 
-        public void View(IEnumerable<string> urls)
+        public async Task ViewAsync(IEnumerable<string> urls)
         {
             foreach (var url in urls)
             {
                 if (IsHtml(url))
                 {
-                    ShowHtml(url);
+                    await ShowHtmlAsync(url);
                 }
                 else
                 {
@@ -48,9 +49,11 @@ namespace ApiPortVS.Reporting
                 || string.Equals(".htm", extension, StringComparison.OrdinalIgnoreCase);
         }
 
-        private void ShowHtml(string url)
+        private async Task ShowHtmlAsync(string url)
         {
             const uint REUSE_EXISTING_BROWSER_IF_AVAILABLE = 0;
+
+            await Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             if (!_fileSystem.FileExists(url))
             {

--- a/src/ApiPort.VisualStudio/Reporting/VsBrowserReportViewer.cs
+++ b/src/ApiPort.VisualStudio/Reporting/VsBrowserReportViewer.cs
@@ -32,7 +32,7 @@ namespace ApiPortVS.Reporting
             {
                 if (IsHtml(url))
                 {
-                    await ShowHtmlAsync(url);
+                    await ShowHtmlAsync(url).ConfigureAwait(false);
                 }
                 else
                 {

--- a/src/ApiPort.VisualStudio/Resources/LocalizedStrings.Designer.cs
+++ b/src/ApiPort.VisualStudio/Resources/LocalizedStrings.Designer.cs
@@ -179,7 +179,7 @@ namespace ApiPortVS.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to locate build output directory..
+        ///   Looks up a localized string similar to Failed to locate build output files..
         /// </summary>
         public static string FailedToLocateBuildOutputDir {
             get {

--- a/src/ApiPort.VisualStudio/Resources/LocalizedStrings.Designer.cs
+++ b/src/ApiPort.VisualStudio/Resources/LocalizedStrings.Designer.cs
@@ -404,6 +404,21 @@ namespace ApiPortVS.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to         Source line information for portable pdbs is not currently supported.
+        ///        Add the following code to: {0}&apos;s
+        ///        project (ie. *.csproj or *.fsproj) and try again.
+        ///
+        ///        &lt;PropertyGroup&gt;
+        ///          &lt;DebugType&gt;Full&lt;/DebugType&gt;
+        ///        &lt;/PropertyGroup&gt;.
+        /// </summary>
+        public static string SourceLineMappingNotSupportedPortablePdb {
+            get {
+                return ResourceManager.GetString("SourceLineMappingNotSupportedPortablePdb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Submission ID:.
         /// </summary>
         public static string SubmissionId {

--- a/src/ApiPort.VisualStudio/Resources/LocalizedStrings.resx
+++ b/src/ApiPort.VisualStudio/Resources/LocalizedStrings.resx
@@ -288,4 +288,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.</value>
   <data name="ReportNotAvailable" xml:space="preserve">
     <value>The report is not available. It may have been deleted.</value>
   </data>
+  <data name="SourceLineMappingNotSupportedPortablePdb" xml:space="preserve">
+    <value>        Source line information for portable pdbs is not currently supported.
+        Add the following code to: {0}'s
+        project (ie. *.csproj or *.fsproj) and try again.
+
+        &lt;PropertyGroup&gt;
+          &lt;DebugType&gt;Full&lt;/DebugType&gt;
+        &lt;/PropertyGroup&gt;</value>
+    <comment>Due to an OutOfMemoryException thrown when trying to parse portable pdb files.
+https://github.com/icsharpcode/ILSpy/issues/789
+There is no public build for https://github.com/Microsoft/cci yet, which supports it.
+    </comment>
+  </data>
 </root>

--- a/src/ApiPort.VisualStudio/Resources/LocalizedStrings.resx
+++ b/src/ApiPort.VisualStudio/Resources/LocalizedStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -245,7 +245,7 @@
     <value>Using default target platforms.</value>
   </data>
   <data name="FailedToLocateBuildOutputDir" xml:space="preserve">
-    <value>Failed to locate build output directory.</value>
+    <value>Failed to locate build output files.</value>
   </data>
   <data name="CopyrightFormat" xml:space="preserve">
     <value>Microsoft (R) .NET Portability Analyzer {0} (alpha)

--- a/src/ApiPort.VisualStudio/SourceMapping/CciMetadataTraverser.cs
+++ b/src/ApiPort.VisualStudio/SourceMapping/CciMetadataTraverser.cs
@@ -155,7 +155,6 @@ namespace ApiPortVS.SourceMapping
             private readonly int _column;
             private readonly int _line;
             private readonly string _path;
-            private readonly string _assembly;
 
             public CciSourceItem(string assembly, IPrimarySourceLocation location, MissingInfo item, IEnumerable<FrameworkName> unsupportedPlatformNames)
             {

--- a/src/ApiPort.VisualStudio/SourceMapping/CciMetadataTraverser.cs
+++ b/src/ApiPort.VisualStudio/SourceMapping/CciMetadataTraverser.cs
@@ -25,9 +25,11 @@ namespace ApiPortVS.SourceMapping
         private readonly IDictionary<string, MissingTypeInfo> _interestingTypes;
         private readonly ReportingResult _analysis;
         private readonly PdbReader _pdbReader;
+        private readonly string _assemblyPath;
 
-        public CciMetadataTraverser(ReportingResult analysis, PdbReader pdbReader)
+        public CciMetadataTraverser(string assemblyPath, ReportingResult analysis, PdbReader pdbReader)
         {
+            _assemblyPath = assemblyPath;
             _analysis = analysis;
             _pdbReader = pdbReader;
 
@@ -142,7 +144,7 @@ namespace ApiPortVS.SourceMapping
         {
             var unsupportedPlatformNames = GetUnsupportedPlatformNames(GetTargetStatus(memberInfo));
 
-            return new CciSourceItem(location, memberInfo, unsupportedPlatformNames);
+            return new CciSourceItem(_assemblyPath, location, memberInfo, unsupportedPlatformNames);
         }
 
         [DebuggerDisplay("{_item}")]
@@ -153,9 +155,11 @@ namespace ApiPortVS.SourceMapping
             private readonly int _column;
             private readonly int _line;
             private readonly string _path;
+            private readonly string _assembly;
 
-            public CciSourceItem(IPrimarySourceLocation location, MissingInfo item, IEnumerable<FrameworkName> unsupportedPlatformNames)
+            public CciSourceItem(string assembly, IPrimarySourceLocation location, MissingInfo item, IEnumerable<FrameworkName> unsupportedPlatformNames)
             {
+                Assembly = assembly;
                 _column = location.StartColumn;
                 _line = location.StartLine;
                 _path = location.SourceDocument.Location;
@@ -174,6 +178,8 @@ namespace ApiPortVS.SourceMapping
             public int Line { get { return _line; } }
 
             public string Path { get { return _path; } }
+
+            public string Assembly { get; }
         }
     }
 }

--- a/src/ApiPort.VisualStudio/SourceMapping/CciSourceLineMapper.cs
+++ b/src/ApiPort.VisualStudio/SourceMapping/CciSourceLineMapper.cs
@@ -24,7 +24,7 @@ namespace ApiPortVS.SourceMapping
             using (var pdbFs = File.OpenRead(pdbPath))
             using (var pdbReader = new PdbReader(pdbFs, host))
             {
-                var metadataVisitor = new CciMetadataTraverser(report, pdbReader);
+                var metadataVisitor = new CciMetadataTraverser(assemblyPath, report, pdbReader);
                 var traverser = new MetadataTraverser
                 {
                     PreorderVisitor = metadataVisitor,

--- a/src/ApiPort.VisualStudio/ViewModels/OptionsViewModel.cs
+++ b/src/ApiPort.VisualStudio/ViewModels/OptionsViewModel.cs
@@ -111,8 +111,8 @@ namespace ApiPortVS.ViewModels
 
             try
             {
-                await UpdateTargetsAsync();
-                await UpdateResultsAsync();
+                await UpdateTargetsAsync().ConfigureAwait(false);
+                await UpdateResultsAsync().ConfigureAwait(false);
 
                 _optionsModel.LastUpdate = DateTimeOffset.Now;
 
@@ -130,7 +130,7 @@ namespace ApiPortVS.ViewModels
 
         private async Task UpdateResultsAsync()
         {
-            var formats = await _apiPortService.GetResultFormatsAsync();
+            var formats = await _apiPortService.GetResultFormatsAsync().ConfigureAwait(false);
             var current = new HashSet<string>(Formats.Where(f => f.IsSelected).Select(f => f.MimeType), StringComparer.OrdinalIgnoreCase);
 
             if (current.Count == 0)
@@ -155,7 +155,7 @@ namespace ApiPortVS.ViewModels
         /// <returns>Targets that were removed</returns>
         private async Task UpdateTargetsAsync()
         {
-            var targets = await GetTargetsAsync();
+            var targets = await GetTargetsAsync().ConfigureAwait(false);
             var canonicalPlatforms = targets.GroupBy(t => t.Name).Select(t =>
             {
                 return new TargetPlatform
@@ -207,7 +207,7 @@ namespace ApiPortVS.ViewModels
 
         private async Task<IEnumerable<AvailableTarget>> GetTargetsAsync()
         {
-            var allTargetInfos = await _apiPortService.GetTargetsAsync();
+            var allTargetInfos = await _apiPortService.GetTargetsAsync().ConfigureAwait(false);
 
             // We don't want any grouped targets as that option only makes sense for command line
             var targetInfos = allTargetInfos.Response.Where(t => !t.ExpandedTargets.Any());

--- a/src/ApiPort.VisualStudio/Views/OptionsPageControl.xaml.cs
+++ b/src/ApiPort.VisualStudio/Views/OptionsPageControl.xaml.cs
@@ -24,7 +24,7 @@ namespace ApiPortVS.Views
             DataContext = viewModel;
             GuidanceLink.NavigateUri = new Uri(LocalizedStrings.MoreInformationUrl);
 
-            Loaded += async (s, e) => await viewModel.UpdateAsync();
+            Loaded += async (s, e) => await viewModel.UpdateAsync().ConfigureAwait(false);
             Unloaded += (s, e) => viewModel.Save();
         }
 
@@ -35,7 +35,7 @@ namespace ApiPortVS.Views
 
         private async void RefreshRequested(object sender, RoutedEventArgs e)
         {
-            await ViewModel.UpdateAsync(force: true);
+            await ViewModel.UpdateAsync(force: true).ConfigureAwait(false);
         }
 
         private void UpdateDirectoryClick(object sender, RoutedEventArgs e)

--- a/src/ApiPort.VisualStudio/app.config
+++ b/src/ApiPort.VisualStudio/app.config
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.NonGeneric" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Utilities" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Imaging" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.CoreUtility" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.1.0.0" newVersion="15.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/ApiPort.VisualStudio/packages.config
+++ b/src/ApiPort.VisualStudio/packages.config
@@ -6,6 +6,7 @@
   <package id="Microsoft.Build" version="15.1.548" targetFramework="net46" />
   <package id="Microsoft.Build.Framework" version="15.1.548" targetFramework="net46" />
   <package id="Microsoft.Cci" version="4.0.0-rc3-24214-00" targetFramework="net46" />
+  <package id="Microsoft.CodeQuality.Analyzers" version="2.0.0-beta2" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
   <package id="Microsoft.Extensions.Primitives" version="1.1.0" targetFramework="net46" />
   <package id="Microsoft.Net.Http.Headers" version="1.1.1" targetFramework="net46" />

--- a/src/ApiPort.VisualStudio/packages.config
+++ b/src/ApiPort.VisualStudio/packages.config
@@ -6,13 +6,18 @@
   <package id="Microsoft.Build" version="15.1.548" targetFramework="net46" />
   <package id="Microsoft.Build.Framework" version="15.1.548" targetFramework="net46" />
   <package id="Microsoft.Cci" version="4.0.0-rc3-24214-00" targetFramework="net46" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
   <package id="Microsoft.Extensions.Primitives" version="1.1.0" targetFramework="net46" />
   <package id="Microsoft.Net.Http.Headers" version="1.1.1" targetFramework="net46" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net46" />
+  <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Composition" version="15.0.70" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.26201" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Imaging" version="15.0.26201" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.ProjectSystem" version="15.0.751" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.SDK.EmbedInteropTypes" version="15.0.4" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.SDK.VsixSuppression" version="14.1.32" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Shell.14.0" version="14.3.25407" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Shell.Framework" version="15.0.26201" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Shell.Immutable.10.0" version="10.0.30319" targetFramework="net46" />
@@ -39,6 +44,7 @@
   <package id="System.Buffers" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
   <package id="System.Collections.NonGeneric" version="4.3.0" targetFramework="net46" />
   <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Contracts" version="4.3.0" targetFramework="net46" />

--- a/src/ApiPort.Vsix/ApiPort.Vsix.csproj
+++ b/src/ApiPort.Vsix/ApiPort.Vsix.csproj
@@ -38,6 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DeployExtension>True</DeployExtension>
+    <CreateVsixContainer>True</CreateVsixContainer>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/ApiPort.Vsix/ApiPort.Vsix.csproj
+++ b/src/ApiPort.Vsix/ApiPort.Vsix.csproj
@@ -52,6 +52,7 @@
     <IsPackage>true</IsPackage>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>

--- a/src/ApiPort.Vsix/ApiPort.Vsix.csproj
+++ b/src/ApiPort.Vsix/ApiPort.Vsix.csproj
@@ -29,6 +29,10 @@
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <CreateVsixContainer>True</CreateVsixContainer>
+
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/ApiPort.Vsix/app.config
+++ b/src/ApiPort.Vsix/app.config
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.NonGeneric" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Utilities" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Imaging" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.CoreUtility" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.1.0.0" newVersion="15.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/ApiPortVS.Tests/ApiPortVS.Tests.csproj
+++ b/tests/ApiPortVS.Tests/ApiPortVS.Tests.csproj
@@ -137,6 +137,7 @@
     <Compile Include="TestAssemblyFile.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/ApiPortVS.Tests/app.config
+++ b/tests/ApiPortVS.Tests/app.config
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Utilities" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Imaging" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.CoreUtility" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.NonGeneric" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.1.0.0" newVersion="15.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
* Fixes output path determination for projects. Before we would look for at a project for `<OutputFileName>` and stop if that property could not be determined.
* Supports .NET Core projects now. (Need to verify for project.json projects in VS2015.)
  * **Caveat**:  Released version Microsoft.Cci does not support portable PDB file structure, so it throws an OOM. As a result, I had to add this output window as a workaround... for now.  The repository has support for portable PDB, but I have no idea where the latest builds are. There is an issue here to get the builds: Microsoft/cci#46.
![image](https://cloud.githubusercontent.com/assets/10136526/26428665/cb5c7f1a-4097-11e7-8b8e-c290cfd20df1.png)
* Supports showing the proper projects for source line information. (Before, it would show the first project for all the source line information.)
![image](https://cloud.githubusercontent.com/assets/10136526/26428531/1354ad20-4097-11e7-8d97-ed8dc59f0e98.png)
* Fixes UI hangs due to async/await.  As a result, I used the ThreadHelper from this blog and ConfigureAwait(false): https://blogs.msdn.microsoft.com/andrewarnottms/2014/05/07/asynchronous-and-multithreaded-programming-within-vs-using-the-joinabletaskfactory/

Possibly fixes #429
Fixes #397, #390 

/cc: @twsouthwick 
