### PR TITLE
Overwrite the output file if it already exists.

### DIFF
--- a/src/ApiPort.VisualStudio.Common/Analyze/AnalysisOptions.cs
+++ b/src/ApiPort.VisualStudio.Common/Analyze/AnalysisOptions.cs
@@ -45,5 +45,7 @@ namespace ApiPortVS
         public IEnumerable<string> InvalidInputFiles { get; } = Enumerable.Empty<string>();
 
         public string ServiceEndpoint { get; } = string.Empty;
+
+        public bool OverwriteOutputFile { get; }
     }
 }

--- a/src/ApiPort/CommandLine/AnalyzeOptions.cs
+++ b/src/ApiPort/CommandLine/AnalyzeOptions.cs
@@ -88,6 +88,9 @@ namespace ApiPort.CommandLine
                 TargetMapFile = options.TargetMap;
                 BreakingChangeSuppressions = options.SuppressBreakingChange;
 
+                //Set OverwriteOutputFile to true if the output file name is explicitly specified 
+                OverwriteOutputFile = string.IsNullOrWhiteSpace(options.Out) ? false : true;
+
                 UpdateRequestFlags(options);
                 UpdateInputAssemblies(options);
             }

--- a/src/ApiPort/CommandLine/AnalyzeOptions.cs
+++ b/src/ApiPort/CommandLine/AnalyzeOptions.cs
@@ -82,14 +82,17 @@ namespace ApiPort.CommandLine
             {
                 Description = options.Description;
                 ServiceEndpoint = options.Endpoint;
-                OutputFileName = options.Out;
                 Targets = options.Target;
                 OutputFormats = options.ResultFormat;
                 TargetMapFile = options.TargetMap;
                 BreakingChangeSuppressions = options.SuppressBreakingChange;
 
                 //Set OverwriteOutputFile to true if the output file name is explicitly specified 
-                OverwriteOutputFile = string.IsNullOrWhiteSpace(options.Out) ? false : true;
+                if(!string.IsNullOrWhiteSpace(options.Out))
+                {
+                    OverwriteOutputFile = true;
+                    OutputFileName = options.Out;
+                }
 
                 UpdateRequestFlags(options);
                 UpdateInputAssemblies(options);

--- a/src/ApiPort/ConsoleApiPort.cs
+++ b/src/ApiPort/ConsoleApiPort.cs
@@ -106,11 +106,14 @@ namespace ApiPort
             var outputPaths = await _apiPortClient.WriteAnalysisReportsAsync(_options);
 
             Console.WriteLine();
-            Console.WriteLine(LocalizedStrings.OutputWrittenTo);
-
-            foreach (var outputPath in outputPaths)
+            if (outputPaths.Any())
             {
-                Console.WriteLine(outputPath);
+                Console.WriteLine(LocalizedStrings.OutputWrittenTo);
+
+                foreach (var outputPath in outputPaths)
+                {
+                    Console.WriteLine(outputPath);
+                }
             }
         }
 

--- a/src/Microsoft.Fx.Portability/ApiPortClient.cs
+++ b/src/Microsoft.Fx.Portability/ApiPortClient.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Fx.Portability
                     }
                 }
 
