### PR TITLE
Add new target for Microsoft.Fx.Portability project

### DIFF
--- a/src/ApiPort.VisualStudio.Common/ApiPort.VisualStudio.Common.csproj
+++ b/src/ApiPort.VisualStudio.Common/ApiPort.VisualStudio.Common.csproj
@@ -118,8 +118,9 @@
     </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.4.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Collections.NonGeneric, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.NonGeneric.4.0.1\lib\net46\System.Collections.NonGeneric.dll</HintPath>
@@ -146,6 +147,7 @@
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.Fx.Portability\Microsoft.Fx.Portability.csproj">
       <Project>{8d84ec23-9977-4cc8-b649-035ffae9664c}</Project>
+      <AdditionalProperties>TargetFramework=net46</AdditionalProperties>
       <Name>Microsoft.Fx.Portability</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/ApiPort.VisualStudio.Common/packages.config
+++ b/src/ApiPort.VisualStudio.Common/packages.config
@@ -20,10 +20,16 @@
   <package id="Microsoft.VisualStudio.Utilities" version="14.3.25407" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net46" />
   <package id="System.Collections" version="4.0.11" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net46" />
   <package id="System.Collections.NonGeneric" version="4.0.1" targetFramework="net46" />
+  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net46" />
+  <package id="System.Globalization" version="4.0.0" targetFramework="net46" />
   <package id="System.IO.FileSystem" version="4.0.1" targetFramework="net46" />
   <package id="System.IO.FileSystem.Primitives" version="4.0.1" targetFramework="net46" />
+  <package id="System.Linq" version="4.0.0" targetFramework="net46" />
+  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net46" />
   <package id="System.Runtime" version="4.1.0" targetFramework="net46" />
+  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net46" />
   <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net46" />
+  <package id="System.Threading" version="4.0.0" targetFramework="net46" />
 </packages>

--- a/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
+++ b/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
@@ -186,10 +186,6 @@
     <Reference Include="System.Buffers, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Buffers.4.3.0\lib\netstandard1.1\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Collections.NonGeneric, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.NonGeneric.4.3.0\lib\net46\System.Collections.NonGeneric.dll</HintPath>
     </Reference>
@@ -331,8 +327,12 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
@@ -371,6 +371,7 @@
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.Fx.Portability\Microsoft.Fx.Portability.csproj">
       <Project>{8d84ec23-9977-4cc8-b649-035ffae9664c}</Project>
+      <AdditionalProperties>TargetFramework=net46</AdditionalProperties>
       <Name>Microsoft.Fx.Portability</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/ApiPort.VisualStudio/app.config
+++ b/src/ApiPort.VisualStudio/app.config
@@ -35,10 +35,6 @@
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-14.0.0.0" newVersion="14.0.0.0" />
       </dependentAssembly>
@@ -65,6 +61,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.37.0" newVersion="1.1.37.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/ApiPort.VisualStudio/packages.config
+++ b/src/ApiPort.VisualStudio/packages.config
@@ -40,7 +40,6 @@
   <package id="System.Buffers" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
   <package id="System.Collections.NonGeneric" version="4.3.0" targetFramework="net46" />
   <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Contracts" version="4.3.0" targetFramework="net46" />

--- a/src/ApiPort.Vsix/app.config
+++ b/src/ApiPort.Vsix/app.config
@@ -35,10 +35,6 @@
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-14.0.0.0" newVersion="14.0.0.0" />
       </dependentAssembly>
@@ -65,6 +61,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.37.0" newVersion="1.1.37.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
+++ b/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -22,9 +22,16 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.1" />
     <PackageReference Include="MicroBuild.Core" Version="0.2.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
     <PackageReference Include="System.Linq.Parallel" Version="4.3.0" />
     <PackageReference Include="System.Runtime" Version="4.3.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)'== 'netstandard1.3'">
+    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'== 'net46'">
+    <PackageReference Include="System.Collections.Immutable" Version="1.1.37" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'== 'net451'">

--- a/tests/ApiPortVS.Tests/app.config
+++ b/tests/ApiPortVS.Tests/app.config
@@ -35,10 +35,6 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.2.0" newVersion="1.2.2.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-14.0.0.0" newVersion="14.0.0.0" />
       </dependentAssembly>
@@ -61,6 +57,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.ComponentModelHost" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-14.0.0.0" newVersion="14.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.37.0" newVersion="1.1.37.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
ApiPort.VisualStudio.2015 project needs version 1.1.37 of System.Collection.Immutable because that's what Visual Studio 2015 uses. 
According to https://github.com/dotnet/roslyn/issues/15559 , providing code base redirects for some of these core assemblies comes with the risk of breaking various functionality in VS.
Microsoft.Fx.Portability , which ApiPort.VisualStudio.2015 depends on, cannot use 1.1.37 because this package is not compatible with .NET Standard 1.3. 
Add net46 target for Microsoft.Fx.Portability project so that it can use version 1.1.37 of System.Collections.Immutable.
Fixes #471 