### PR TITLE
Fix NullReferenceException in NuGetPackageInfo

### DIFF
--- a/src/Microsoft.Fx.Portability/ObjectModel/NuGetPackageInfo.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/NuGetPackageInfo.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Runtime.Versioning;
 
 namespace Microsoft.Fx.Portability.ObjectModel
@@ -18,9 +20,9 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         public NuGetPackageInfo(string assemblyInfo, FrameworkName target, IEnumerable<NuGetPackageId> supportedPackages)
         {
-            AssemblyInfo = assemblyInfo;
-            Target = target;
-            SupportedPackages = supportedPackages?.ToImmutableList() ?? ImmutableList.Create<NuGetPackageId>();
+            AssemblyInfo = assemblyInfo ?? throw new ArgumentNullException(nameof(assemblyInfo));
+            Target = target ?? throw new ArgumentNullException(nameof(target));
+            SupportedPackages = supportedPackages?.OrderBy(x => x.PackageId).ToImmutableList() ?? ImmutableList.Create<NuGetPackageId>();
         }
 
         public override bool Equals(object obj)
@@ -32,8 +34,9 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
             if (obj is NuGetPackageInfo other)
             {
-                return string.Equals(other.AssemblyInfo, AssemblyInfo, System.StringComparison.Ordinal)
-                && Target.Equals(other.Target);
+                return string.Equals(other.AssemblyInfo, AssemblyInfo, StringComparison.Ordinal)
+                    && Target.Equals(other.Target)
+                    && SupportedPackages.SequenceEqual(other.SupportedPackages);
             }
             return false;
         }

--- a/tests/Microsoft.Fx.Portability.Tests/ObjectModel/NuGetPackageInfoTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ObjectModel/NuGetPackageInfoTests.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.Fx.Portability.ObjectModel;
+using System;
+using System.Linq;
+using System.Runtime.Versioning;
+using Xunit;
+
+namespace Microsoft.Fx.Portability.Tests.ObjectModel
+{
+    public class NuGetPackageInfoTests
+    {
+        [Fact]
+        public void NuGetPackageInfoCreated()
+        {
+            var assemblyInfo = "MyNuGetPackage, Version=1.5.3";
+            var frameworkName = new FrameworkName("SomeFramework", Version.Parse("5.6.7.2"));
+            var supportedPackages = new[] {
+                new NuGetPackageId("MyNuGetPackageId.1", "1.2.2", "https://aurl.com"),
+                new NuGetPackageId("AnotherNuGetPackage.32", "3.4.4", "https://nourl"),
+                new NuGetPackageId("Something", "13.3.4", null)
+            };
+
+            var packageInfo = new NuGetPackageInfo(assemblyInfo, frameworkName, supportedPackages);
+            var noPackagesInfo = new NuGetPackageInfo(assemblyInfo, frameworkName, null);
+
+            Assert.Equal(assemblyInfo, packageInfo.AssemblyInfo);
+            Assert.Equal(frameworkName, packageInfo.Target);
+
+            var ordered = supportedPackages.OrderBy(x => x.PackageId);
+            Assert.True(packageInfo.SupportedPackages.SequenceEqual(ordered));
+
+            Assert.Equal(assemblyInfo, noPackagesInfo.AssemblyInfo);
+            Assert.Equal(frameworkName, noPackagesInfo.Target);
+            Assert.Empty(noPackagesInfo.SupportedPackages);
+        }
+
+        [Fact]
+        public void Equality()
+        {
+            // Set up
+            var assemblyName = "MyNuGetPackage, Version=1.0.4";
+            var frameworkName = new FrameworkName("SomeFramework", Version.Parse("5.6.7.2"));
+            var supportedPackages = new[] {
+                new NuGetPackageId("MyNuGetPackageId.1", "1.2.2", "https://aurl.com"),
+                new NuGetPackageId("AnotherNuGetPackage.32", "3.4.4", "https://nourl"),
+                new NuGetPackageId("Something", "13.3.4", null)
+            };
+            var supportedPackagesRemove1 = supportedPackages.Take(2);
+
+            var original = new NuGetPackageInfo(assemblyName, frameworkName, supportedPackages);
+            var compared = new NuGetPackageInfo(assemblyName, frameworkName, supportedPackages);
+            var comparedNotSamePackages = new NuGetPackageInfo(assemblyName, frameworkName, supportedPackagesRemove1);
+
+            // Act & Assert
+            Assert.True(original.Equals(compared));
+
+            Assert.False(original.Equals("something"));
+            Assert.False(original.Equals(null));
+            Assert.False(original.Equals(comparedNotSamePackages));
+        }
+
+        [Fact]
+        public void InvalidConstruction()
+        {
+            var assemblyName = "MyNuGetPackage, Version=1.0.4";
+            var frameworkName = new FrameworkName("SomeFramework", Version.Parse("5.6.7.2"));
+            var supportedPackages = new[] {
+                new NuGetPackageId("MyNuGetPackageId.1", "1.2.2", "https://aurl.com"),
+                new NuGetPackageId("AnotherNuGetPackage.32", "3.4.4", "https://nourl"),
+                new NuGetPackageId("Something", "13.3.4", null)
+            };
+
+            Assert.Throws<ArgumentNullException>(() => new NuGetPackageInfo(null, frameworkName, supportedPackages));
+            Assert.Throws<ArgumentNullException>(() => new NuGetPackageInfo(assemblyName, null, supportedPackages));
+        }
+    }
+}


### PR DESCRIPTION
* Fixes potential NRE in NuGetPackageInfo
* Update equality check to consider NuGetPackageInfo.SupportedPackages
* Adds tests

I missed these in the last review and felt bad. So, I fixed the issues.
