### PR TITLE
Fix NullReferenceException when an AssemblyInfo is null in an AnalyzeRequest

### DIFF
--- a/src/ApiPort.VisualStudio/Analyze/ProjectAnalyzer.cs
+++ b/src/ApiPort.VisualStudio/Analyze/ProjectAnalyzer.cs
@@ -48,7 +48,7 @@ namespace ApiPortVS.Analyze
             }
 
             // TODO: Add option to include everything in output, not just build artifacts
-            var targetAssemblies = projects.SelectMany(p => p.GetAssemblyPaths()).ToList();
+            var targetAssemblies = projects.SelectMany(p => p.GetAssemblyPaths().Where(x => !string.IsNullOrEmpty(x))).ToList();
 
             var result = await _analyzer.WriteAnalysisReportsAsync(targetAssemblies, _reportWriter, true);
 

--- a/src/ApiPort.VisualStudio/DteProjectExtensions.cs
+++ b/src/ApiPort.VisualStudio/DteProjectExtensions.cs
@@ -34,7 +34,7 @@ namespace ApiPortVS
             {
                 var buildDir = project.GetBuildOutputPath();
 
-                var targetAssemblies = getAllDirectories(buildDir);
+                var targetAssemblies = getAllDirectories(buildDir) ?? Enumerable.Empty<string>();
 
                 if (!targetAssemblies.Any())
                 {

--- a/src/Microsoft.Fx.Portability/Analyzer/RequestAnalyzer.cs
+++ b/src/Microsoft.Fx.Portability/Analyzer/RequestAnalyzer.cs
@@ -32,9 +32,11 @@ namespace Microsoft.Fx.Portability.Analyzer
                 .OrderBy(x => x.FullName, StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
-            var assemblyIdentities = request.UserAssemblies
-                .Where(x => x.AssemblyIdentity != null)
-                .Select(a => a.AssemblyIdentity);
+            // TODO: It's possible that an AssemblyInfo in UserAssemblies is null.
+            // This appears to be coming from analysis in the VSIX, possibly
+            // from CCI.  Figure out where this is coming from.
+            var assemblyIdentities = request?.UserAssemblies.Where(x => x != null && x.AssemblyIdentity != null).Select(a => a.AssemblyIdentity)
+                ?? Enumerable.Empty<string>();
 
             var userAssemblies = new HashSet<string>(assemblyIdentities, StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
NullReferenceException was occurring when there was an AssemblyIdentity that was null. This fixes that.

```
System.NullReferenceException:
   at Microsoft.Fx.Portability.Analyzer.RequestAnalyzer+<>c.<AnalyzeRequest>b__5_1 (Microsoft.Fx.Portability, Version=2.1.0.0, Culture=neutral, PublicKeyToken=4a286c3e845c3e69)
   at System.Linq.Enumerable+WhereSelectListIterator`2.MoveNext (System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.Collections.Generic.HashSet`1.UnionWith (System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at System.Collections.Generic.HashSet`1..ctor (System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
   at Microsoft.Fx.Portability.Analyzer.RequestAnalyzer.AnalyzeRequest (Microsoft.Fx.Portability, Version=2.1.0.0, Culture=neutral, PublicKeyToken=4a286c3e845c3e69)
```