### PR TITLE
Add ProvideCodeBase attributes to tell VS where to load assemblies from

### DIFF
--- a/PortabilityTools.VisualStudio.Imports.targets
+++ b/PortabilityTools.VisualStudio.Imports.targets
@@ -1,8 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- Manually add NuGet dependencies to VSIX, including framework facades -->
+  <!-- Manually add NuGet dependencies to VSIX, including framework facades. To regenerate this, run the following powershell from ApiPort.Vsix output:
+  
+  gci *.dll `
+    | where Name -notmatch Microsoft.VisualStudio `
+    | where Name -notmatch stdole `
+    | where Name -notmatch vslang `
+    | where Name -notmatch EnvDTE `
+    | where Name -notmatch Microsoft.Build `
+    | % { Write-Host "<VSIXSourceItem Include=`"`$(OutputPath)\$($_.Name)`" />" }
+ 
+  -->
   <Target Name="AddToVsixSources" AfterTargets="GetVsixSourceItems">
     <ItemGroup>
+      <VSIXSourceItem Include="$(OutputPath)\ApiPort.VisualStudio.2015.dll" />
+      <VSIXSourceItem Include="$(OutputPath)\ApiPort.VisualStudio.2017.dll" />
+      <VSIXSourceItem Include="$(OutputPath)\ApiPort.VisualStudio.Common.dll" />
       <VSIXSourceItem Include="$(OutputPath)\ApiPort.VisualStudio.dll" />
       <VSIXSourceItem Include="$(OutputPath)\Autofac.dll" />
       <VSIXSourceItem Include="$(OutputPath)\Microsoft.AspNetCore.WebUtilities.dll" />
@@ -10,12 +23,21 @@
       <VSIXSourceItem Include="$(OutputPath)\Microsoft.Extensions.Primitives.dll" />
       <VSIXSourceItem Include="$(OutputPath)\Microsoft.Fx.Portability.Cci.dll" />
       <VSIXSourceItem Include="$(OutputPath)\Microsoft.Fx.Portability.dll" />
+      <VSIXSourceItem Include="$(OutputPath)\Microsoft.Net.Http.Headers.dll" />
       <VSIXSourceItem Include="$(OutputPath)\Microsoft.Win32.Primitives.dll" />
       <VSIXSourceItem Include="$(OutputPath)\Newtonsoft.Json.dll" />
       <VSIXSourceItem Include="$(OutputPath)\System.AppContext.dll" />
       <VSIXSourceItem Include="$(OutputPath)\System.Buffers.dll" />
+      <VSIXSourceItem Include="$(OutputPath)\System.Collections.Immutable.dll" />
       <VSIXSourceItem Include="$(OutputPath)\System.Collections.NonGeneric.dll" />
+      <VSIXSourceItem Include="$(OutputPath)\System.Composition.AttributedModel.dll" />
+      <VSIXSourceItem Include="$(OutputPath)\System.Composition.Convention.dll" />
+      <VSIXSourceItem Include="$(OutputPath)\System.Composition.Hosting.dll" />
+      <VSIXSourceItem Include="$(OutputPath)\System.Composition.Runtime.dll" />
+      <VSIXSourceItem Include="$(OutputPath)\System.Composition.TypedParts.dll" />
       <VSIXSourceItem Include="$(OutputPath)\System.Console.dll" />
+      <VSIXSourceItem Include="$(OutputPath)\System.Diagnostics.FileVersionInfo.dll" />
+      <VSIXSourceItem Include="$(OutputPath)\System.Diagnostics.TraceSource.dll" />
       <VSIXSourceItem Include="$(OutputPath)\System.Globalization.Calendars.dll" />
       <VSIXSourceItem Include="$(OutputPath)\System.IO.Compression.dll" />
       <VSIXSourceItem Include="$(OutputPath)\System.IO.Compression.ZipFile.dll" />
@@ -23,12 +45,15 @@
       <VSIXSourceItem Include="$(OutputPath)\System.IO.FileSystem.Primitives.dll" />
       <VSIXSourceItem Include="$(OutputPath)\System.Net.Http.dll" />
       <VSIXSourceItem Include="$(OutputPath)\System.Net.Sockets.dll" />
+      <VSIXSourceItem Include="$(OutputPath)\System.Runtime.CompilerServices.Unsafe.dll" />
       <VSIXSourceItem Include="$(OutputPath)\System.Runtime.InteropServices.RuntimeInformation.dll" />
       <VSIXSourceItem Include="$(OutputPath)\System.Security.Cryptography.Algorithms.dll" />
       <VSIXSourceItem Include="$(OutputPath)\System.Security.Cryptography.Encoding.dll" />
       <VSIXSourceItem Include="$(OutputPath)\System.Security.Cryptography.Primitives.dll" />
       <VSIXSourceItem Include="$(OutputPath)\System.Security.Cryptography.X509Certificates.dll" />
       <VSIXSourceItem Include="$(OutputPath)\System.Text.Encodings.Web.dll" />
+      <VSIXSourceItem Include="$(OutputPath)\System.Threading.Tasks.Dataflow.dll" />
+      <VSIXSourceItem Include="$(OutputPath)\System.Xml.ReaderWriter.dll" />
     </ItemGroup>
   </Target>
 </Project>

--- a/PortabilityTools.VisualStudio.Imports.targets
+++ b/PortabilityTools.VisualStudio.Imports.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Manually add NuGet dependencies to VSIX, including framework facades. To regenerate this, run the following powershell from ApiPort.Vsix output:
-  
+
   gci *.dll `
     | where Name -notmatch Microsoft.VisualStudio `
     | where Name -notmatch stdole `
@@ -9,7 +9,7 @@
     | where Name -notmatch EnvDTE `
     | where Name -notmatch Microsoft.Build `
     | % { Write-Host "<VSIXSourceItem Include=`"`$(OutputPath)\$($_.Name)`" />" }
