### PR TITLE
Clean up xunit warnings

### DIFF
--- a/tests/ApiPort.Tests/AnalyzeOptionsTests.cs
+++ b/tests/ApiPort.Tests/AnalyzeOptionsTests.cs
@@ -13,7 +13,7 @@ namespace ApiPort.Tests
     public class AnalyzeOptionsTests
     {
         /// <summary>
-        /// Test that 'ExplicitlySpecified' flag is correctly set up when a directory is passed 
+        /// Test that 'ExplicitlySpecified' flag is correctly set up when a directory is passed
         /// in command line for analyzing
         /// </summary>
         [Fact]
@@ -81,7 +81,7 @@ namespace ApiPort.Tests
 
             // The scenario tested is when an assembly is passed in twice, once explicitly and once as part of the folder
             // Assert that we test this scenario.
-            Assert.True(Path.GetDirectoryName(currentAssemblyPath).Equals(directoryPath, StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(Path.GetDirectoryName(currentAssemblyPath), directoryPath, StringComparer.OrdinalIgnoreCase);
 
             foreach (var element in analyzeOptions.InputAssemblies)
             {

--- a/tests/ApiPort.Tests/ApiPort.Tests.csproj
+++ b/tests/ApiPort.Tests/ApiPort.Tests.csproj
@@ -13,8 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ApiPortVS.Tests/ApiPortVS.Tests.csproj
+++ b/tests/ApiPortVS.Tests/ApiPortVS.Tests.csproj
@@ -12,10 +12,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NSubstitute" Version="2.0.2" />
+    <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="EnvDTE100" Version="10.0.1" />
     <PackageReference Include="Microsoft.Build" Version="14.3.0" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />

--- a/tests/Microsoft.Fx.Portability.Cci.Tests/Microsoft.Fx.Portability.Cci.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Cci.Tests/Microsoft.Fx.Portability.Cci.Tests.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="Castle.Core" Version="4.1.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
   </ItemGroup>
 

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         [Theory]
         public void TestForDocId(string source, string docid)
         {
-            TestForDocId(source, docid, false);
+            TestForDocIdHelper(source, docid, false);
         }
 
         [InlineData("Spec.cs", "T:N.X`1")]
@@ -70,10 +70,10 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         [Theory]
         public void TestForDocIdUnsafe(string source, string docid)
         {
-            TestForDocId(source, docid, true);
+            TestForDocIdHelper(source, docid, true);
         }
 
-        private void TestForDocId(string source, string docid, bool allowUnsafe)
+        private void TestForDocIdHelper(string source, string docid, bool allowUnsafe)
         {
             var dependencyFinder = new ReflectionMetadataDependencyFinder(new AlwaysTrueDependencyFilter());
             var assemblyToTest = TestAssembly.Create(source, allowUnsafe);
@@ -175,7 +175,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
 
             var dependencyFinder = new ReflectionMetadataDependencyFinder(new AlwaysTrueDependencyFilter());
             var progressReporter = Substitute.For<IProgressReporter>();
-            
+
             var dependencies = dependencyFinder.FindDependencies(new[] { assemblyToTest }, progressReporter);
 
             var foundDocIds = dependencies

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="System.Diagnostics.FileVersionInfo " Version="4.3.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
   </ItemGroup>
 

--- a/tests/Microsoft.Fx.Portability.Offline.Tests/Microsoft.Fx.Portability.Offline.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Offline.Tests/Microsoft.Fx.Portability.Offline.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="Castle.Core" Version="4.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
   </ItemGroup>
 

--- a/tests/Microsoft.Fx.Portability.Offline.Tests/OffLineApiPortServiceTests.cs
+++ b/tests/Microsoft.Fx.Portability.Offline.Tests/OffLineApiPortServiceTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Fx.Portability.Offline.Tests
 
             var result = await _OfflineApiPortService.QueryDocIdsAsync(docIdsToPass);
             Assert.Equal(expectedDocIds.Count, result.Response.Count);
-            Assert.Equal(0, expectedDocIds.Except(result.Response.Select(d => d.Definition.DocId)).Count());
+            Assert.Empty(expectedDocIds.Except(result.Response.Select(d => d.Definition.DocId)));
         }
 
         [Fact]

--- a/tests/Microsoft.Fx.Portability.Reports.Html.Tests/Microsoft.Fx.Portability.Reports.Html.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Reports.Html.Tests/Microsoft.Fx.Portability.Reports.Html.Tests.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="Castle.Core" Version="4.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
   </ItemGroup>
 

--- a/tests/Microsoft.Fx.Portability.Tests/Analysis/AnalysisEngine.NuGetPackageInfo.Tests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/Analysis/AnalysisEngine.NuGetPackageInfo.Tests.cs
@@ -67,8 +67,8 @@ namespace Microsoft.Fx.Portability.Tests.Analysis
             var netstandard16Result = nugetPackageResult.Single(x => x.Target == NetStandard16);
             var net11Result = nugetPackageResult.Single(x => x.Target == Net11);
 
-            Assert.Equal(1, windows80Result.SupportedPackages.Count);
-            Assert.Equal(1, netstandard16Result.SupportedPackages.Count);
+            Assert.Single(windows80Result.SupportedPackages);
+            Assert.Single(netstandard16Result.SupportedPackages);
             // We did not have any packages that supported .NET Standard 2.0
             Assert.Empty(net11Result.SupportedPackages);
 
@@ -110,7 +110,7 @@ namespace Microsoft.Fx.Portability.Tests.Analysis
             var assemblies = engine.ComputeAssembliesToRemove(inputAssemblies, targets, nugetPackageResult);
 
             // Assert
-            Assert.Equal(1, assemblies.Count());
+            Assert.Single(assemblies);
             Assert.Equal(assemblies.First(), userNuGetPackage.AssemblyIdentity);
         }
 
@@ -179,7 +179,7 @@ namespace Microsoft.Fx.Portability.Tests.Analysis
         /// <summary>
         /// Tests that if the flag isExplicitlySpecified is not set in AssemblyInfo,
         /// it defaults to being true (which means assembly is not removed).
-        /// That is important for compatibility of old ApiPort tool with the service, after 
+        /// That is important for compatibility of old ApiPort tool with the service, after
         /// 'isExplicitlySpecified' was added.
         /// </summary>
         [Fact]

--- a/tests/Microsoft.Fx.Portability.Tests/Analysis/AnalysisEngineTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/Analysis/AnalysisEngineTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
             var unreferencedAssms = engine.FindUnreferencedAssemblies(s_unreferencedAssemblies, Enumerable.Empty<AssemblyInfo>()).ToList();
 
             // 1 missing assembly since Microsoft.CSharp is a FX assembly
-            Assert.Equal(1, unreferencedAssms.Count);
+            Assert.Single(unreferencedAssms);
         }
 
         [Fact]
@@ -302,35 +302,35 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
 
             // Vanilla
             var result = engine.FindBreakingChangeSkippedAssemblies(new[] { framework }, testData.SelectMany(kvp => kvp.Value).Distinct(), GenerateIgnoreAssemblies(false, new[] { ".NET Framework,Version=v4.5.1" }));
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             Assert.Equal("userAsm1, Version=1.0.0.0", result.FirstOrDefault().AssemblyIdentity);
 
             // Empty ignore targets
             result = engine.FindBreakingChangeSkippedAssemblies(new[] { framework }, testData.SelectMany(kvp => kvp.Value).Distinct(), GenerateIgnoreAssemblies(false, new string[0]));
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             Assert.Equal("userAsm1, Version=1.0.0.0", result.FirstOrDefault().AssemblyIdentity);
 
             // Empty ignore targets with multiple targets
             result = engine.FindBreakingChangeSkippedAssemblies(new[] { framework, framework2 }, testData.SelectMany(kvp => kvp.Value).Distinct(), GenerateIgnoreAssemblies(false, new string[0]));
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             Assert.Equal("userAsm1, Version=1.0.0.0", result.FirstOrDefault().AssemblyIdentity);
 
             // Ignore a different target
             result = engine.FindBreakingChangeSkippedAssemblies(new[] { framework }, testData.SelectMany(kvp => kvp.Value).Distinct(), GenerateIgnoreAssemblies(false, new[] { ".NET Framework,Version=v4.5.2" }));
-            Assert.Equal(0, result.Count());
+            Assert.Empty(result);
 
             // Ignore some but not all targets
             result = engine.FindBreakingChangeSkippedAssemblies(new[] { framework, framework2 }, testData.SelectMany(kvp => kvp.Value).Distinct(), GenerateIgnoreAssemblies(false, new[] { ".NET Framework,Version=v4.5.1" }));
-            Assert.Equal(0, result.Count());
+            Assert.Empty(result);
 
             // Ignore all targets
             result = engine.FindBreakingChangeSkippedAssemblies(new[] { framework, framework2 }, testData.SelectMany(kvp => kvp.Value).Distinct(), GenerateIgnoreAssemblies(false, new[] { ".NET Framework,Version=v4.5.1", ".NET Framework,Version=v4.5.2" }));
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             Assert.Equal("userAsm1, Version=1.0.0.0", result.FirstOrDefault().AssemblyIdentity);
 
             // Ignore different assembly
             result = engine.FindBreakingChangeSkippedAssemblies(new[] { framework }, testData.SelectMany(kvp => kvp.Value).Distinct(), GenerateIgnoreAssemblies(true, new string[0]));
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             Assert.Equal("userAsm2, Version=2.0.0.0", result.FirstOrDefault().AssemblyIdentity);
         }
 
@@ -415,7 +415,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
 
             var engine = new AnalysisEngine(Substitute.For<IApiCatalogLookup>(), Substitute.For<IApiRecommendations>(), Substitute.For<IPackageFinder>());
 
-            var assembliesToRemove = new [] { userAsm1.AssemblyIdentity, userAsm2.AssemblyIdentity };
+            var assembliesToRemove = new[] { userAsm1.AssemblyIdentity, userAsm2.AssemblyIdentity };
             var result = engine.FilterDependencies(testData, assembliesToRemove);
 
             Assert.False(result.ContainsKey(mi0));
@@ -467,7 +467,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
             }
             else
             {
-                Assert.Equal(1, breakingChanges.Count);
+                Assert.Single(breakingChanges);
                 Assert.Equal("5", breakingChanges.First().Break.Id);
             }
         }

