### PR TITLE
Fix Html Report Generation

### DIFF
--- a/PortabilityTools.sln
+++ b/PortabilityTools.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26214.1
+VisualStudioVersion = 15.0.26530.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C991F5FC-04B5-420C-98A0-80974AA946F7}"
 	ProjectSection(SolutionItems) = preProject
@@ -64,6 +64,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiPortVS.Tests", "tests\ApiPortVS.Tests\ApiPortVS.Tests.csproj", "{2D8DA586-E0EA-4AD1-BA3C-E4AC0310A45E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Fx.Portability.Cci.Tests", "tests\Microsoft.Fx.Portability.Cci.Tests\Microsoft.Fx.Portability.Cci.Tests.csproj", "{6917BF09-E416-43F9-B184-4691AF473271}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Fx.Portability.Reports.Html.Tests", "tests\Microsoft.Fx.Portability.Reports.Html.Tests\Microsoft.Fx.Portability.Reports.Html.Tests.csproj", "{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -741,6 +743,54 @@ Global
 		{6917BF09-E416-43F9-B184-4691AF473271}.Ubuntu_Release|x64.Build.0 = Release|Any CPU
 		{6917BF09-E416-43F9-B184-4691AF473271}.Ubuntu_Release|x86.ActiveCfg = Release|Any CPU
 		{6917BF09-E416-43F9-B184-4691AF473271}.Ubuntu_Release|x86.Build.0 = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Debug|ARM.Build.0 = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Debug|x64.Build.0 = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Debug|x86.Build.0 = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Osx_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Osx_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Osx_Debug|ARM.ActiveCfg = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Osx_Debug|ARM.Build.0 = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Osx_Debug|x64.ActiveCfg = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Osx_Debug|x64.Build.0 = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Osx_Debug|x86.ActiveCfg = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Osx_Debug|x86.Build.0 = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Osx_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Osx_Release|Any CPU.Build.0 = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Osx_Release|ARM.ActiveCfg = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Osx_Release|ARM.Build.0 = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Osx_Release|x64.ActiveCfg = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Osx_Release|x64.Build.0 = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Osx_Release|x86.ActiveCfg = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Osx_Release|x86.Build.0 = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Release|ARM.ActiveCfg = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Release|ARM.Build.0 = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Release|x64.ActiveCfg = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Release|x64.Build.0 = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Release|x86.ActiveCfg = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Release|x86.Build.0 = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Ubuntu_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Ubuntu_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Ubuntu_Debug|ARM.ActiveCfg = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Ubuntu_Debug|ARM.Build.0 = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Ubuntu_Debug|x64.ActiveCfg = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Ubuntu_Debug|x64.Build.0 = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Ubuntu_Debug|x86.ActiveCfg = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Ubuntu_Debug|x86.Build.0 = Debug|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Ubuntu_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Ubuntu_Release|Any CPU.Build.0 = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Ubuntu_Release|ARM.ActiveCfg = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Ubuntu_Release|ARM.Build.0 = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Ubuntu_Release|x64.ActiveCfg = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Ubuntu_Release|x64.Build.0 = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Ubuntu_Release|x86.ActiveCfg = Release|Any CPU
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}.Ubuntu_Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -763,5 +813,6 @@ Global
 		{B0468D19-0F98-49A8-BA28-926331C72E26} = {6234AABE-C4F3-4094-9C0D-FFD589235DBE}
 		{2D8DA586-E0EA-4AD1-BA3C-E4AC0310A45E} = {7DC7AA2C-0401-495B-B42C-32F44085EBE6}
 		{6917BF09-E416-43F9-B184-4691AF473271} = {7DC7AA2C-0401-495B-B42C-32F44085EBE6}
+		{4EDE5B41-A4AD-4BFB-9986-F566FB887A34} = {7DC7AA2C-0401-495B-B42C-32F44085EBE6}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
@@ -61,8 +61,7 @@ namespace Microsoft.Fx.Portability.Reports
 
         private static string Resolve(string name)
         {
-            var fullName = $"Microsoft.Fx.Portability.Reports.Resources.{name}.cshtml";
-            var names = typeof(HtmlReportWriter).GetTypeInfo().Assembly.GetManifestResourceNames();
+            var fullName = $"{typeof(HtmlReportWriter).Assembly.GetName().Name}.Resources.{name}.cshtml";
             using (var template = typeof(HtmlReportWriter).GetTypeInfo().Assembly.GetManifestResourceStream(fullName))
             {
                 if (template == default(Stream))

--- a/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Reflection;
 using System.Text;
 using System;
+using Microsoft.Fx.Portability.Reports.Html;
 
 namespace Microsoft.Fx.Portability.Reports
 {
@@ -60,12 +61,21 @@ namespace Microsoft.Fx.Portability.Reports
 
         private static string Resolve(string name)
         {
+            var fullName = $"Microsoft.Fx.Portability.Reports.Resources.{name}.cshtml";
             var names = typeof(HtmlReportWriter).GetTypeInfo().Assembly.GetManifestResourceNames();
-            using (var template = typeof(HtmlReportWriter).GetTypeInfo().Assembly.GetManifestResourceStream("Microsoft.Fx.Portability.Reports.Resources." + name + ".cshtml"))
-            using (var reader = new StreamReader(template, Encoding.UTF8))
+            using (var template = typeof(HtmlReportWriter).GetTypeInfo().Assembly.GetManifestResourceStream(fullName))
             {
-                return reader.ReadToEnd();
+                if (template == default(Stream))
+                {
+                    throw new MissingResourceException(fullName);
+                }
+
+                using (var reader = new StreamReader(template, Encoding.UTF8))
+                {
+                    return reader.ReadToEnd();
+                }
             }
+
         }
 
         public class HtmlHelper

--- a/src/Microsoft.Fx.Portability.Reports.Html/Microsoft.Fx.Portability.Reports.Html.csproj
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Microsoft.Fx.Portability.Reports.Html.csproj
@@ -26,6 +26,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Resources\_PortabilityReport.cshtml" />
+    <EmbeddedResource Include="Resources\ReportTemplate.cshtml" />
+    <EmbeddedResource Include="Resources\_Scripts.cshtml" />
+    <EmbeddedResource Include="Resources\_Styles.cshtml" />
+    <EmbeddedResource Include="Resources\_BreakingChangesReport.cshtml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.Fx.Portability\Microsoft.Fx.Portability.csproj">
       <Project>{8d84ec23-9977-4cc8-b649-035ffae9664c}</Project>
       <Name>Microsoft.Fx.Portability</Name>

--- a/src/Microsoft.Fx.Portability.Reports.Html/MissingResourceException.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/MissingResourceException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Reflection;
+
+namespace Microsoft.Fx.Portability.Reports.Html
+{
+    public class MissingResourceException : Exception
+    {
+        public MissingResourceException(string resourceName)
+            : base($"Could not locate: {resourceName}"
+                + Environment.NewLine + "Existing resources: "
+                + string.Join(", ", typeof(MissingResourceException).GetTypeInfo().Assembly.GetManifestResourceNames()))
+        { }
+    }
+}

--- a/src/Microsoft.Fx.Portability.Reports.Html/RazorHtmlObject.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/RazorHtmlObject.cs
@@ -51,7 +51,9 @@ namespace Microsoft.Fx.Portability.Reports
             TargetHeaders = _targetMapper.GetTargetNames(response.ReportingResult.Targets, true);
             OrderedBreakingChangesByAssembly = GetGroupedBreakingChanges(response.BreakingChanges, response.ReportingResult.GetAssemblyUsageInfo().Select(a => a.SourceAssembly));
             BreakingChangesSummary = GetBreakingChangesSummary(OrderedBreakingChangesByAssembly);
-            OrderedBreakingChangeSkippedAssemblies = response.BreakingChangeSkippedAssemblies.OrderBy(a => a.AssemblyIdentity);
+
+            var skippedAssemblies = response.BreakingChangeSkippedAssemblies ?? Enumerable.Empty<AssemblyInfo>();
+            OrderedBreakingChangeSkippedAssemblies = skippedAssemblies.OrderBy(a => a.AssemblyIdentity);
         }
 
         private IDictionary<BreakingChange, IEnumerable<MemberInfo>> GetBreakingChangesSummary(IEnumerable<KeyValuePair<AssemblyInfo, IDictionary<BreakingChange, IEnumerable<MemberInfo>>>> orderedBreakingChangesByAssembly)
@@ -66,7 +68,8 @@ namespace Microsoft.Fx.Portability.Reports
         private IOrderedEnumerable<KeyValuePair<AssemblyInfo, IDictionary<BreakingChange, IEnumerable<MemberInfo>>>> GetGroupedBreakingChanges(IList<BreakingChangeDependency> breakingChanges, IEnumerable<AssemblyInfo> assembliesToInclude)
         {
             Dictionary<AssemblyInfo, IDictionary<BreakingChange, IEnumerable<MemberInfo>>> ret = new Dictionary<AssemblyInfo, IDictionary<BreakingChange, IEnumerable<MemberInfo>>>();
-            foreach (BreakingChangeDependency b in breakingChanges)
+
+            foreach (BreakingChangeDependency b in breakingChanges ?? Enumerable.Empty<BreakingChangeDependency>())
             {
                 // Add breaking changes, grouped by assembly, each with a collection of MemberInfos that trigger the break
                 if (!ret.ContainsKey(b.DependantAssembly))

--- a/src/Microsoft.Fx.Portability/Analyzer/RequestAnalyzer.cs
+++ b/src/Microsoft.Fx.Portability/Analyzer/RequestAnalyzer.cs
@@ -32,7 +32,11 @@ namespace Microsoft.Fx.Portability.Analyzer
                 .OrderBy(x => x.FullName, StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
-            var userAssemblies = new HashSet<string>(request.UserAssemblies.Select(a => a.AssemblyIdentity), StringComparer.OrdinalIgnoreCase);
+            var assemblyIdentities = request.UserAssemblies
+                .Where(x => x.AssemblyIdentity != null)
+                .Select(a => a.AssemblyIdentity);
+
+            var userAssemblies = new HashSet<string>(assemblyIdentities, StringComparer.OrdinalIgnoreCase);
 
             var notInAnyTarget = request.RequestFlags.HasFlag(AnalyzeRequestFlags.ShowNonPortableApis)
                 ? _analysisEngine.FindMembersNotInTargets(targets, userAssemblies, request.Dependencies)

--- a/tests/Microsoft.Fx.Portability.Reports.Html.Tests/Class1.cs
+++ b/tests/Microsoft.Fx.Portability.Reports.Html.Tests/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Microsoft.Fx.Portability.Reports.Html.Tests
+{
+    public class Class1
+    {
+    }
+}

--- a/tests/Microsoft.Fx.Portability.Reports.Html.Tests/Class1.cs
+++ b/tests/Microsoft.Fx.Portability.Reports.Html.Tests/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace Microsoft.Fx.Portability.Reports.Html.Tests
-{
-    public class Class1
-    {
-    }
-}

--- a/tests/Microsoft.Fx.Portability.Reports.Html.Tests/HtmlReportWriterTests.cs
+++ b/tests/Microsoft.Fx.Portability.Reports.Html.Tests/HtmlReportWriterTests.cs
@@ -1,0 +1,81 @@
+﻿using Microsoft.Fx.Portability.ObjectModel;
+using Microsoft.Fx.Portability.Reporting.ObjectModel;
+using NSubstitute;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Versioning;
+using Xunit;
+
+namespace Microsoft.Fx.Portability.Reports.Html.Tests
+{
+    public class HtmlReportWriterTests
+    {
+        /// <summary>
+        /// Tests that the templates are embedded into the assembly.
+        /// </summary>
+        /// <param name="templateName"></param>
+        [InlineData("_PortabilityReport.cshtml")]
+        [InlineData("ReportTemplate.cshtml")]
+        [InlineData("_Scripts.cshtml")]
+        [InlineData("_Styles.cshtml")]
+        [InlineData("_BreakingChangesReport.cshtml")]
+        [Theory]
+        public void CanFindTemplates(string templateName)
+        {
+            var fullName = $"{typeof(HtmlReportWriter).Assembly.GetName().Name}.Resources.{templateName}";
+
+            var stream = typeof(HtmlReportWriter).Assembly.GetManifestResourceStream(fullName);
+
+            Assert.NotNull(stream);
+        }
+
+        [Fact]
+        public void CreatesHtmlReport()
+        {
+            var mapper = Substitute.For<ITargetMapper>();
+            var writer = new HtmlReportWriter(mapper);
+
+            var response = new AnalyzeResponse
+            {
+                MissingDependencies = new List<MemberInfo>
+                {
+                    new MemberInfo { MemberDocId = "Type1.doc1", DefinedInAssemblyIdentity = "Assembly1", TypeDocId = "Type1" },
+                    new MemberInfo { MemberDocId = "Type2.doc2", DefinedInAssemblyIdentity = "Assembly2", TypeDocId = "Type2" }
+                },
+                SubmissionId = Guid.NewGuid().ToString(),
+                Targets = new List<FrameworkName> { new FrameworkName("target1", Version.Parse("1.0.0.0")) },
+                UnresolvedUserAssemblies = new List<string> { "UnresolvedAssembly", "UnresolvedAssembly2", "UnresolvedAssembly3" },
+                BreakingChangeSkippedAssemblies = new List<AssemblyInfo>(),
+                BreakingChanges = new List<BreakingChangeDependency>(),
+            };
+
+            var reportingResult = new ReportingResult(response.Targets, response.MissingDependencies, response.SubmissionId, AnalyzeRequestFlags.NoTelemetry);
+            response.ReportingResult = reportingResult;
+
+            var tempFile = Path.GetTempFileName();
+
+            try
+            {
+                using (var file = File.OpenWrite(tempFile))
+                {
+                    writer.WriteStream(file, response);
+                }
+
+                Assert.True(File.Exists(tempFile));
+
+                var contents = File.ReadAllText(tempFile);
+
+                Assert.True(!string.IsNullOrEmpty(contents));
+                Assert.Contains(response.SubmissionId, contents);
+            }
+            finally
+            {
+                if (File.Exists(tempFile))
+                {
+                    File.Delete(tempFile);
+                }
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Fx.Portability.Reports.Html.Tests/Microsoft.Fx.Portability.Reports.Html.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Reports.Html.Tests/Microsoft.Fx.Portability.Reports.Html.Tests.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +13,10 @@
     <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Fx.Portability.Reports.Html\Microsoft.Fx.Portability.Reports.Html.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/Microsoft.Fx.Portability.Reports.Html.Tests/Microsoft.Fx.Portability.Reports.Html.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Reports.Html.Tests/Microsoft.Fx.Portability.Reports.Html.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.0.0" />
+    <PackageReference Include="NSubstitute" Version="2.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
* Fixes #434 when running in VSIX or trying to use `ApiPort.exe analyze --f Foo.dll -r HTML` because EmbeddedResources were not being included into assembly
* Adds unit tests