### PR TITLE
Fix crash when opening report in VS

### DIFF
--- a/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
+++ b/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
@@ -45,6 +45,13 @@
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup>
+    <!-- Debugging Settings; Stored in project file instead of .user file to be available to everyone -->
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
+    <StartArguments>/RootSuffix Exp</StartArguments>
+    <EnableUnmanagedDebugging>False</EnableUnmanagedDebugging>
+  </PropertyGroup>
+  <PropertyGroup>
     <OutputPath>$(OutputDrop)\$(AssemblyName)</OutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/src/ApiPort.VisualStudio/Models/OptionsModel.cs
+++ b/src/ApiPort.VisualStudio/Models/OptionsModel.cs
@@ -43,7 +43,7 @@ namespace ApiPortVS.Models
             LastUpdate = DateTimeOffset.MinValue;
             OutputDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Portability Analysis");
         }
-        
+
         public DateTimeOffset LastUpdate { get; set; }
 
         public IList<SelectedResultFormat> Formats
@@ -61,24 +61,13 @@ namespace ApiPortVS.Models
         public string OutputDirectory
         {
             get { return _outputDirectory; }
-            set
-            {
-                UpdateProperty(ref _outputDirectory, value);
-
-                if (!Directory.Exists(_outputDirectory))
-                {
-                    Directory.CreateDirectory(_outputDirectory);
-                }
-            }
+            set { UpdateProperty(ref _outputDirectory, value); }
         }
 
         public string DefaultOutputName
         {
             get { return _defaultOutputName; }
-            set
-            {
-                UpdateProperty(ref _defaultOutputName, value);
-            }
+            set { UpdateProperty(ref _defaultOutputName, value); }
         }
 
         public static OptionsModel Load()