- 
+
   -->
   <Target Name="AddToVsixSources" AfterTargets="GetVsixSourceItems">
     <ItemGroup>

--- a/PortabilityTools.sln
+++ b/PortabilityTools.sln
@@ -5,9 +5,12 @@ VisualStudioVersion = 15.0.26730.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C991F5FC-04B5-420C-98A0-80974AA946F7}"
 	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		global.json = global.json
 		LICENSE = LICENSE
 		NuGet.config = NuGet.config
+		PortabilityTools.VisualStudio.Imports.targets = PortabilityTools.VisualStudio.Imports.targets
 		README.md = README.md
 	EndProjectSection
 	ProjectSection(FolderGlobals) = preProject

--- a/build.ps1
+++ b/build.ps1
@@ -72,7 +72,7 @@ if ($Platform -eq "AnyCPU") {
 
 Push-Location $root
 
-& $MSBuild PortabilityTools.sln "/t:restore;build;pack" /p:Configuration=$Configuration /p:Platform="$PlatformToUse" /nologo /m /v:m /nr:false /flp:logfile=$binFolder\msbuild.log`;verbosity=$Verbosity /p:DeployExtension=false 
+& $MSBuild PortabilityTools.sln "/t:restore;build;pack" /p:Configuration=$Configuration /p:Platform="$PlatformToUse" /nologo /m /v:m /nr:false /flp:logfile=$binFolder\msbuild.log`;verbosity=$Verbosity
 
 Pop-Location
 

--- a/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
+++ b/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
@@ -17,6 +17,7 @@
     <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>
+    <DeployExtension>false</DeployExtension>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Most projects will just inherit this from Directory.Build.props, but since this contains WPF, a temp project is created which causes issues with MSBuildProjectName -->
@@ -39,13 +40,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <RunCodeAnalysis>false</RunCodeAnalysis>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- Debugging Settings; Stored in project file instead of .user file to be available to everyone -->
-    <StartAction>Program</StartAction>
-    <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
-    <StartArguments>/RootSuffix Exp</StartArguments>
-    <EnableUnmanagedDebugging>False</EnableUnmanagedDebugging>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Core" />

--- a/src/ApiPort.VisualStudio/Properties/Properties.cs
+++ b/src/ApiPort.VisualStudio/Properties/Properties.cs
@@ -1,3 +1,56 @@
 ﻿using Microsoft.VisualStudio.Shell;
 
 [assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.Win32.Primitives")]
+
+/* Need to provide a code base attribute for each assembly. To regenerate this, run the following powershell from ApiPort.Vsix output:
+ 
+ gci *.dll `
+   | where Name -notmatch Microsoft.VisualStudio `
+   | where Name -notmatch stdole `
+   | where Name -notmatch vslang `
+   | where Name -notmatch EnvDTE `
+   | where Name -notmatch Microsoft.Build `
+   | % { Write - Host "[assembly: ProvideCodeBase(CodeBase = @`"`$PackageFolder`$\$($_.Name)`")]" }
+
+ */
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\ApiPort.VisualStudio.2015.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\ApiPort.VisualStudio.2017.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\ApiPort.VisualStudio.Common.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\ApiPort.VisualStudio.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Autofac.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.AspNetCore.WebUtilities.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Cci.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.Primitives.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Fx.Portability.Cci.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Fx.Portability.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Net.Http.Headers.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Win32.Primitives.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Newtonsoft.Json.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.AppContext.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Buffers.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Collections.Immutable.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Collections.NonGeneric.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Composition.AttributedModel.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Composition.Convention.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Composition.Hosting.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Composition.Runtime.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Composition.TypedParts.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Console.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Diagnostics.FileVersionInfo.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Diagnostics.TraceSource.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Globalization.Calendars.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.IO.Compression.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.IO.Compression.ZipFile.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.IO.FileSystem.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.IO.FileSystem.Primitives.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Net.Http.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Net.Sockets.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Runtime.CompilerServices.Unsafe.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Runtime.InteropServices.RuntimeInformation.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Security.Cryptography.Algorithms.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Security.Cryptography.Encoding.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Security.Cryptography.Primitives.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Security.Cryptography.X509Certificates.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Text.Encodings.Web.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Threading.Tasks.Dataflow.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Xml.ReaderWriter.dll")]

--- a/src/ApiPort.VisualStudio/Properties/Properties.cs
+++ b/src/ApiPort.VisualStudio/Properties/Properties.cs
@@ -3,7 +3,7 @@
 [assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.Win32.Primitives")]
 
 /* Need to provide a code base attribute for each assembly. To regenerate this, run the following powershell from ApiPort.Vsix output:
- 
+
  gci *.dll `
    | where Name -notmatch Microsoft.VisualStudio `
    | where Name -notmatch stdole `

--- a/src/ApiPort.Vsix/ApiPort.Vsix.csproj
+++ b/src/ApiPort.Vsix/ApiPort.Vsix.csproj
@@ -19,9 +19,6 @@
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <CreateVsixContainer>True</CreateVsixContainer>
-    <StartAction>Program</StartAction>
-    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
-    <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,6 +40,13 @@
   <PropertyGroup>
     <!-- This project does not output any binaries, so API Scan can be skipped. -->
     <IsPackage>true</IsPackage>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!-- Debugging Settings; Stored in project file instead of .user file to be available to everyone -->
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
+    <StartArguments>/RootSuffix Exp</StartArguments>
+    <EnableUnmanagedDebugging>False</EnableUnmanagedDebugging>
   </PropertyGroup>
   <ItemGroup>
     <None Include="source.extension.vsixmanifest">


### PR DESCRIPTION
Fixes #478 