### PR TITLE
Set project reference to a specific target.

### DIFF
--- a/src/ApiPort.VisualStudio.Common/ApiPort.VisualStudio.Common.csproj
+++ b/src/ApiPort.VisualStudio.Common/ApiPort.VisualStudio.Common.csproj
@@ -47,6 +47,7 @@
     <ProjectReference Include="..\Microsoft.Fx.Portability\Microsoft.Fx.Portability.csproj">
       <Project>{8d84ec23-9977-4cc8-b649-035ffae9664c}</Project>
       <Name>Microsoft.Fx.Portability</Name>
+      <AdditionalProperties>TargetFramework=net46</AdditionalProperties>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/ApiPort/ApiPort.csproj
+++ b/src/ApiPort/ApiPort.csproj
@@ -50,7 +50,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Fx.Portability.MetadataReader\Microsoft.Fx.Portability.MetadataReader.csproj" />
-    <ProjectReference Include="..\Microsoft.Fx.Portability\Microsoft.Fx.Portability.csproj" />
+    <ProjectReference Include="..\Microsoft.Fx.Portability\Microsoft.Fx.Portability.csproj">
+      <AdditionalProperties>TargetFramework=netstandard1.3</AdditionalProperties>
+    </ProjectReference>
   </ItemGroup>
 
   <Target Name="AfterBuild">


### PR DESCRIPTION
The project Microsoft.Fx.Portability targets net46 and netstandard1.3 (net46 is needed so that System.Collections.Immutable version no higher that 1.1.37 is used for Visual Studio 2015 extension - see #473 )
Some projects that reference Microsoft.Fx.Portability need to specify the target.