--- a/src/ApiPort.VisualStudio/Models/OptionsModel.cs
+++ b/src/ApiPort.VisualStudio/Models/OptionsModel.cs
@@ -13,35 +13,37 @@ using System.Reflection;
 namespace ApiPortVS.Models
 {
     /// <summary>
-    /// The options for ApiPort VS that is persisted
+    /// The options for ApiPort VS that are persisted
     /// </summary>
     public class OptionsModel : NotifyPropertyBase
     {
-        private const string OptionsFileName = "options.dat";
-
-        public static readonly string OptionsFilePath;
+        private static readonly string s_optionsFilePath;
+        private static readonly string s_defaultOutputDirectory;
+        private static readonly string s_defaultOutputName;
 
         private IList<SelectedResultFormat> _formats;
         private IList<TargetPlatform> _platforms;
         private string _outputDirectory;
-        private string _defaultOutputName;
+        private string _outputName;
 
         static OptionsModel()
         {
             var assembly = Assembly.GetExecutingAssembly();
             var directory = Path.GetDirectoryName(assembly.Location);
 
-            OptionsFilePath = Path.Combine(directory, OptionsFileName);
+            s_defaultOutputName = "ApiPortAnalysis";
+            s_defaultOutputDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Portability Analysis");
+            s_optionsFilePath = Path.Combine(directory, "options.dat");
         }
 
         public OptionsModel()
         {
             _platforms = Array.Empty<TargetPlatform>();
             _formats = Array.Empty<SelectedResultFormat>();
-            _defaultOutputName = "ApiPortAnalysis";
+            _outputName = s_defaultOutputName;
+            _outputDirectory = s_defaultOutputDirectory;
 
             LastUpdate = DateTimeOffset.MinValue;
-            OutputDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Portability Analysis");
         }
 
         public DateTimeOffset LastUpdate { get; set; }
@@ -61,22 +63,22 @@ namespace ApiPortVS.Models
         public string OutputDirectory
         {
             get { return _outputDirectory; }
-            set { UpdateProperty(ref _outputDirectory, value); }
+            set { UpdateProperty(ref _outputDirectory, string.IsNullOrWhiteSpace(value) ? _outputDirectory : value); }
         }
 
         public string DefaultOutputName
         {
-            get { return _defaultOutputName; }
-            set { UpdateProperty(ref _defaultOutputName, value); }
+            get { return _outputName; }
+            set { UpdateProperty(ref _outputName, string.IsNullOrWhiteSpace(value) ? s_defaultOutputName : value); }
         }
 
         public static OptionsModel Load()
         {
             try
             {
-                if (File.Exists(OptionsFilePath))
+                if (File.Exists(s_optionsFilePath))
                 {
-                    var bytes = File.ReadAllBytes(OptionsFilePath);
+                    var bytes = File.ReadAllBytes(s_optionsFilePath);
 
                     return bytes.Deserialize<OptionsModel>();
                 }
@@ -93,13 +95,13 @@ namespace ApiPortVS.Models
         {
             try
             {
-                File.WriteAllBytes(OptionsFilePath, this.Serialize());
+                File.WriteAllBytes(s_optionsFilePath, this.Serialize());
 
                 return true;
             }
             catch (IOException)
             {
-                Debug.WriteLine(string.Format(LocalizedStrings.UnableToSaveFileFormat, OptionsFilePath));
+                Debug.WriteLine(string.Format(LocalizedStrings.UnableToSaveFileFormat, s_optionsFilePath));
 
                 return false;
             }

--- a/src/ApiPort.VisualStudio/Resources/LocalizedStrings.Designer.cs
+++ b/src/ApiPort.VisualStudio/Resources/LocalizedStrings.Designer.cs
@@ -368,11 +368,29 @@ namespace ApiPortVS.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The directory the report was in is not available. It may have been deleted..
+        /// </summary>
+        public static string ReportDirectoryNotAvailable {
+            get {
+                return ResourceManager.GetString("ReportDirectoryNotAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Report written to &apos;{0}&apos;.
         /// </summary>
         public static string ReportLocation {
             get {
                 return ResourceManager.GetString("ReportLocation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The report is not available. It may have been deleted..
+        /// </summary>
+        public static string ReportNotAvailable {
+            get {
+                return ResourceManager.GetString("ReportNotAvailable", resourceCulture);
             }
         }
         

--- a/src/ApiPort.VisualStudio/Resources/LocalizedStrings.resx
+++ b/src/ApiPort.VisualStudio/Resources/LocalizedStrings.resx
@@ -282,4 +282,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.</value>
   <data name="GeneralSettings" xml:space="preserve">
     <value>General</value>
   </data>
+  <data name="ReportDirectoryNotAvailable" xml:space="preserve">
+    <value>The directory the report was in is not available. It may have been deleted.</value>
+  </data>
+  <data name="ReportNotAvailable" xml:space="preserve">
+    <value>The report is not available. It may have been deleted.</value>
+  </data>
 </root>

--- a/src/Microsoft.Fx.Portability/Reporting/ReportFileWriter.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/ReportFileWriter.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Fx.Portability.Reporting
         {
             try
             {
-                using (Stream destinationStream = _fileSystem.CreateFile(filePath))
+                using (var destinationStream = _fileSystem.CreateFile(filePath))
                 using (var memoryStream = new MemoryStream(report))
                 {
                     await memoryStream.CopyToAsync(destinationStream);
@@ -62,7 +62,7 @@ namespace Microsoft.Fx.Portability.Reporting
 
         private string GetFileName(string directory, string fileName, string inputExtension, bool isUnique)
         {
-            // We want to change the extension of the filename given regardless 
+            // We want to change the extension of the filename given regardless
             // of whether the user gave an extension or not. However, if they give
             // us an extension and it doesn't match the expected one, we'll report
             // the problem to them.

--- a/src/Microsoft.Fx.Portability/Reporting/ReportFileWriter.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/ReportFileWriter.cs
@@ -32,14 +32,17 @@ namespace Microsoft.Fx.Portability.Reporting
 
             var filePath = _fileSystem.CombinePaths(outputDirectory, filename);
             var isWritten = await TryWriteReportAsync(report, filePath);
-            if (isWritten)
-                return filePath;
 
-            return null;
+            return isWritten ? filePath : null;
         }
 
         private async Task<bool> TryWriteReportAsync(byte[] report, string filePath)
         {
+            if (filePath == null)
+            {
+                return false;
+            }
+
             try
             {
                 using (var destinationStream = _fileSystem.CreateFile(filePath))

--- a/src/Microsoft.Fx.Portability/Reporting/WindowsFileSystem.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/WindowsFileSystem.cs
@@ -42,7 +42,14 @@ namespace Microsoft.Fx.Portability.Reporting
 
         public virtual Stream CreateFile(string path)
         {
-            return File.Open(path, FileMode.Create, FileAccess.ReadWrite);
+            var file = new FileInfo(path);
+
+            if (!file.Directory.Exists)
+            {
+                file.Directory.Create();
+            }
+
+            return file.Open(FileMode.Create, FileAccess.ReadWrite);
         }
 
         public virtual IEnumerable<string> SearchPathForFile(string filename)

--- a/src/Microsoft.Fx.Portability/Reporting/WindowsFileSystem.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/WindowsFileSystem.cs
@@ -42,6 +42,11 @@ namespace Microsoft.Fx.Portability.Reporting
 
         public virtual Stream CreateFile(string path)
         {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
             var file = new FileInfo(path);
 
             if (!file.Directory.Exists)


### PR DESCRIPTION
This will check if the report (or directory) is available and if it is, will launch it. Otherwise, a notification is given and then the entries are removed from the pane. This change also moves to create the directory to output to if it is not already there

Fixes #402 and #359 