### PR TITLE
Add Nuget package information

### DIFF
--- a/PortabilityTools.sln
+++ b/PortabilityTools.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.12
+VisualStudioVersion = 15.0.26730.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C991F5FC-04B5-420C-98A0-80974AA946F7}"
 	ProjectSection(SolutionItems) = preProject
@@ -72,6 +72,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiPort.VisualStudio.2017", "src\ApiPort.VisualStudio.2017\ApiPort.VisualStudio.2017.csproj", "{C0629A8D-7107-46CF-83B8-408E1886AB36}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiPort.VisualStudio.Common", "src\ApiPort.VisualStudio.Common\ApiPort.VisualStudio.Common.csproj", "{60798B82-B273-4D39-AA52-021C7228A0AD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiPort.Tests", "tests\ApiPort.Tests\ApiPort.Tests.csproj", "{EE708186-6345-486D-9810-17D98439DAAE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -941,6 +943,54 @@ Global
 		{60798B82-B273-4D39-AA52-021C7228A0AD}.Ubuntu_Release|x64.Build.0 = Release|Any CPU
 		{60798B82-B273-4D39-AA52-021C7228A0AD}.Ubuntu_Release|x86.ActiveCfg = Release|Any CPU
 		{60798B82-B273-4D39-AA52-021C7228A0AD}.Ubuntu_Release|x86.Build.0 = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Debug|ARM.Build.0 = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Debug|x64.Build.0 = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Debug|x86.Build.0 = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Osx_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Osx_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Osx_Debug|ARM.ActiveCfg = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Osx_Debug|ARM.Build.0 = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Osx_Debug|x64.ActiveCfg = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Osx_Debug|x64.Build.0 = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Osx_Debug|x86.ActiveCfg = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Osx_Debug|x86.Build.0 = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Osx_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Osx_Release|Any CPU.Build.0 = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Osx_Release|ARM.ActiveCfg = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Osx_Release|ARM.Build.0 = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Osx_Release|x64.ActiveCfg = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Osx_Release|x64.Build.0 = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Osx_Release|x86.ActiveCfg = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Osx_Release|x86.Build.0 = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Release|ARM.ActiveCfg = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Release|ARM.Build.0 = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Release|x64.ActiveCfg = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Release|x64.Build.0 = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Release|x86.ActiveCfg = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Release|x86.Build.0 = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Ubuntu_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Ubuntu_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Ubuntu_Debug|ARM.ActiveCfg = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Ubuntu_Debug|ARM.Build.0 = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Ubuntu_Debug|x64.ActiveCfg = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Ubuntu_Debug|x64.Build.0 = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Ubuntu_Debug|x86.ActiveCfg = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Ubuntu_Debug|x86.Build.0 = Debug|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Ubuntu_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Ubuntu_Release|Any CPU.Build.0 = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Ubuntu_Release|ARM.ActiveCfg = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Ubuntu_Release|ARM.Build.0 = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Ubuntu_Release|x64.ActiveCfg = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Ubuntu_Release|x64.Build.0 = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Ubuntu_Release|x86.ActiveCfg = Release|Any CPU
+		{EE708186-6345-486D-9810-17D98439DAAE}.Ubuntu_Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -967,5 +1017,9 @@ Global
 		{9DEF460B-6383-4665-839B-C0B5E6BB6A5F} = {0D1724F6-078E-4576-9680-6B9334D562DC}
 		{C0629A8D-7107-46CF-83B8-408E1886AB36} = {0D1724F6-078E-4576-9680-6B9334D562DC}
 		{60798B82-B273-4D39-AA52-021C7228A0AD} = {0D1724F6-078E-4576-9680-6B9334D562DC}
+		{EE708186-6345-486D-9810-17D98439DAAE} = {7DC7AA2C-0401-495B-B42C-32F44085EBE6}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8E8B2DB2-4847-4909-8631-A995D50F10EF}
 	EndGlobalSection
 EndGlobal

--- a/src/ApiPort.VisualStudio.Common/Analyze/AnalysisOptions.cs
+++ b/src/ApiPort.VisualStudio.Common/Analyze/AnalysisOptions.cs
@@ -4,16 +4,18 @@
 using Microsoft.Fx.Portability;
 using Microsoft.Fx.Portability.ObjectModel;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace ApiPortVS
 {
     public class AnalysisOptions : IApiPortOptions
     {
-        public AnalysisOptions(string description, IEnumerable<string> inputAssemblies, IEnumerable<string> targets, IEnumerable<string> formats, bool discardMetadata, string outputFileName)
+        public AnalysisOptions(string description, IEnumerable<string> inputAssemblies, IEnumerable<string> targets, IEnumerable<string> formats, bool discardMetadata, string outputFileName, bool isAssemblySpecified)
         {
             Description = description;
-            InputAssemblies = inputAssemblies.Select(target => new AssemblyFile(target)).ToList();
+            InputAssemblies = inputAssemblies.Select(target => new KeyValuePair<IAssemblyFile, bool>(new AssemblyFile(target), isAssemblySpecified)).ToImmutableDictionary();
+
             Targets = targets.ToList();
             OutputFormats = formats.ToList();
             OutputFileName = outputFileName;
@@ -28,7 +30,7 @@ namespace ApiPortVS
 
         public string Description { get; }
 
-        public IEnumerable<IAssemblyFile> InputAssemblies { get; }
+        public ImmutableDictionary<IAssemblyFile, bool> InputAssemblies { get; }
 
         public AnalyzeRequestFlags RequestFlags { get; }
 

--- a/src/ApiPort.VisualStudio.Common/Analyze/ApiPortVsAnalyzer.cs
+++ b/src/ApiPort.VisualStudio.Common/Analyze/ApiPortVsAnalyzer.cs
@@ -105,13 +105,17 @@ namespace ApiPortVS.Analyze
             // TODO: Allow setting description
             string description = null;
 
+            // NuGet packages referenced in the project system are not
+            // explicitly passed in, so we'll not want to see their portability
+            // statistics.
             return new AnalysisOptions(
                 description,
                 assemblyPaths,
                 targets,
                 formats,
                 !_optionsViewModel.SaveMetadata,
-                reportFileName);
+                reportFileName,
+                isAssemblySpecified: false);
         }
     }
 }

--- a/src/ApiPort.VisualStudio.Common/ApiPort.VisualStudio.Common.csproj
+++ b/src/ApiPort.VisualStudio.Common/ApiPort.VisualStudio.Common.csproj
@@ -118,6 +118,9 @@
     </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.4.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.NonGeneric, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.NonGeneric.4.0.1\lib\net46\System.Collections.NonGeneric.dll</HintPath>
     </Reference>
@@ -194,7 +197,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/ApiPort.VisualStudio.Common/packages.config
+++ b/src/ApiPort.VisualStudio.Common/packages.config
@@ -20,6 +20,7 @@
   <package id="Microsoft.VisualStudio.Utilities" version="14.3.25407" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net46" />
   <package id="System.Collections" version="4.0.11" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net46" />
   <package id="System.Collections.NonGeneric" version="4.0.1" targetFramework="net46" />
   <package id="System.IO.FileSystem" version="4.0.1" targetFramework="net46" />
   <package id="System.IO.FileSystem.Primitives" version="4.0.1" targetFramework="net46" />

--- a/src/ApiPort/AssemblyInfo.cs
+++ b/src/ApiPort/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("ApiPort.Tests")]

--- a/src/ApiPort/CommandLine/AnalyzeOptions.cs
+++ b/src/ApiPort/CommandLine/AnalyzeOptions.cs
@@ -43,7 +43,7 @@ namespace ApiPort.CommandLine
             return options.Help ? CommonCommands.Help : new AnalyzeCommandLineOption(options);
         }
 
-        private class Options
+        public class Options
         {
             public string Endpoint { get; set; }
             public List<string> File { get; set; } = new List<string>();
@@ -61,7 +61,7 @@ namespace ApiPort.CommandLine
             public string TargetMap { get; set; }
         }
 
