### PR TITLE
Set default value of IsExplicitlySpecified to true.

### DIFF
--- a/src/Microsoft.Fx.Portability/ObjectModel/AssemblyInfo.cs
+++ b/src/Microsoft.Fx.Portability/ObjectModel/AssemblyInfo.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
             }
         }
 
-        public bool IsExplicitlySpecified { get; set; }
+        public bool IsExplicitlySpecified { get; set; } = true;
 
         public override bool Equals(object obj)
         {

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Fx.Portability.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class LocalizedStrings {
@@ -211,6 +211,15 @@ namespace Microsoft.Fx.Portability.Resources {
         public static string EdgeCompatIssueDescription {
             get {
                 return ResourceManager.GetString("EdgeCompatIssueDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Framework.
+        /// </summary>
+        public static string FrameworkNameHeader {
+            get {
+                return ResourceManager.GetString("FrameworkNameHeader", resourceCulture);
             }
         }
         
@@ -410,6 +419,15 @@ namespace Microsoft.Fx.Portability.Resources {
         public static string OverwriteFile {
             get {
                 return ResourceManager.GetString("OverwriteFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PackageId.
+        /// </summary>
+        public static string PackageIdHeader {
+            get {
+                return ResourceManager.GetString("PackageIdHeader", resourceCulture);
             }
         }
         
@@ -698,6 +716,15 @@ namespace Microsoft.Fx.Portability.Resources {
         public static string UsedBy {
             get {
                 return ResourceManager.GetString("UsedBy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Version.
+        /// </summary>
+        public static string VersionHeader {
+            get {
+                return ResourceManager.GetString("VersionHeader", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
@@ -353,4 +353,16 @@
   <data name="MissingAssemblyInfo" xml:space="preserve">
     <value>Cannot locate assembly info for System.Object</value>
   </data>
+  <data name="FrameworkNameHeader" xml:space="preserve">
+    <value>Framework</value>
+    <comment>Framework name header column in Excel</comment>
+  </data>
+  <data name="PackageIdHeader" xml:space="preserve">
+    <value>PackageId</value>
+    <comment>PackageId header column in Excel</comment>
+  </data>
+  <data name="VersionHeader" xml:space="preserve">
+    <value>Version</value>
+    <comment>Version header column in Excel</comment>
+  </data>
 </root>

--- a/tests/Microsoft.Fx.Portability.Tests/Analysis/AnalysisEngine.NuGetPackageInfo.Tests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/Analysis/AnalysisEngine.NuGetPackageInfo.Tests.cs
@@ -176,15 +176,44 @@ namespace Microsoft.Fx.Portability.Tests.Analysis
             Assert.Empty(assemblies);
         }
 
-        private static AssemblyInfo GetAssemblyInfo(string assemblyName, string version, bool isExplicitlySpecified)
+        /// <summary>
+        /// Tests that if the flag isExplicitlySpecified is not set in AssemblyInfo,
+        /// it defaults to being true (which means assembly is not removed).
+        /// That is important for compatibility of old ApiPort tool with the new service, after 
+        /// 'isExplicitlySpecified' was added.
+        /// </summary>
+        [Fact]
+        public void ComputeAssembliesToRemove_AssemblyFlagNotSet()
         {
-            return GetAssemblyInfo(assemblyName, version, string.Empty, isExplicitlySpecified);
+            // Arrange
+            var userNuGetPackage = GetAssemblyInfo("NugetPackageAssembly", "2.0.5.0");
+            var inputAssemblies = new[] { userNuGetPackage };
+
+            var targets = new[] { Windows81, NetStandard16 };
+            var packageId = new[] { GetNuGetPackage("SomeNuGetPackage", "2.0.1") };
+            var engine = new AnalysisEngine(Substitute.For<IApiCatalogLookup>(), Substitute.For<IApiRecommendations>(), Substitute.For<IPackageFinder>());
+
+            var nugetPackageResult = new[]
+            {
+                new NuGetPackageInfo(userNuGetPackage.AssemblyIdentity, Windows81, packageId),
+                new NuGetPackageInfo(userNuGetPackage.AssemblyIdentity, NetStandard16, packageId)
+            };
+
+            var assemblies = engine.ComputeAssembliesToRemove(inputAssemblies, targets, nugetPackageResult);
+
+            Assert.Empty(assemblies);
         }
 
-        private static AssemblyInfo GetAssemblyInfo(string assemblyName, string version, string location, bool isExplicitlySpecified)
+        private static AssemblyInfo GetAssemblyInfo(string assemblyName, string version, bool isExplicitlySpecified)
         {
             var name = new FrameworkName(assemblyName, Version.Parse(version));
             return new AssemblyInfo { AssemblyIdentity = name.ToString(), IsExplicitlySpecified = isExplicitlySpecified };
+        }
+
+        private static AssemblyInfo GetAssemblyInfo(string assemblyName, string version)
+        {
+            var name = new FrameworkName(assemblyName, Version.Parse(version));
+            return new AssemblyInfo { AssemblyIdentity = name.ToString() };
         }
 
         private static NuGetPackageId GetNuGetPackage(string packageId, string version, string url = null)

--- a/tests/Microsoft.Fx.Portability.Tests/Analysis/AnalysisEngine.NuGetPackageInfo.Tests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/Analysis/AnalysisEngine.NuGetPackageInfo.Tests.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Fx.Portability.Tests.Analysis
         /// <summary>
         /// Tests that if the flag isExplicitlySpecified is not set in AssemblyInfo,
         /// it defaults to being true (which means assembly is not removed).
-        /// That is important for compatibility of old ApiPort tool with the new service, after 
+        /// That is important for compatibility of old ApiPort tool with the service, after 
         /// 'isExplicitlySpecified' was added.
         /// </summary>
         [Fact]


### PR DESCRIPTION
AssemblyInfo needs to have the default value of `IsExplicitlySpecified` to true. This is needed for compatibility: keep current behavior with regard to skipping assemblies  when running the old ApiPort tool with the new service.