--- a/tests/Microsoft.Fx.Portability.Tests/Analysis/TargetNameParserTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/Analysis/TargetNameParserTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Fx.Portability.Tests
 
             // Tests if we actually filter out the public targets based on the default target list in the config
             // We should only have 1 target!
-            Assert.Equal(1, targets.Count());
+            Assert.Single(targets);
             Assert.Equal(TestCatalog.Target1.FullName, targets.First().ToString());
         }
 
@@ -31,7 +31,7 @@ namespace Microsoft.Fx.Portability.Tests
             var targets = parser.MapTargetsToExplicitVersions(Enumerable.Empty<string>());
 
             // We should only have 1 target!
-            Assert.Equal(1, targets.Count());
+            Assert.Single(targets);
             Assert.Equal(TestCatalog.Target1.FullName, targets.First().ToString());
         }
 
@@ -42,7 +42,7 @@ namespace Microsoft.Fx.Portability.Tests
             var targets = parser.MapTargetsToExplicitVersions(new String[] { "target 1, version=1.0" });
 
             // We should only have 1 target!
-            Assert.Equal(1, targets.Count());
+            Assert.Single(targets);
             Assert.Equal("target 1,Version=v1.0", targets.First().ToString());
         }
 
@@ -53,7 +53,7 @@ namespace Microsoft.Fx.Portability.Tests
             var targets = parser.MapTargetsToExplicitVersions(Enumerable.Empty<string>());
 
             // We should only have 0 target!