-        private class AnalyzeCommandLineOption : ConsoleDefaultApiPortOptions, ICommandLineOptions
+        public class AnalyzeCommandLineOption : ConsoleDefaultApiPortOptions, ICommandLineOptions
         {
             private readonly static string[] s_ValidExtensions = new string[]
             {

--- a/src/ApiPort/CommandLine/ConsoleDefaultApiPortOptions.cs
+++ b/src/ApiPort/CommandLine/ConsoleDefaultApiPortOptions.cs
@@ -4,6 +4,7 @@
 using Microsoft.Fx.Portability;
 using Microsoft.Fx.Portability.ObjectModel;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 
@@ -75,7 +76,14 @@ namespace ApiPort.CommandLine
             }
         }
 
-        public override IEnumerable<IAssemblyFile> InputAssemblies
+        /// <summary>
+        /// All of the input assemblies.
+        /// Key: Assembly file
+        /// Value: Boolean indicating whether the assembly was explicitly
+        ///     specified. True if it was passed in (ie. command-line
+        ///     arguments) and false otherwise.
+        /// </summary>
+        public override ImmutableDictionary<IAssemblyFile, bool> InputAssemblies
         {
             get { return base.InputAssemblies; }
             set

--- a/src/ApiPort/FileOutputApiPortService.cs
+++ b/src/ApiPort/FileOutputApiPortService.cs
@@ -67,7 +67,7 @@ namespace ApiPort
 
         public Task<ServiceResponse<ResultFormatInformation>> GetDefaultResultFormatAsync()
         {
-            //s_formats contains one element
+            // s_formats contains one element
             var response = ServiceResponse.Create(s_formats.First());
 
             return Task.FromResult(response);

--- a/src/ApiPort/ICommandLineOptions.cs
+++ b/src/ApiPort/ICommandLineOptions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Fx.Portability;
-using System.Collections.Generic;
 
 namespace ApiPort
 {

--- a/src/Microsoft.Fx.Portability.Cci/Analyzer/CciDependencyFinder.cs
+++ b/src/Microsoft.Fx.Portability.Cci/Analyzer/CciDependencyFinder.cs
@@ -5,7 +5,6 @@ using Microsoft.Fx.Portability.Resources;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 
 namespace Microsoft.Fx.Portability.Analyzer

--- a/src/Microsoft.Fx.Portability.Cci/Analyzer/DependencyFinderEngine.cs
+++ b/src/Microsoft.Fx.Portability.Cci/Analyzer/DependencyFinderEngine.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Cci.Extensions;
+using Microsoft.Fx.Portability.ObjectModel;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.Cci.Extensions;
-using Microsoft.Fx.Portability.ObjectModel;
 
 namespace Microsoft.Fx.Portability.Analyzer
 {
@@ -121,10 +121,14 @@ namespace Microsoft.Fx.Portability.Analyzer
 
                 // Extract the fileversion and assembly version from the assembly.
                 FileVersionInfo fileInfo = FileVersionInfo.GetVersionInfo(assemblyLocation);
-                AssemblyInfo assemblyInfo = new AssemblyInfo();
-                assemblyInfo.AssemblyIdentity = cciAssembly.AssemblyIdentity.Format();
-                assemblyInfo.FileVersion = fileInfo.FileVersion ?? string.Empty;
-                assemblyInfo.TargetFrameworkMoniker = cciAssembly.GetTargetFrameworkMoniker();
+
+                var assemblyInfo = new AssemblyInfo
+                {
+                    Location = cciAssembly.Location,
+                    AssemblyIdentity = cciAssembly.AssemblyIdentity.Format(),
+                    FileVersion = fileInfo.FileVersion ?? string.Empty,
+                    TargetFrameworkMoniker = cciAssembly.GetTargetFrameworkMoniker()
+                };
 
                 // remember this assembly as a user assembly.
                 _userAssemblies.Add(assemblyInfo);

--- a/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
@@ -5,7 +5,6 @@ using Microsoft.Fx.Portability.ObjectModel;
 using Microsoft.Fx.Portability.Resources;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Reflection.Metadata;
 
 namespace Microsoft.Fx.Portability.Analyzer
@@ -14,7 +13,6 @@ namespace Microsoft.Fx.Portability.Analyzer
     {
         private readonly IDependencyFilter _assemblyFilter;
         private readonly MetadataReader _reader;
-        private readonly string _assemblyLocation;
 
         private readonly AssemblyReferenceInformation _currentAssemblyInfo;
         private readonly string _currentAssemblyName;
@@ -23,11 +21,11 @@ namespace Microsoft.Fx.Portability.Analyzer
         {
             _assemblyFilter = assemblyFilter;
             _reader = metadataReader;
-            _assemblyLocation = file.Name;
 
             MemberDependency = new List<MemberDependency>();
             CallingAssembly = new AssemblyInfo
             {
+                Location = file.Name,
                 AssemblyIdentity = metadataReader.FormatAssemblyInfo().ToString(),
                 FileVersion = file.Version ?? string.Empty,
                 TargetFrameworkMoniker = metadataReader.GetTargetFrameworkMoniker() ?? string.Empty

--- a/src/Microsoft.Fx.Portability.MetadataReader/ReflectionMetadataDependencyFinder.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/ReflectionMetadataDependencyFinder.cs
@@ -4,8 +4,6 @@
 using Microsoft.Fx.Portability.Resources;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
 
 namespace Microsoft.Fx.Portability.Analyzer
 {
@@ -20,8 +18,6 @@ namespace Microsoft.Fx.Portability.Analyzer
 
         public IDependencyInfo FindDependencies(IEnumerable<IAssemblyFile> files, IProgressReporter _progressReporter)
         {
-            var inputAssemblyPaths = files.Where(f => FilterValidFiles(f, _progressReporter)).ToList();
-
             using (var task = _progressReporter.StartTask(LocalizedStrings.DetectingAssemblyReferences))
             {
                 try
@@ -35,18 +31,6 @@ namespace Microsoft.Fx.Portability.Analyzer
                     throw;
                 }
             }
-        }
-
-        private static bool FilterValidFiles(IAssemblyFile file, IProgressReporter _progressReporter)
-        {
-            if (file.Exists)
-            {
-                return true;
-            }
-
-            _progressReporter.ReportIssue(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.UnknownFile, file.Name));
-
-            return false;
         }
     }
 }

--- a/src/Microsoft.Fx.Portability.Offline/OfflineDataModule.cs
+++ b/src/Microsoft.Fx.Portability.Offline/OfflineDataModule.cs
@@ -5,7 +5,6 @@ using Autofac;
 using Microsoft.Fx.Portability.Analysis;
 using Microsoft.Fx.Portability.ObjectModel;
 using Microsoft.Fx.Portability.Reporting;
-using Microsoft.Fx.Portability.Reports;
 using System.Collections.Generic;
 
 namespace Microsoft.Fx.Portability
@@ -35,6 +34,10 @@ namespace Microsoft.Fx.Portability
 
             builder.RegisterType<OfflineApiRecommendations>()
                 .As<IApiRecommendations>()
+                .SingleInstance();
+
+            builder.RegisterType<OfflinePackageFinder>()
+                .As<IPackageFinder>()
                 .SingleInstance();
 
             builder.RegisterType<TargetNameParser>()

--- a/src/Microsoft.Fx.Portability.Offline/OfflinePackageFinder.cs
+++ b/src/Microsoft.Fx.Portability.Offline/OfflinePackageFinder.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Runtime.Versioning;
+
+namespace Microsoft.Fx.Portability.ObjectModel
+{
+    public class OfflinePackageFinder : IPackageFinder
+    {
+        public bool TryFindPackage(string assemblyInfo, IEnumerable<FrameworkName> targets, out ImmutableDictionary<FrameworkName, IEnumerable<NuGetPackageId>> packages)
+        {
+            packages = ImmutableDictionary<FrameworkName, IEnumerable<NuGetPackageId>>.Empty;
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.Fx.Portability.Reports.Html/RazorHtmlObject.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/RazorHtmlObject.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Fx.Portability.Reports
 
         public IOrderedEnumerable<AssemblyInfo> OrderedBreakingChangeSkippedAssemblies { get; private set; }
 
+        public IEnumerable<NuGetPackageInfo> NuGetPackages { get; private set; }
+
         public RazorHtmlObject(AnalyzeResponse response, ITargetMapper targetMapper)
         {
             CatalogBuiltOn = response.CatalogLastUpdated;
@@ -54,6 +56,7 @@ namespace Microsoft.Fx.Portability.Reports
 
             var skippedAssemblies = response.BreakingChangeSkippedAssemblies ?? Enumerable.Empty<AssemblyInfo>();
             OrderedBreakingChangeSkippedAssemblies = skippedAssemblies.OrderBy(a => a.AssemblyIdentity);
+            NuGetPackages = response.NuGetPackages;
         }
 
         private IDictionary<BreakingChange, IEnumerable<MemberInfo>> GetBreakingChangesSummary(IEnumerable<KeyValuePair<AssemblyInfo, IDictionary<BreakingChange, IEnumerable<MemberInfo>>>> orderedBreakingChangesByAssembly)

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
@@ -208,3 +208,60 @@
             </p>
         }
 </div>
+
+<div id="nugetpackageinfo">
+    <h3>Available NuGet Packages</h3>
+    @{
+        var nugetColumnHeaders = new List<string>();
+        nugetColumnHeaders.Add("Assembly");
+        nugetColumnHeaders.Add("Framework");
+        nugetColumnHeaders.Add("Package Id");
+        nugetColumnHeaders.Add("Package Version");
+    }
+    
+    <table>
+        <tbody>
+            <tr>
+                @foreach (var header in nugetColumnHeaders)
+                {
+                    <th>@header</th>
+                }
+            </tr>
+            @foreach (var nugetPackage in Model.NuGetPackages)
+            {
+                if (nugetPackage.SupportedPackages != null)
+                {
+                    foreach (var package in nugetPackage.SupportedPackages)
+                    {
+                        <tr>
+                            <td>@nugetPackage.AssemblyInfo</td>
+                            <td>@nugetPackage.Target.FullName</td>
+                            @if (!string.IsNullOrEmpty(package.Hyperlink))
+                            {
+                                <td><a href="@package.Hyperlink">@package.PackageId</a></td>
+                            }
+                            else
+                            {
+                                <td>@package.PackageId</td>
+                            }
+                            <td>@package.Version</td>
+                        </tr>
+                    }
+                }
+                else
+                {
+                    <tr>
+                        <td>@nugetPackage.AssemblyInfo</td>
+                        <td>@nugetPackage.Target.FullName</td>
+                        <td>Not Supported</td>
+                    </tr>
+
+                }
+            }
+        </tbody>
+    </table>
+
+    <p>
+        <a href="#@LocalizedStrings.PortabilitySummaryPageTitle">@LocalizedStrings.BackToSummary</a>
+    </p>
+</div>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
@@ -209,59 +209,62 @@
         }
 </div>
 
-<div id="nugetpackageinfo">
-    <h3>Available NuGet Packages</h3>
-    @{
-        var nugetColumnHeaders = new List<string>();
-        nugetColumnHeaders.Add("Assembly");
-        nugetColumnHeaders.Add("Framework");
-        nugetColumnHeaders.Add("Package Id");
-        nugetColumnHeaders.Add("Package Version");
-    }
+@if (Model.NuGetPackages != null && Model.NuGetPackages.Any())
+{
+    <div id="nugetpackageinfo">
+        <h3>Available NuGet Packages</h3>
+        @{
+            var nugetColumnHeaders = new List<string>();
+            nugetColumnHeaders.Add("Assembly");
+            nugetColumnHeaders.Add("Framework");
+            nugetColumnHeaders.Add("Package Id");
+            nugetColumnHeaders.Add("Package Version");
+        }
     
-    <table>
-        <tbody>
-            <tr>
-                @foreach (var header in nugetColumnHeaders)
+        <table>
+            <tbody>
+                <tr>
+                    @foreach (var header in nugetColumnHeaders)
+                    {
+                        <th>@header</th>
+                    }
+                </tr>
+                @foreach (var nugetPackage in Model.NuGetPackages)
                 {
-                    <th>@header</th>
-                }
-            </tr>
-            @foreach (var nugetPackage in Model.NuGetPackages)
-            {
-                if (nugetPackage.SupportedPackages != null)
-                {
-                    foreach (var package in nugetPackage.SupportedPackages)
+                    if (nugetPackage.SupportedPackages != null)
+                    {
+                        foreach (var package in nugetPackage.SupportedPackages)
+                        {
+                            <tr>
+                                <td>@nugetPackage.AssemblyInfo</td>
+                                <td>@nugetPackage.Target.FullName</td>
+                                @if (!string.IsNullOrEmpty(package.Hyperlink))
+                                {
+                                    <td><a href="@package.Hyperlink">@package.PackageId</a></td>
+                                }
+                                else
+                                {
+                                    <td>@package.PackageId</td>
+                                }
+                                <td>@package.Version</td>
+                            </tr>
+                        }
+                    }
+                    else
                     {
                         <tr>
                             <td>@nugetPackage.AssemblyInfo</td>
                             <td>@nugetPackage.Target.FullName</td>
-                            @if (!string.IsNullOrEmpty(package.Hyperlink))
-                            {
-                                <td><a href="@package.Hyperlink">@package.PackageId</a></td>
-                            }
-                            else
-                            {
-                                <td>@package.PackageId</td>
-                            }
-                            <td>@package.Version</td>
+                            <td>Not Supported</td>
                         </tr>
+
                     }
                 }
-                else
-                {
-                    <tr>
-                        <td>@nugetPackage.AssemblyInfo</td>
-                        <td>@nugetPackage.Target.FullName</td>
-                        <td>Not Supported</td>
-                    </tr>
+            </tbody>
+        </table>
 
-                }
-            }
-        </tbody>
-    </table>
-
-    <p>
-        <a href="#@LocalizedStrings.PortabilitySummaryPageTitle">@LocalizedStrings.BackToSummary</a>
-    </p>
-</div>
+        <p>
+            <a href="#@LocalizedStrings.PortabilitySummaryPageTitle">@LocalizedStrings.BackToSummary</a>
+        </p>
+    </div>
+}

--- a/src/Microsoft.Fx.Portability/Analyzer/IDependencyInfo.cs
+++ b/src/Microsoft.Fx.Portability/Analyzer/IDependencyInfo.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Fx.Portability.ObjectModel;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace Microsoft.Fx.Portability.Analyzer

--- a/src/Microsoft.Fx.Portability/IAnalysisEngine.cs
+++ b/src/Microsoft.Fx.Portability/IAnalysisEngine.cs
@@ -33,5 +33,11 @@ namespace Microsoft.Fx.Portability
             IEnumerable<string> breakingChangesToSuppress,
             ICollection<string> userAssemblies,
             bool ShowRetargettingIssues = false);
+
+        IEnumerable<NuGetPackageInfo> GetNuGetPackagesInfo(IEnumerable<string> assemblies, IEnumerable<FrameworkName> targets);
+
+        IEnumerable<string> ComputeAssembliesToRemove(IEnumerable<AssemblyInfo> userAssemblies, IEnumerable<FrameworkName> targets, IEnumerable<NuGetPackageInfo> nugetPackagesForUserAssemblies);
+
+        IDictionary<MemberInfo, ICollection<AssemblyInfo>> FilterDependencies(IDictionary<MemberInfo, ICollection<AssemblyInfo>> dependencies, IEnumerable<string> assembliesToRemove);
     }
 }

--- a/src/Microsoft.Fx.Portability/IApiPortOptions.cs
+++ b/src/Microsoft.Fx.Portability/IApiPortOptions.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Fx.Portability.ObjectModel;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 
 namespace Microsoft.Fx.Portability
@@ -10,7 +11,12 @@ namespace Microsoft.Fx.Portability
     public interface IApiPortOptions
     {
         string Description { get; }
-        IEnumerable<IAssemblyFile> InputAssemblies { get; }
+
+        /// <summary>
+        /// Key: IAssemblyFile
+        /// Value: true if the file was explicitly specified and false otherwise.
+        /// </summary>
+        ImmutableDictionary<IAssemblyFile, bool> InputAssemblies { get; }
         IEnumerable<string> IgnoredAssemblyFiles { get; }
         AnalyzeRequestFlags RequestFlags { get; }
         IEnumerable<string> Targets { get; }

--- a/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
+++ b/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.1" />
     <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
     <PackageReference Include="System.Linq.Parallel" Version="4.3.0" />
     <PackageReference Include="System.Runtime" Version="4.3.0" />
   </ItemGroup>

--- a/src/Microsoft.Fx.Portability/ObjectModel/AnalyzeResponse.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/AnalyzeResponse.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         public IList<FrameworkName> Targets { get; set; }
 
+        public IList<NuGetPackageInfo> NuGetPackages { get; set; }
+
         [JsonIgnore]
         public ReportingResult ReportingResult { get; set; }
 

--- a/src/Microsoft.Fx.Portability/ObjectModel/AssemblyInfo.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Fx.Portability.Resources;
+using Newtonsoft.Json;
 using System;
 using System.Globalization;
 
@@ -26,6 +27,13 @@ namespace Microsoft.Fx.Portability.ObjectModel
             }
         }
 
+        /// <summary>
+        /// Assembly location
+        /// </summary>
+        /// <remarks>Do not serialize location and send it to service.</remarks>
+        [JsonIgnore]
+        public string Location { get; set; }
+
         public string FileVersion
         {
             get { return _fileVersion; }
@@ -45,6 +53,8 @@ namespace Microsoft.Fx.Portability.ObjectModel
                 _hashComputed = false;
             }
         }
