### PR TITLE
Fixes NullReferenceException when seeing data being transmitted

### DIFF
--- a/src/ApiPort/FileOutputApiPortService.cs
+++ b/src/ApiPort/FileOutputApiPortService.cs
@@ -143,12 +143,15 @@ namespace ApiPort
             return Task.FromResult(new ServiceResponse<AnalyzeResponse>(new AnalyzeResponse()));
         }
 
+        /// <summary>
+        /// Returns the analysis as <see cref="s_formats"/>. Input <paramref name="formats"/> is ignored.
+        /// </summary>
         public Task<ServiceResponse<IEnumerable<ReportingResultWithFormat>>> SendAnalysisAsync(AnalyzeRequest a, IEnumerable<string> formats)
         {
-            var result = formats.Select(f => new ReportingResultWithFormat
+            var result = s_formats.Select(f => new ReportingResultWithFormat
             {
-                Data = SendAnalysisAsync(a, f),
-                Format = f
+                Data = SendAnalysisAsync(a, f.DisplayName),
+                Format = f.DisplayName
             });
 
             return Task.FromResult(new ServiceResponse<IEnumerable<ReportingResultWithFormat>>(result.ToList()));


### PR DESCRIPTION
* When using [See the data being transmitted](https://github.com/Microsoft/dotnet-apiport/tree/master/docs/Console#see-the-data-being-transmitted), if format is not specified, it throws a NullReferenceException during analysis.

There is only one supported format, Json, this returns that.