-            Assert.Equal(0, targets.Count());
+            Assert.Empty(targets);
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace Microsoft.Fx.Portability.Tests
             var targets = parser.MapTargetsToExplicitVersions(new string[] { "Target 3" });
 
             // We should only have 1 target!
-            Assert.Equal(1, targets.Count());
+            Assert.Single(targets);
             Assert.Equal(TestCatalog.Target3.FullName, targets.First().ToString());
         }
 
@@ -96,7 +96,7 @@ namespace Microsoft.Fx.Portability.Tests
 
             var parser = new TargetNameParser(new TestCatalog(), $"TargetNonExistent, version=4.0;{target1}");
 
-            Assert.Equal(1, parser.DefaultTargets.Count());
+            Assert.Single(parser.DefaultTargets);
             Assert.Equal(target1Framework, parser.DefaultTargets.Single());
         }
     }

--- a/tests/Microsoft.Fx.Portability.Tests/Analyzer/DotNetFrameworkFilterTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/Analyzer/DotNetFrameworkFilterTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             Assert.True(_assemblyFilter.IsFrameworkAssembly(null));
         }
 
-        // Microsoft public key token 
+        // Microsoft public key token
         [InlineData("b77a5c561934e089", true)]
         [InlineData("b03f5f7f11d50a3a", true)]
         [InlineData("7cec85d7bea7798e", true)]