-                var outputPath = await CreateReport(result.Data, options.OutputFileName, result.Format);
+                var outputPath = await CreateReport(result.Data, options.OutputFileName, result.Format, options.OverwriteOutputFile);
 
                 if (!string.IsNullOrEmpty(outputPath))
                 {
@@ -169,7 +169,7 @@ namespace Microsoft.Fx.Portability
         /// Writes a report given the output format and filename.
         /// </summary>
         /// <returns>null if unable to write the report otherwise, will return the full path to the report.</returns>
-        private async Task<string> CreateReport(byte[] result, string suppliedOutputFileName, string outputFormat)
+        private async Task<string> CreateReport(byte[] result, string suppliedOutputFileName, string outputFormat, bool overwriteFile)
         {
             var filePath = Path.GetFullPath(suppliedOutputFileName);
             var outputDirectory = Path.GetDirectoryName(filePath);
@@ -181,7 +181,7 @@ namespace Microsoft.Fx.Portability
                 {
                     var extension = await GetExtensionForFormat(outputFormat);
 
-                    var filename = await _writer.WriteReportAsync(result, extension, outputDirectory, outputFileName, overwrite: false);
+                    var filename = await _writer.WriteReportAsync(result, extension, outputDirectory, outputFileName, overwriteFile);
 
                     if (string.IsNullOrEmpty(filename))
                     {

--- a/src/Microsoft.Fx.Portability/ApiPortClient.cs
+++ b/src/Microsoft.Fx.Portability/ApiPortClient.cs
@@ -8,6 +8,7 @@ using Microsoft.Fx.Portability.Reporting.ObjectModel;
 using Microsoft.Fx.Portability.Resources;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -171,12 +172,24 @@ namespace Microsoft.Fx.Portability
         /// <returns>null if unable to write the report otherwise, will return the full path to the report.</returns>
         private async Task<string> CreateReport(byte[] result, string suppliedOutputFileName, string outputFormat, bool overwriteFile)
         {
-            var filePath = Path.GetFullPath(suppliedOutputFileName);
-            var outputDirectory = Path.GetDirectoryName(filePath);
-            var outputFileName = Path.GetFileName(filePath);
+            string filePath = null;
 
             using (var progressTask = _progressReport.StartTask(string.Format(LocalizedStrings.WritingReport, outputFormat)))
             {
+                try
+                {
+                    filePath = Path.GetFullPath(suppliedOutputFileName);
+                }
+                catch(Exception ex)
+                {
+                    _progressReport.ReportIssue(string.Format(CultureInfo.InvariantCulture, ex.Message));
+                    progressTask.Abort();
+
+                    return null;
+                }
+
+                var outputDirectory = Path.GetDirectoryName(filePath);
+                var outputFileName = Path.GetFileName(filePath);
                 try
                 {
                     var extension = await GetExtensionForFormat(outputFormat);

--- a/src/Microsoft.Fx.Portability/IApiPortOptions.cs
+++ b/src/Microsoft.Fx.Portability/IApiPortOptions.cs
@@ -19,5 +19,6 @@ namespace Microsoft.Fx.Portability
         string ServiceEndpoint { get; }
         string OutputFileName { get; }
         IEnumerable<string> InvalidInputFiles { get; }
+        bool OverwriteOutputFile { get; }
     }
 }

--- a/src/Microsoft.Fx.Portability/ReadWriteApiPortOptions.cs
+++ b/src/Microsoft.Fx.Portability/ReadWriteApiPortOptions.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Fx.Portability
             ServiceEndpoint = other.ServiceEndpoint;
             InvalidInputFiles = other.InvalidInputFiles;
             OutputFileName = other.OutputFileName;
+            OverwriteOutputFile = other.OverwriteOutputFile;
         }
 
         public virtual IEnumerable<string> BreakingChangeSuppressions { get; set; }
@@ -47,5 +48,7 @@ namespace Microsoft.Fx.Portability
         public virtual string ServiceEndpoint { get; set; }
 
         public virtual IEnumerable<string> Targets { get; set; }
+
+        public virtual bool OverwriteOutputFile { get; set; }
     }
 }

--- a/src/Microsoft.Fx.Portability/Reporting/ReportFileWriter.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/ReportFileWriter.cs
@@ -51,12 +51,14 @@ namespace Microsoft.Fx.Portability.Reporting
                     await memoryStream.CopyToAsync(destinationStream);
                 }
             }
-            catch (IOException)
+            catch (IOException ex)
             {
+                _progressReporter.ReportIssue(string.Format(CultureInfo.InvariantCulture, ex.Message));
                 return false;
             }
-            catch (UnauthorizedAccessException)
+            catch (UnauthorizedAccessException ex)
             {
+                _progressReporter.ReportIssue(string.Format(CultureInfo.InvariantCulture, ex.Message));
                 return false;
             }
 

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
@@ -224,7 +224,7 @@
     <comment>Warning when we are changing the output file name.</comment>
   </data>
   <data name="OverwriteFile" xml:space="preserve">
-    <value>Replaced output file '{0}'</value>
+    <value>File '{0}' already exists and will be overwritten.</value>
     <comment>Displayed when a file exists and will be overwritten</comment>
   </data>
   <data name="AssemblyHeader" xml:space="preserve">

--- a/tests/Microsoft.Fx.Portability.Tests/ReadWriteApiPortOptionsTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ReadWriteApiPortOptionsTests.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Fx.Portability.Tests
 
             public IEnumerable<string> Targets { get; } = GenerateRandomList(5);
 
+            public bool OverwriteOutputFile { get; }
+
             private static IEnumerable<string> GenerateRandomList(int length)
             {
                 return Enumerable.Range(0, length)

--- a/tests/Microsoft.Fx.Portability.Tests/ReportFileWriterTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ReportFileWriterTests.cs
@@ -14,6 +14,33 @@ namespace Microsoft.Fx.Portability.Tests
     public class ReportFileWriterTests
     {
         [Fact]
+        public async Task FileExists_OverwriteTrue()
+        {
+            var dir = "dir";
+            var fileName = "file";
+            var extension = ".html";
+
+            var path = Path.Combine(dir, Path.ChangeExtension(fileName, extension));
+
+            var progressReporter = Substitute.For<IProgressReporter>();
+            var fileSystem = Substitute.ForPartsOf<WindowsFileSystem>();
+
+            fileSystem.FileExists(path).Returns(true);
+            fileSystem.CreateFile(Arg.Any<string>()).Returns(x => new MemoryStream());
+
+            var expectedResult = path;
+            var writer = new ReportFileWriter(fileSystem, progressReporter);
+            var report = Encoding.UTF8.GetBytes("This is a test report.");
+
+            var reportPath = await writer.WriteReportAsync(report, extension, dir, fileName, overwrite: true);
+
+            Assert.Equal(expectedResult, reportPath);
+
+            fileSystem.Received(1).CreateFile(Arg.Any<string>());
+            fileSystem.Received().CreateFile(expectedResult);
+        }
+
+        [Fact]
         public async Task UniquelyNamedFileStream_FileExists_AppendsNumberToName()
         {
             var dir = "dir";


### PR DESCRIPTION
Overwrite the output file when the output file name was explicitly passed in.
Keep previous behavior if no filename is specified.
#401 