+
+        public bool IsExplicitlySpecified { get; set; }
 
         public override bool Equals(object obj)
         {

--- a/src/Microsoft.Fx.Portability/ObjectModel/IPackageFinder.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/IPackageFinder.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Runtime.Versioning;
+
+namespace Microsoft.Fx.Portability.ObjectModel
+{
+    public interface IPackageFinder
+    {
+        /// <summary>
+        /// Retrieves the list of possible NuGet packages that contain a given assembly.
+        /// </summary>
+        /// <param name="assemblyInfo">assembly identity</param>
+        /// <param name="targets">framework supporrted by package.</param>
+        /// <param name="packages">dictionary of framework/list of packages (packages found that support the given framework)</param>
+        /// <returns>
+        /// Returns true if packages exist for that assembly (for any target), false if there are no packages
+        /// If 'true' is returned, but no packages in the list, it means the package is not supported on the given framework.
+        /// If 'false' is returned, it means we don't have any info about that assembly.
+        /// </returns>
+        bool TryFindPackage(string assemblyInfo, IEnumerable<FrameworkName> targets, out ImmutableDictionary<FrameworkName, IEnumerable<NuGetPackageId>> packages);
+    }
+}

--- a/src/Microsoft.Fx.Portability/ObjectModel/NuGetPackageId.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/NuGetPackageId.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Fx.Portability.ObjectModel
+{
+    public struct NuGetPackageId
+    {
+        public readonly string PackageId;
+        public readonly string Version;
+        public readonly string Hyperlink;
+
+        public NuGetPackageId(string packageId, string version, string hyperlink)
+        {
+            PackageId = packageId;
+            Version = version;
+            Hyperlink = hyperlink;
+        }
+    }
+}

--- a/src/Microsoft.Fx.Portability/ObjectModel/NuGetPackageInfo.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/NuGetPackageInfo.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Runtime.Versioning;
+
+namespace Microsoft.Fx.Portability.ObjectModel
+{
+    public class NuGetPackageInfo
+    {
+        private bool _hashComputed;
+        private int _hashCode;
+
+        public string AssemblyInfo { get; private set; }
+        public FrameworkName Target { get; private set; }
+        public ImmutableList<NuGetPackageId> SupportedPackages { get; private set; }
+
+        public NuGetPackageInfo(string assemblyInfo, FrameworkName target, IEnumerable<NuGetPackageId> supportedPackages)
+        {
+            AssemblyInfo = assemblyInfo;
+            Target = target;
+            SupportedPackages = supportedPackages?.ToImmutableList() ?? ImmutableList.Create<NuGetPackageId>();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if(obj == null)
+            {
+                return false;
+            }
+
+            if (obj is NuGetPackageInfo other)
+            {
+                return string.Equals(other.AssemblyInfo, AssemblyInfo, System.StringComparison.Ordinal)
+                && Target.Equals(other.Target);
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            if (!_hashComputed)
+            {
+                _hashCode = (AssemblyInfo ?? string.Empty + Target?.FullName ?? string.Empty).GetHashCode();
+                _hashComputed = true;
+            }
+            return _hashCode;
+        }
+    }
+}

--- a/src/Microsoft.Fx.Portability/ReadWriteApiPortOptions.cs
+++ b/src/Microsoft.Fx.Portability/ReadWriteApiPortOptions.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Fx.Portability.ObjectModel;
 using System.Collections.Generic;
-using System.IO;
+using System.Collections.Immutable;
 
 namespace Microsoft.Fx.Portability
 {
@@ -35,7 +35,7 @@ namespace Microsoft.Fx.Portability
 
         public virtual IEnumerable<string> IgnoredAssemblyFiles { get; set; }
 
-        public virtual IEnumerable<IAssemblyFile> InputAssemblies { get; set; }
+        public virtual ImmutableDictionary<IAssemblyFile, bool> InputAssemblies { get; set; }
 
         public virtual IEnumerable<string> InvalidInputFiles { get; set; }
 

--- a/src/Microsoft.Fx.Portability/Reporting/IReportGenerator.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/IReportGenerator.cs
@@ -10,6 +10,6 @@ namespace Microsoft.Fx.Portability.Reporting
 {
     public interface IReportGenerator
     {
-        ReportingResult ComputeReport(IList<FrameworkName> targets, string submissionId, AnalyzeRequestFlags requestFlags, IDictionary<MemberInfo, ICollection<AssemblyInfo>> allDependencies, IList<MemberInfo> missingDependencies, IDictionary<string, ICollection<string>> unresolvedAssemblies, IList<string> unresolvedUserAssemblies, IEnumerable<string> assembliesWithErrors);
+        ReportingResult ComputeReport(IList<FrameworkName> targets, string submissionId, AnalyzeRequestFlags requestFlags, IDictionary<MemberInfo, ICollection<AssemblyInfo>> allDependencies, IList<MemberInfo> missingDependencies, IDictionary<string, ICollection<string>> unresolvedAssemblies, IList<string> unresolvedUserAssemblies, IEnumerable<string> assembliesWithErrors, IList<NuGetPackageInfo> nugetPackages);
     }
 }

--- a/src/Microsoft.Fx.Portability/Reporting/ObjectModel/ReportingResult.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/ObjectModel/ReportingResult.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Fx.Portability.Reporting.ObjectModel
         public AnalyzeRequestFlags RequestFlags { get { return _requestFlags; } }
         public IList<FrameworkName> Targets { get { return _targets; } }
         public string SubmissionId { get; private set; }
-
+        public IList<NuGetPackageInfo> NuGetPackages { get; set; }
         public ReportingResult(IList<FrameworkName> targets, IEnumerable<MemberInfo> types, string submissionId, AnalyzeRequestFlags requestFlags)
         {
             _targets = targets;

--- a/src/Microsoft.Fx.Portability/Reporting/ReportGenerator.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/ReportGenerator.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Fx.Portability.Reporting
             IList<MemberInfo> missingDependencies,
             IDictionary<string, ICollection<string>> unresolvedAssemblies,
             IList<string> unresolvedUserAssemblies,
-            IEnumerable<string> assembliesWithErrors)
+            IEnumerable<string> assembliesWithErrors,
+            IList<NuGetPackageInfo> nugetPackages)
         {
             var types = allDependencies.Keys.Where(dep => dep.TypeDocId == null);
             ReportingResult result = new ReportingResult(targets, types, submissionId, requestFlags);
@@ -78,6 +79,7 @@ namespace Microsoft.Fx.Portability.Reporting
                 result.SetAssemblyNameMap(assemblyNameMap);
             }
 
+            result.NuGetPackages = nugetPackages;
             return result;
         }
 

--- a/tests/ApiPort.Tests/AnalyzeOptionsTests.cs
+++ b/tests/ApiPort.Tests/AnalyzeOptionsTests.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using ApiPort.CommandLine;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace ApiPort.Tests
+{
+    public class AnalyzeOptionsTests
+    {
+        /// <summary>
+        /// Test that 'ExplicitlySpecified' flag is correctly set up when a directory is passed 
+        /// in command line for analyzing
+        /// </summary>
+        [Fact]
+        public void TestAssemblyFlag_Directory()
+        {
+            var directoryPath = Directory.GetCurrentDirectory();
+            var args = new string[3] {
+                "analyze",
+                "-f",
+                directoryPath
+            };
+            var options = CommandLineOptions.ParseCommandLineOptions(args);
+
+            Assert.True(options is AnalyzeOptions.AnalyzeCommandLineOption);
+            var analyzeOptions = options as AnalyzeOptions.AnalyzeCommandLineOption;
+
+            Assert.True(analyzeOptions.InputAssemblies.Any());
+
+            foreach (var element in analyzeOptions.InputAssemblies)
+            {
+                // The bool with the meaning of 'ExplicitlySpecified' should be false
+                Assert.False(element.Value);
+            }
+        }
+
+        [Fact]
+        public void TestAssemblyFlag_FileName()
+        {
+            var currentAssemblyPath = typeof(AnalyzeOptionsTests).GetTypeInfo().Assembly.Location;
+            var args = new string[3] {
+                "analyze",
+                "-f",
+                currentAssemblyPath
+            };
+
+            var options = CommandLineOptions.ParseCommandLineOptions(args);
+            Assert.True(options is AnalyzeOptions.AnalyzeCommandLineOption);
+
+            var analyzeOptions = options as AnalyzeOptions.AnalyzeCommandLineOption;
+            Assert.True(analyzeOptions.InputAssemblies.Count() == 1);
+
+            // The bool with the meaning of 'ExplicitlySpecified' should be true
+            Assert.True(analyzeOptions.InputAssemblies.First().Value);
+        }
+
+        [Fact]
+        public void TestAssemblyFlag_DirectoryAndFileName()
+        {
+            var directoryPath = Directory.GetCurrentDirectory();
+            var currentAssemblyPath = typeof(AnalyzeOptionsTests).GetTypeInfo().Assembly.Location;
+
+            var args = new string[5] {
+                "analyze",
+                "-f",
+                directoryPath,
+                "-f",
+                currentAssemblyPath
+            };
+            var options = CommandLineOptions.ParseCommandLineOptions(args);
+
+            Assert.True(options is AnalyzeOptions.AnalyzeCommandLineOption);
+            var analyzeOptions = options as AnalyzeOptions.AnalyzeCommandLineOption;
+
+            Assert.True(analyzeOptions.InputAssemblies.Any());
+
+            // The scenario tested is when an assembly is passed in twice, once explicitly and once as part of the folder
+            // Assert that we test this scenario.
+            Assert.True(Path.GetDirectoryName(currentAssemblyPath).Equals(directoryPath, StringComparison.OrdinalIgnoreCase));
+
+            foreach (var element in analyzeOptions.InputAssemblies)
+            {
+                if (element.Key.Name.Equals(currentAssemblyPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    Assert.True(element.Value);
+                }
+                else
+                {
+                    Assert.False(element.Value);
+                }
+            }
+        }
+    }
+}

--- a/tests/ApiPort.Tests/ApiPort.Tests.csproj
+++ b/tests/ApiPort.Tests/ApiPort.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ApiPort\ApiPort.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ApiPortVS.Tests/app.config
+++ b/tests/ApiPortVS.Tests/app.config
@@ -36,7 +36,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.2.0" newVersion="1.2.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -154,7 +154,6 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             var assemblyToTest = TestAssembly.Create("FilterApis.cs");
             var progressReporter = Substitute.For<IProgressReporter>();
 
-            var files = new[] { new KeyValuePair<IAssemblyFile, bool>(assemblyToTest, false) };
             var dependencies = dependencyFinder.FindDependencies(new[] { assemblyToTest }, progressReporter);
             var foundDocIds = dependencies.Dependencies
                 .Select(m => m.Key.MemberDocId)

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -7,7 +7,6 @@ using NSubstitute;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -155,6 +154,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             var assemblyToTest = TestAssembly.Create("FilterApis.cs");
             var progressReporter = Substitute.For<IProgressReporter>();
 
+            var files = new[] { new KeyValuePair<IAssemblyFile, bool>(assemblyToTest, false) };
             var dependencies = dependencyFinder.FindDependencies(new[] { assemblyToTest }, progressReporter);
             var foundDocIds = dependencies.Dependencies
                 .Select(m => m.Key.MemberDocId)
@@ -176,7 +176,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
 
             var dependencyFinder = new ReflectionMetadataDependencyFinder(new AlwaysTrueDependencyFilter());
             var progressReporter = Substitute.For<IProgressReporter>();
-
+            
             var dependencies = dependencyFinder.FindDependencies(new[] { assemblyToTest }, progressReporter);
 
             var foundDocIds = dependencies

--- a/tests/Microsoft.Fx.Portability.Tests/Analysis/AnalysisEngine.NuGetPackageInfo.Tests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/Analysis/AnalysisEngine.NuGetPackageInfo.Tests.cs
@@ -1,0 +1,195 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Fx.Portability.Analysis;
+using Microsoft.Fx.Portability.ObjectModel;
+using NSubstitute;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.Versioning;
+using Xunit;
+using static Microsoft.Fx.Portability.Tests.TestData.TestFrameworks;
+
+namespace Microsoft.Fx.Portability.Tests.Analysis
+{
+    /// <summary>
+    /// Tests GetNuGetPackageInfo for AnalysisEngine
+    /// </summary>
+    public class AnalysisEngineTestsNuGetPackageInfo
+    {
+        /// <summary>
+        /// Tests that given a set of assemblies, the correct nuget package is returned.
+        /// </summary>
+        [Fact]
+        public void TestGetNugetPackageInfo()
+        {
+            // Arrange
+            var nugetPackageAssembly = GetAssemblyInfo("NugetPackageAssembly", "2.0.5.0", isExplicitlySpecified: false);
+            var inputAssemblies = new[]
+            {
+                GetAssemblyInfo("TestUserAssembly", "2.0.5.0", isExplicitlySpecified: true),
+                nugetPackageAssembly,
+                GetAssemblyInfo("TestUserLibrary", "5.0.0", isExplicitlySpecified: true),
+            };
+            var targets = new[] { Windows80, Net11, NetStandard16 };
+            var packageFinder = Substitute.For<IPackageFinder>();
+
+            var nugetPackageWin80 = GetNuGetPackage("TestNuGetPackage", "1.3.4");
+            var nugetPackageNetStandard = GetNuGetPackage("TestNuGetPackage", "10.0.8");
+
+            packageFinder.TryFindPackage(nugetPackageAssembly.AssemblyIdentity, targets, out var packages)
+                .Returns(x =>
+                {
+                    // return this value in `out var packages`
+                    x[2] = new Dictionary<FrameworkName, IEnumerable<NuGetPackageId>>
+                    {
+                        { Windows80,  new[] { nugetPackageWin80 } },
+                        { NetStandard16,  new[] { nugetPackageNetStandard } }
+                    }
+                    .ToImmutableDictionary();
+                    return true;
+                });
+
+            var engine = new AnalysisEngine(Substitute.For<IApiCatalogLookup>(), Substitute.For<IApiRecommendations>(), packageFinder);
+
+            // Act
+            var nugetPackageResult = engine.GetNuGetPackagesInfo(inputAssemblies.Select(x => x.AssemblyIdentity), targets).ToArray();
+
+            // Assert
+
+            // We expect that it was able to locate this particular package and
+            // return a result for each input target framework.
+            Assert.Equal(nugetPackageResult.Count(), targets.Length);
+
+            var windows80Result = nugetPackageResult.Single(x => x.Target == Windows80);
+            var netstandard16Result = nugetPackageResult.Single(x => x.Target == NetStandard16);
+            var net11Result = nugetPackageResult.Single(x => x.Target == Net11);
+
+            Assert.Equal(1, windows80Result.SupportedPackages.Count);
+            Assert.Equal(1, netstandard16Result.SupportedPackages.Count);
+            // We did not have any packages that supported .NET Standard 2.0
+            Assert.Empty(net11Result.SupportedPackages);
+
+            Assert.Equal(nugetPackageWin80, windows80Result.SupportedPackages.First());
+            Assert.Equal(nugetPackageNetStandard, netstandard16Result.SupportedPackages.First());
+
+            foreach (var result in nugetPackageResult)
+            {
+                Assert.Equal(result.AssemblyInfo, nugetPackageAssembly.AssemblyIdentity);
+            }
+        }
+
+        /// <summary>
+        /// Tests that if an assembly is not explicitly specified, it'll be in the set of assemblies to remove.
+        /// </summary>
+        [Fact]
+        public void ComputeAssembliesToRemove_PackageFound()
+        {
+            // Arrange
+            var userNuGetPackage = GetAssemblyInfo("NugetPackageAssembly", "2.0.5.0", isExplicitlySpecified: false);
+            var inputAssemblies = new[]
+            {
+                GetAssemblyInfo("TestUserAssembly", "2.0.5.0", isExplicitlySpecified: true),
+                userNuGetPackage,
+                GetAssemblyInfo("TestUserLibrary", "5.0.0", isExplicitlySpecified: true),
+            };
+
+            var targets = new[] { Windows81, NetStandard16 };
+            var packageId = new[] { GetNuGetPackage("SomeNuGetPackage", "2.0.1") };
+            var engine = new AnalysisEngine(Substitute.For<IApiCatalogLookup>(), Substitute.For<IApiRecommendations>(), Substitute.For<IPackageFinder>());
+
+            var nugetPackageResult = new[]
+            {
+                new NuGetPackageInfo(userNuGetPackage.AssemblyIdentity, Windows81, packageId),
+                new NuGetPackageInfo(userNuGetPackage.AssemblyIdentity, NetStandard16, packageId)
+            };
+
+            // Act
+            var assemblies = engine.ComputeAssembliesToRemove(inputAssemblies, targets, nugetPackageResult);
+
+            // Assert
+            Assert.Equal(1, assemblies.Count());
+            Assert.Equal(assemblies.First(), userNuGetPackage.AssemblyIdentity);
+        }
+
+        /// <summary>
+        /// Tests that if a matching NuGet package, BUT does not support all
+        /// the given targets... we shouldn't remove it.
+        /// </summary>
+        [Fact]
+        public void ComputeAssembliesToRemove_PackageNotFound()
+        {
+            // Arrange
+            var userNuGetPackage = GetAssemblyInfo("NugetPackageAssembly", "2.0.5.0", isExplicitlySpecified: false);
+            var inputAssemblies = new[]
+            {
+                GetAssemblyInfo("TestUserAssembly", "2.0.5.0", isExplicitlySpecified: true),
+                userNuGetPackage,
+                GetAssemblyInfo("TestUserLibrary", "5.0.0", isExplicitlySpecified: true),
+            };
+
+            var targets = new[] { Windows81, NetStandard16 };
+            var packageId = new[] { GetNuGetPackage("SomeNuGetPackage", "2.0.1") };
+            var engine = new AnalysisEngine(Substitute.For<IApiCatalogLookup>(), Substitute.For<IApiRecommendations>(), Substitute.For<IPackageFinder>());
+
+            var nugetPackageResult = new[]
+            {
+                new NuGetPackageInfo(userNuGetPackage.AssemblyIdentity, Windows81, packageId),
+            };
+
+            var assemblies = engine.ComputeAssembliesToRemove(inputAssemblies, targets, nugetPackageResult);
+
+            Assert.Empty(assemblies);
+        }
+
+        /// <summary>
+        /// Tests that for an explicitly given assembly, if a matching NuGet
+        /// package is found, AND all of its targets are supported, it is not
+        /// removed.
+        /// </summary>
+        [Fact]
+        public void ComputeAssembliesToRemove_AssemblyExplicitlyPassedIn()
+        {
+            // Arrange
+            var userNuGetPackage = GetAssemblyInfo("NugetPackageAssembly", "2.0.5.0", isExplicitlySpecified: true);
+            var inputAssemblies = new[]
+            {
+                GetAssemblyInfo("TestUserAssembly", "2.0.5.0", isExplicitlySpecified: true),
+                userNuGetPackage,
+                GetAssemblyInfo("TestUserLibrary", "5.0.0", isExplicitlySpecified: true),
+            };
+
+            var targets = new[] { Windows81, NetStandard16 };
+            var packageId = new[] { GetNuGetPackage("SomeNuGetPackage", "2.0.1") };
+            var engine = new AnalysisEngine(Substitute.For<IApiCatalogLookup>(), Substitute.For<IApiRecommendations>(), Substitute.For<IPackageFinder>());
+
+            var nugetPackageResult = new[]
+            {
+                new NuGetPackageInfo(userNuGetPackage.AssemblyIdentity, Windows81, packageId),
+                new NuGetPackageInfo(userNuGetPackage.AssemblyIdentity, NetStandard16, packageId)
+            };
+
+            var assemblies = engine.ComputeAssembliesToRemove(inputAssemblies, targets, nugetPackageResult);
+
+            Assert.Empty(assemblies);
+        }
+
+        private static AssemblyInfo GetAssemblyInfo(string assemblyName, string version, bool isExplicitlySpecified)
+        {
+            return GetAssemblyInfo(assemblyName, version, string.Empty, isExplicitlySpecified);
+        }
+
+        private static AssemblyInfo GetAssemblyInfo(string assemblyName, string version, string location, bool isExplicitlySpecified)
+        {
+            var name = new FrameworkName(assemblyName, Version.Parse(version));
+            return new AssemblyInfo { AssemblyIdentity = name.ToString(), IsExplicitlySpecified = isExplicitlySpecified };
+        }
+
+        private static NuGetPackageId GetNuGetPackage(string packageId, string version, string url = null)
+        {
+            return new NuGetPackageId(packageId, version, url);
+        }
+    }
+}

--- a/tests/Microsoft.Fx.Portability.Tests/Analysis/AnalysisEngineTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/Analysis/AnalysisEngineTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Fx.Portability.ObjectModel;
 using NSubstitute;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.Versioning;
 using Xunit;
@@ -25,7 +26,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         [Fact]
         public void FindUnreferencedAssemblies_AllNulls()
         {
-            var engine = new AnalysisEngine(null, null);
+            var engine = new AnalysisEngine(null, null, null);
 
             engine.FindUnreferencedAssemblies(null, null).ToList();
         }
@@ -35,7 +36,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         {
             var catalog = Substitute.For<IApiCatalogLookup>();
             var recommendations = Substitute.For<IApiRecommendations>();
-            var engine = new AnalysisEngine(catalog, recommendations);
+            var engine = new AnalysisEngine(catalog, recommendations, null);
 
             var result = engine.FindUnreferencedAssemblies(s_unreferencedAssemblies, null).ToList();
 
@@ -47,7 +48,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         {
             var catalog = Substitute.For<IApiCatalogLookup>();
             var recommendations = Substitute.For<IApiRecommendations>();
-            var engine = new AnalysisEngine(catalog, recommendations);
+            var engine = new AnalysisEngine(catalog, recommendations, null);
 
             var specifiedUserAssemblies = s_unreferencedAssemblies.Select(ua => new AssemblyInfo() { AssemblyIdentity = ua, FileVersion = "0.0.0.0" }).ToList();
             var unreferencedAssms = engine.FindUnreferencedAssemblies(s_unreferencedAssemblies, specifiedUserAssemblies).ToList();
@@ -63,7 +64,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
             catalog.IsFrameworkAssembly(GetAssemblyIdentityWithoutCultureAndVersion(s_unreferencedAssemblies[0])).Returns(true);
 
             var recommendations = Substitute.For<IApiRecommendations>();
-            var engine = new AnalysisEngine(catalog, recommendations);
+            var engine = new AnalysisEngine(catalog, recommendations, null);
 
             var specifiedUserAssemblies = new[] { new AssemblyInfo { FileVersion = "", AssemblyIdentity = "MyAssembly" } };
             var unreferencedAssms = engine.FindUnreferencedAssemblies(s_unreferencedAssemblies, specifiedUserAssemblies).ToList();
@@ -79,11 +80,11 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
             catalog.IsFrameworkAssembly(GetAssemblyIdentityWithoutCultureAndVersion(s_unreferencedAssemblies[0])).Returns(true);
 
             var recommendations = Substitute.For<IApiRecommendations>();
-            var engine = new AnalysisEngine(catalog, recommendations);
+            var engine = new AnalysisEngine(catalog, recommendations, null);
 
             var unreferencedAssms = engine.FindUnreferencedAssemblies(s_unreferencedAssemblies, Enumerable.Empty<AssemblyInfo>()).ToList();
 
-            // 1 missing assembly since Microsoft.CSharp is a FX assembly 
+            // 1 missing assembly since Microsoft.CSharp is a FX assembly
             Assert.Equal(1, unreferencedAssms.Count);
         }
 
@@ -94,7 +95,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
             catalog.IsFrameworkAssembly(GetAssemblyIdentityWithoutCultureAndVersion(s_unreferencedAssemblies[0])).Returns(true);
 
             var recommendations = Substitute.For<IApiRecommendations>();
-            var engine = new AnalysisEngine(catalog, recommendations);
+            var engine = new AnalysisEngine(catalog, recommendations, null);
 
             var specifiedUserAssemblies = new List<AssemblyInfo>() { new AssemblyInfo() { FileVersion = "", AssemblyIdentity = "MyAssembly" }, null };
             var unreferencedAssms = engine.FindUnreferencedAssemblies(s_unreferencedAssemblies, specifiedUserAssemblies).ToList();
@@ -110,7 +111,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
             catalog.IsFrameworkAssembly(GetAssemblyIdentityWithoutCultureAndVersion(s_unreferencedAssemblies[0])).Returns(true);
 
             var recommendations = Substitute.For<IApiRecommendations>();
-            var engine = new AnalysisEngine(catalog, recommendations);
+            var engine = new AnalysisEngine(catalog, recommendations, null);
 
             var specifiedUserAssemblies = new List<AssemblyInfo>() { new AssemblyInfo() { FileVersion = "", AssemblyIdentity = "MyAssembly" } };
             var listWithNulls = s_unreferencedAssemblies.Concat(new List<string>() { null }).ToList();
@@ -125,7 +126,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         [Fact]
         public void FindMembersNotInTargets_AllNull()
         {
-            var engine = new AnalysisEngine(null, null);
+            var engine = new AnalysisEngine(null, null, null);
 
             engine.FindMembersNotInTargets(null, null, null);
         }
@@ -158,12 +159,11 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
             catalog.IsFrameworkMember(mi2.MemberDocId).Returns(true);
 
             var recommendations = Substitute.For<IApiRecommendations>();
-            var engine = new AnalysisEngine(catalog, recommendations);
+            var engine = new AnalysisEngine(catalog, recommendations, null);
             var notInTarget = engine.FindMembersNotInTargets(targets, Array.Empty<string>(), testData);
 
             Assert.Equal(2, notInTarget.Count);
         }
-
 
         [Fact]
         public void FindMembersNotInTargetsWithSuppliedAssembly()
@@ -193,7 +193,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
             catalog.IsFrameworkMember(mi2.MemberDocId).Returns(true);
 
             var recommendations = Substitute.For<IApiRecommendations>();
-            var engine = new AnalysisEngine(catalog, recommendations);
+            var engine = new AnalysisEngine(catalog, recommendations, null);
             var notInTarget = engine.FindMembersNotInTargets(targets, new[] { mi1.DefinedInAssemblyIdentity }, testData);
 
             Assert.Equal(1, notInTarget.Count);
@@ -210,7 +210,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
             GenerateTestData(catalog);
 
             var recommendations = Substitute.For<IApiRecommendations>();
-            var engine = new AnalysisEngine(catalog, recommendations);
+            var engine = new AnalysisEngine(catalog, recommendations, null);
             var notInTarget = engine.FindMembersNotInTargets(targets, Array.Empty<string>(), testData);
 
             Assert.Equal(0, notInTarget.Count);
@@ -262,7 +262,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
             var catalog = Substitute.For<IApiCatalogLookup>();
             var recommendations = GenerateTestRecommendationsWithFixedEntry();
             var testData = GenerateTestData(catalog);
-            var engine = new AnalysisEngine(catalog, recommendations);
+            var engine = new AnalysisEngine(catalog, recommendations, null);
 
             var framework = new FrameworkName(".NET Core Framework,Version=4.5.1");
 
@@ -295,7 +295,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
             var catalog = Substitute.For<IApiCatalogLookup>();
             var recommendations = GenerateTestRecommendationsWithFixedEntry();
             var testData = GenerateTestData(catalog);
-            var engine = new AnalysisEngine(catalog, recommendations);
+            var engine = new AnalysisEngine(catalog, recommendations, null);
 
             var framework = new FrameworkName(".NET Framework, Version = v4.5.1");
             var framework2 = new FrameworkName(".NET Framework, Version = v4.5.2");
@@ -340,7 +340,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
             var catalog = Substitute.For<IApiCatalogLookup>();
             var recommendations = GenerateTestRecommendationsForShowRetargetting(2, 3);
             var testData = GenerateTestData(catalog);
-            var engine = new AnalysisEngine(catalog, recommendations);
+            var engine = new AnalysisEngine(catalog, recommendations, null);
 
             var framework = new FrameworkName(".NET Framework, Version = v4.5");
 
@@ -369,7 +369,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
             var catalog = Substitute.For<IApiCatalogLookup>();
             var recommendations = GenerateTestRecommendationsForShowRetargetting(2, 3);
             var testData = GenerateTestData(catalog);
-            var engine = new AnalysisEngine(catalog, recommendations);
+            var engine = new AnalysisEngine(catalog, recommendations, null);
 
             var framework = new FrameworkName(".NET Framework, Version = v4.5");
 
@@ -392,6 +392,39 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
             }
         }
 