@@ -26,7 +26,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         [InlineData("24eec0d8c86cda1e", true)]
         [InlineData("0738eb9f132ed756", true)]
         // Microsoft public key token (different case)
-        [InlineData("0738eb9f132ed756", true)]
+        [InlineData("0738eb9F132ed756", true)]
         // Non-Microsoft public key token
         [InlineData("something", false)]
         [Theory]

--- a/tests/Microsoft.Fx.Portability.Tests/ApiPortServiceTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ApiPortServiceTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Fx.Portability.Tests
             var result = serviceResponse.Response;
 
             Assert.Equal(docIds.Count(), result.Count());
-            Assert.Equal(0, docIds.Except(result.Select(r => r.Definition.DocId)).Count());
+            Assert.Empty(docIds.Except(result.Select(r => r.Definition.DocId)));
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace Microsoft.Fx.Portability.Tests
             var result = serviceResponse.Response;
 
             Assert.Equal(expected.Count(), result.Count());
-            Assert.Equal(0, expected.Except(result.Select(r => r.DisplayName)).Count());
+            Assert.Empty(expected.Except(result.Select(r => r.DisplayName)));
         }
 
         private HttpResponseMessage HttpRequestConverter(HttpRequestMessage request)

--- a/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="Castle.Core" Version="4.1.0" />
     <PackageReference Include="System.Diagnostics.FileVersionInfo " Version="4.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
   </ItemGroup>
 

--- a/tests/Microsoft.Fx.Portability.Tests/SerializationTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/SerializationTests.cs
@@ -108,6 +108,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         private static void VerifyEmptySerialized<T>()
+            where T : class
         {
             var deserialized = "".Serialize().Deserialize<T>();
 

--- a/tests/Microsoft.Fx.Portability.Tests/TargetMapTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/TargetMapTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Fx.Portability.Tests
         [Fact]
         public void VerifySingleAliasMapping()
         {
-            Assert.Throws(typeof(AliasMappedToMultipleNamesException), () =>
+            Assert.Throws<AliasMappedToMultipleNamesException>(() =>
             {
                 var map = new TargetMapper();
 
@@ -171,11 +171,7 @@ namespace Microsoft.Fx.Portability.Tests
             var map = new TargetMapper();
             var groupings = "group1: target1,target2; group2 target1, target3";
 
-            try
-            {
-                map.ParseAliasString(groupings, true);
-            }
-            catch (ArgumentOutOfRangeException) { }
+            Assert.Throws<ArgumentOutOfRangeException>(() => map.ParseAliasString(groupings, true));
 
             Assert.Equal("group1", map.GetNames("group1").Single());
             Assert.Equal("group2", map.GetNames("group2").Single());
@@ -184,7 +180,7 @@ namespace Microsoft.Fx.Portability.Tests
         [Fact]
         public void ParseInvalidGroupsValidate()
         {
-            Assert.Throws(typeof(ArgumentOutOfRangeException), () =>
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
             {
                 var map = new TargetMapper();
                 var groupings = "group1 target1,target2; group2: target1, target3";


### PR DESCRIPTION
This updates xunit to the latest beta (causes some crashes on Fall Creators Update if not) and addresses new warnings from xunit analyzers