+        [Fact]
+        public void FilterDependencies()
+        {
+            var testData = new Dictionary<MemberInfo, ICollection<AssemblyInfo>>();
+
+            var userAsm1 = new AssemblyInfo() { AssemblyIdentity = "userAsm1, Version=1.0.0.0", FileVersion = "1.0.0.0", IsExplicitlySpecified = true };
+            var userAsm2 = new AssemblyInfo() { AssemblyIdentity = "userAsm2, Version=2.0.0.0", FileVersion = "2.0.0.0", IsExplicitlySpecified = true };
+            var userAsm3 = new AssemblyInfo() { AssemblyIdentity = "userAsm3, Version=3.0.0.0", FileVersion = "3.0.0.0" };
+            var mi0 = new MemberInfo() { DefinedInAssemblyIdentity = "System.Drawing, Version=1.0.136.0, PublicKeyToken=b03f5f7f11d50a3a", MemberDocId = "T:System.Drawing.Color" };
+            var mi1 = new MemberInfo() { DefinedInAssemblyIdentity = "System.Drawing, Version=1.0.136.0, PublicKeyToken=b03f5f7f11d50a3a", MemberDocId = "T:System.Drawing.Brush" };
+            var mi2 = new MemberInfo() { DefinedInAssemblyIdentity = "System.Data, Version=1.0.136.0, PublicKeyToken=b77a5c561934e089", MemberDocId = "T:System.Data.SqlTypes.SqlBoolean" };
+
+            testData.Add(mi0, new List<AssemblyInfo>() { userAsm1 });
+            var usedIn1 = new HashSet<AssemblyInfo>() { userAsm1, userAsm2 };
+            testData.Add(mi1, usedIn1);
+
+            var usedIn2 = new HashSet<AssemblyInfo>() { userAsm2, userAsm3 };
+            testData.Add(mi2, usedIn2);
+
+            var targets = new List<FrameworkName>() { new FrameworkName("Windows Phone, version=8.1") };
+
+            var engine = new AnalysisEngine(Substitute.For<IApiCatalogLookup>(), Substitute.For<IApiRecommendations>(), Substitute.For<IPackageFinder>());
+
+            var assembliesToRemove = new [] { userAsm1.AssemblyIdentity, userAsm2.AssemblyIdentity };
+            var result = engine.FilterDependencies(testData, assembliesToRemove);
+
+            Assert.False(result.ContainsKey(mi0));
+            Assert.False(result.ContainsKey(mi1));
+            Assert.True(result.ContainsKey(mi2));
+
+            var mi2_usedIn = result[mi2];
+            Assert.True(mi2_usedIn.Contains(userAsm3) && !mi2_usedIn.Contains(userAsm2));
+        }
         private static void TestBreakingChangeWithoutFixedEntry(Version version, bool noBreakingChangesExpected)
         {
             TestBreakingChange(version, GenerateTestRecommendationsWithoutFixedEntry(), noBreakingChangesExpected, null, Enumerable.Empty<string>());
@@ -421,7 +454,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         {
             var catalog = Substitute.For<IApiCatalogLookup>();
             var testData = GenerateTestData(catalog);
-            var engine = new AnalysisEngine(catalog, recommendations);
+            var engine = new AnalysisEngine(catalog, recommendations, null);
 
             // Value from AnalysisEngine.FullFrameworkIdentifier
             var framework = new FrameworkName(".NET Framework" + ",Version=" + version);

--- a/tests/Microsoft.Fx.Portability.Tests/ApiPortClientTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ApiPortClientTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Fx.Portability.Reporting;
 using NSubstitute;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -73,7 +74,6 @@ namespace Microsoft.Fx.Portability.Tests
 
             dependencyFinder.FindDependencies(Arg.Any<IEnumerable<IAssemblyFile>>(), Arg.Any<IProgressReporter>()).Returns(r =>
             {
-                var list = r.Arg<IEnumerable<IAssemblyFile>>();
                 var shared = r.Arg<IProgressReporter>();
 
                 var dependencies = Substitute.For<IDependencyInfo>();
@@ -93,7 +93,7 @@ namespace Microsoft.Fx.Portability.Tests
             var options = Substitute.For<IApiPortOptions>();
 
             options.Targets.Returns(Enumerable.Empty<string>());
-            options.InputAssemblies.Returns(Enumerable.Empty<IAssemblyFile>());
+            options.InputAssemblies.Returns(ImmutableDictionary<IAssemblyFile, bool>.Empty);
 
             var result = await client.AnalyzeAssembliesAsync(options);
         }

--- a/tests/Microsoft.Fx.Portability.Tests/ReadWriteApiPortOptionsTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ReadWriteApiPortOptionsTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.Fx.Portability.ObjectModel;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -33,7 +34,7 @@ namespace Microsoft.Fx.Portability.Tests
 
             public IEnumerable<string> IgnoredAssemblyFiles { get; } = GenerateRandomList(5);
 
-            public IEnumerable<IAssemblyFile> InputAssemblies { get; } = new[] { new TestAssemblyFile() };
+            public ImmutableDictionary<IAssemblyFile, bool> InputAssemblies { get; } = ImmutableDictionary<IAssemblyFile, bool>.Empty.Add(new TestAssemblyFile(), false);
 
             public IEnumerable<string> InvalidInputFiles { get; } = GenerateRandomList(5);
 

--- a/tests/Microsoft.Fx.Portability.Tests/TestData/TestDotNetCatalog.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/TestData/TestDotNetCatalog.cs
@@ -3,18 +3,12 @@
 
 using Microsoft.Fx.Portability.ObjectModel;
 using System;
-using System.Runtime.Versioning;
+using static Microsoft.Fx.Portability.Tests.TestData.TestFrameworks;
 
 namespace Microsoft.Fx.Portability.Tests.TestData
 {
     public class TestDotNetCatalog : DotNetCatalog
     {
-        private static readonly FrameworkName s_windows80 = new FrameworkName("Windows,Version=v8.0");
-        private static readonly FrameworkName s_windows81 = new FrameworkName("Windows,Version=v8.1");
-        private static readonly FrameworkName s_netCore50 = new FrameworkName(".NET Core,Version=v5.0");
-        private static readonly FrameworkName s_net11 = new FrameworkName(".NET Framework,Version=v1.1");
-        private static readonly FrameworkName s_net40 = new FrameworkName(".NET Framework,Version=v4.0");
-
         private static readonly string[] s_frameworkIdentities = new[] {
             "System.Collections, PublicKeyToken=b03f5f7f11d50a3a",
             "System.Collections.Concurrent, PublicKeyToken=b03f5f7f11d50a3a",
@@ -22,11 +16,13 @@ namespace Microsoft.Fx.Portability.Tests.TestData
         };
 
         private static readonly TargetInfo[] s_testSupportedTargets = new[] {
-            new TargetInfo { DisplayName = s_windows80, IsReleased = true },
-            new TargetInfo { DisplayName = s_windows81, IsReleased = true },
-            new TargetInfo { DisplayName = s_netCore50, IsReleased = true },
-            new TargetInfo { DisplayName = s_net11, IsReleased = true },
-            new TargetInfo { DisplayName = s_net40, IsReleased = true },
+            new TargetInfo { DisplayName = Windows80, IsReleased = true },
+            new TargetInfo { DisplayName = Windows81, IsReleased = true },
+            new TargetInfo { DisplayName = NetCore50, IsReleased = true },
+            new TargetInfo { DisplayName = Net11, IsReleased = true },
+            new TargetInfo { DisplayName = Net40, IsReleased = true },
+            new TargetInfo { DisplayName = NetStandard16, IsReleased = true },
+            new TargetInfo { DisplayName = NetStandard20, IsReleased = false },
         };
 
         public TestDotNetCatalog()
@@ -40,8 +36,8 @@ namespace Microsoft.Fx.Portability.Tests.TestData
 
         private ApiInfoStorage[] GetApis()
         {
-            var targets11 = new[] { s_windows80, s_netCore50, s_net11 };
-            var targets40 = new[] { s_windows80, s_netCore50, s_net40 };
+            var targets11 = new[] { Windows80, NetCore50, Net11 };
+            var targets40 = new[] { Windows80, NetCore50, Net40, NetStandard16 };
 
             var apis = new[] {
                 new ApiInfoStorage {

--- a/tests/Microsoft.Fx.Portability.Tests/TestData/TestFrameworks.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/TestData/TestFrameworks.cs
@@ -1,0 +1,15 @@
+﻿using System.Runtime.Versioning;
+
+namespace Microsoft.Fx.Portability.Tests.TestData
+{
+    public static class TestFrameworks
+    {
+        internal static readonly FrameworkName Windows80 = new FrameworkName("Windows,Version=v8.0");
+        internal static readonly FrameworkName Windows81 = new FrameworkName("Windows,Version=v8.1");
+        internal static readonly FrameworkName NetCore50 = new FrameworkName(".NET Core,Version=v5.0");
+        internal static readonly FrameworkName Net11 = new FrameworkName(".NET Framework,Version=v1.1");
+        internal static readonly FrameworkName Net40 = new FrameworkName(".NET Framework,Version=v4.0");
+        internal static readonly FrameworkName NetStandard16 = new FrameworkName(".NETStandard,Version=v1.6");
+        internal static readonly FrameworkName NetStandard20 = new FrameworkName(".NETStandard,Version=v2.0");
+    }
+}


### PR DESCRIPTION
Provide information on supported NuGet packages that the analyzed binaries depend on.
- Get NuGet package suggestion for a given binary (IPackageFinder to be implemented) - the result will be a list of possible NuGet packages for an assembly/framework pair.
- Display the NuGet package ID and version in analysis output
- NuGet packages info is obtained for user assemblies and for dependencies.
- If the user passes in an entire directory as command line argument, set a flag to exclude the assembly from analysis if a supported NuGet package is found.