### PR TITLE
Add FxCop analyzers and fix up culture aware formatting

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,8 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputDrop>$(TF_BUILD_BINARIESDIRECTORY)</OutputDrop>
     <NoWarn>$(NoWarn),1570,1572,1573,1574,1591,1701</NoWarn>
+    <Features>IOperation;$(Features)</Features>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\rules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -78,11 +78,27 @@
     </AssemblyVersionAttribute>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="MicroBuild.Core" Version="0.2.0">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference> 
-  </ItemGroup>
+  <Choose>
+    <When Condition="!$(AssemblyName.ToLower().Contains('test'))">
+      <PropertyGroup>
+        <IsTestProject>false</IsTestProject>
+      </PropertyGroup>
+      <ItemGroup>
+        <PackageReference Include="MicroBuild.Core" Version="0.2.0">
+          <PrivateAssets>All</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1">
+          <PrivateAssets>All</PrivateAssets>
+        </PackageReference>
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <IsTestProject>true</IsTestProject>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
 
   <Target Name="GenerateAssemblyInfoFile" BeforeTargets="BeforeBuild">
     <MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
@@ -101,4 +117,5 @@
         <Compile Remove="@(EmbeddedResource-> '%(Identity)')" />
     </ItemGroup>
   </Target>
+
 </Project>

--- a/PortabilityTools.sln
+++ b/PortabilityTools.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		NuGet.config = NuGet.config
 		PortabilityTools.VisualStudio.Imports.targets = PortabilityTools.VisualStudio.Imports.targets
 		README.md = README.md
+		rules.ruleset = rules.ruleset
 	EndProjectSection
 	ProjectSection(FolderGlobals) = preProject
 		global_1json__JSONSchema = http://json.schemastore.org/global
@@ -65,11 +66,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Fx.Portability.Cc
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Fx.Portability.Reports.Html.Tests", "tests\Microsoft.Fx.Portability.Reports.Html.Tests\Microsoft.Fx.Portability.Reports.Html.Tests.csproj", "{4EDE5B41-A4AD-4BFB-9986-F566FB887A34}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiPort.VisualStudio.2015", "src\ApiPort.VisualStudio.2015\ApiPort.VisualStudio.2015.csproj", "{9DEF460B-6383-4665-839B-C0B5E6BB6A5F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApiPort.VisualStudio.2015", "src\ApiPort.VisualStudio.2015\ApiPort.VisualStudio.2015.csproj", "{9DEF460B-6383-4665-839B-C0B5E6BB6A5F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiPort.VisualStudio.2017", "src\ApiPort.VisualStudio.2017\ApiPort.VisualStudio.2017.csproj", "{C0629A8D-7107-46CF-83B8-408E1886AB36}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApiPort.VisualStudio.2017", "src\ApiPort.VisualStudio.2017\ApiPort.VisualStudio.2017.csproj", "{C0629A8D-7107-46CF-83B8-408E1886AB36}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiPort.VisualStudio.Common", "src\ApiPort.VisualStudio.Common\ApiPort.VisualStudio.Common.csproj", "{60798B82-B273-4D39-AA52-021C7228A0AD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApiPort.VisualStudio.Common", "src\ApiPort.VisualStudio.Common\ApiPort.VisualStudio.Common.csproj", "{60798B82-B273-4D39-AA52-021C7228A0AD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApiPort.Tests", "tests\ApiPort.Tests\ApiPort.Tests.csproj", "{EE708186-6345-486D-9810-17D98439DAAE}"
 EndProject

--- a/rules.ruleset
+++ b/rules.ruleset
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="rules" ToolsVersion="15.0">
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="CA1030" Action="None" />
+    <Rule Id="CA1034" Action="None" />
+    <Rule Id="CA1036" Action="None" />
+    <Rule Id="CA1051" Action="None" />
+    <Rule Id="CA1052" Action="None" />
+    <Rule Id="CA1056" Action="None" />
+    <Rule Id="CA1064" Action="None" />
+    <Rule Id="CA1067" Action="None" />
+    <Rule Id="CA1710" Action="None" />
+    <Rule Id="CA1716" Action="None" />
+    <Rule Id="CA1717" Action="None" />
+    <Rule Id="CA1721" Action="None" />
+    <Rule Id="CA1724" Action="None" />
+    <Rule Id="CA1801" Action="None" />
+    <Rule Id="CA1812" Action="None" />
+    <Rule Id="CA1815" Action="None" />
+    <Rule Id="CA1823" Action="None" />
+    <Rule Id="CA2007" Action="None" />
+    <Rule Id="CA2211" Action="None" />
+    <Rule Id="CA2227" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeQuality.CSharp.Analyzers" RuleNamespace="Microsoft.CodeQuality.CSharp.Analyzers">
+    <Rule Id="CA1032" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
+    <Rule Id="CA1308" Action="None" />
+    <Rule Id="CA1816" Action="None" />
+    <Rule Id="CA2208" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.NetCore.CSharp.Analyzers" RuleNamespace="Microsoft.NetCore.CSharp.Analyzers">
+    <Rule Id="CA1810" Action="None" />
+    <Rule Id="CA1824" Action="None" />
+    <Rule Id="CA1825" Action="None" />
+    <Rule Id="CA5350" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.NetFramework.Analyzers" RuleNamespace="Microsoft.NetFramework.Analyzers">
+    <Rule Id="CA2235" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.NetFramework.CSharp.Analyzers" RuleNamespace="Microsoft.NetFramework.CSharp.Analyzers">
+    <Rule Id="CA5350" Action="None" />
+  </Rules>
+</RuleSet>

--- a/samples/SearchFxApi/Program.cs
+++ b/samples/SearchFxApi/Program.cs
@@ -4,6 +4,7 @@
 using Microsoft.Fx.Portability;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -28,7 +29,7 @@ namespace SearchFxApi
             }
 
             Console.Write("Enter api number:  ");
-            var index = int.Parse(Console.ReadLine());
+            var index = int.Parse(Console.ReadLine(), CultureInfo.CurrentCulture);
 
             var apiToSearchFor = matchingApis[index];
             var apiInformation = GetApi(analysisService, apiToSearchFor.DocId).Result;

--- a/src/ApiPort.VisualStudio.Common/Analyze/ApiPortVsAnalyzer.cs
+++ b/src/ApiPort.VisualStudio.Common/Analyze/ApiPortVsAnalyzer.cs
@@ -8,6 +8,7 @@ using Microsoft.Fx.Portability;
 using Microsoft.Fx.Portability.Reporting;
 using Microsoft.Fx.Portability.Reporting.ObjectModel;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -84,7 +85,7 @@ namespace ApiPortVS.Analyze
                 {
                     await _threadingService.SwitchToMainThreadAsync();
 
-                    var message = string.Format(LocalizedStrings.InvalidPlatformSelectedFormat, invalidPlatform.Name);
+                    var message = string.Format(CultureInfo.CurrentCulture, LocalizedStrings.InvalidPlatformSelectedFormat, invalidPlatform.Name);
                     _outputWindow.WriteLine(message);
                 }
             }

--- a/src/ApiPort.VisualStudio.Common/ViewModels/OptionsViewModel.cs
+++ b/src/ApiPort.VisualStudio.Common/ViewModels/OptionsViewModel.cs
@@ -238,7 +238,7 @@ namespace ApiPortVS.ViewModels
                     {
                         foreach (var name in _targetMapper.GetNames(alias))
                         {
-                            if (String.Equals(platform.Name, name))
+                            if (String.Equals(platform.Name, name, StringComparison.Ordinal))
                             {
                                 platform.AlternativeNames.Add(alias);
                             }

--- a/src/ApiPort.VisualStudio/AnalyzeMenu.cs
+++ b/src/ApiPort.VisualStudio/AnalyzeMenu.cs
@@ -12,6 +12,7 @@ using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -170,8 +171,8 @@ namespace ApiPortVS
 
             var header = new StringBuilder();
             var assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version;
-            header.AppendLine(string.Format(LocalizedStrings.CopyrightFormat, assemblyVersion));
-            header.AppendLine(string.Concat(LocalizedStrings.MoreInformationAvailableAt, " ", LocalizedStrings.MoreInformationUrl));
+            header.AppendLine(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.CopyrightFormat, assemblyVersion));
+            header.AppendLine(string.Concat(CultureInfo.CurrentCulture, LocalizedStrings.MoreInformationAvailableAt, " ", LocalizedStrings.MoreInformationUrl));
 
             _output.WriteLine(header.ToString());
         }

--- a/src/ApiPort.VisualStudio/OutputWindowWriter.cs
+++ b/src/ApiPort.VisualStudio/OutputWindowWriter.cs
@@ -54,7 +54,7 @@ namespace ApiPortVS
 
         public override void Write(char text)
         {
-            var errCode = _outputWindow.OutputStringThreadSafe(text.ToString());
+            var errCode = _outputWindow.OutputStringThreadSafe(text.ToString(CultureInfo.CurrentCulture));
 
             if (ErrorHandler.Failed(errCode))
             {

--- a/src/ApiPort/ConsoleApiPort.cs
+++ b/src/ApiPort/ConsoleApiPort.cs
@@ -36,7 +36,7 @@ namespace ApiPort
 
                 foreach (var outputFormat in outputFormats)
                 {
-                    Console.WriteLine(string.Format(LocalizedStrings.TargetsListNoVersion, outputFormat));
+                    Console.WriteLine(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.TargetsListNoVersion, outputFormat));
                 }
             }
         }

--- a/src/ApiPort/ConsoleProgressReporter.cs
+++ b/src/ApiPort/ConsoleProgressReporter.cs
@@ -5,6 +5,7 @@ using ApiPort.Resources;
 using Microsoft.Fx.Portability;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -139,7 +140,7 @@ namespace ApiPort
 
                     Console.SetCursorPosition(left, Console.CursorTop);
 
-                    WriteColor(string.Format(LocalizedStrings.ProgressReportInProgress, new string('.', ++count % 4).PadRight(3)), ConsoleColor.Yellow);
+                    WriteColor(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.ProgressReportInProgress, new string('.', ++count % 4).PadRight(3)), ConsoleColor.Yellow);
 
                     await Task.Delay(350);
                 }

--- a/src/ApiPort/DocIdSearchRepl.cs
+++ b/src/ApiPort/DocIdSearchRepl.cs
@@ -69,11 +69,11 @@ namespace ApiPort
                     if (Int32.TryParse(trimmed, out updatedCount))
                     {
                         count = updatedCount;
-                        WriteColorLine(string.Format("Updated count to {0}", count), ConsoleColor.Yellow);
+                        WriteColorLine($"Updated count to {count}", ConsoleColor.Yellow);
                     }
                     else
                     {
-                        WriteColorLine(string.Format("Invalid number: '{0}'", trimmed), ConsoleColor.Red);
+                        WriteColorLine($"Invalid number: '{trimmed}'", ConsoleColor.Red);
                     }
 
                     continue;
@@ -85,12 +85,12 @@ namespace ApiPort
                 {
                     foreach (var result in results)
                     {
-                        WriteColorLine(string.Format("\"{0}\",", result), ConsoleColor.Cyan);
+                        WriteColorLine($"\"{result}\",", ConsoleColor.Cyan);
                     }
                 }
                 else
                 {
-                    WriteColorLine(string.Format("Did not find anything for search '{0}'", query), ConsoleColor.Yellow);
+                    WriteColorLine($"Did not find anything for search '{query}'", ConsoleColor.Yellow);
                 }
             }
         }
@@ -100,7 +100,7 @@ namespace ApiPort
             e.Cancel = true;
         }
 
-        private static void WriteColorLine(string message, ConsoleColor color)
+        private static void WriteColorLine(FormattableString message, ConsoleColor color)
         {
             var previousColor =
 #if LINUX

--- a/src/ApiPort/Proxy/ProxyProvider.cs
+++ b/src/ApiPort/Proxy/ProxyProvider.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Fx.Portability.Proxy
     /// 1. From a configuration file <see cref="ProxyConstants.ConfigurationFile"/>
     /// 2. From an environment variable <see cref="ProxyConstants.HttpProxy"/>
     /// 3. System provided proxy
-    /// 
+    ///
     /// Looks for the one in the configuration file because the user would
-    /// explicitly want to override their current proxy settings in order 
+    /// explicitly want to override their current proxy settings in order
     /// for the configuration value to be set.
     /// </summary>
     /// <remarks>
@@ -243,7 +243,7 @@ namespace Microsoft.Fx.Portability.Proxy
                 if (proxyUri != null)
                 {
                     var proxyAddress = new Uri(proxyUri.AbsoluteUri);
-                    if (string.Equals(proxyAddress.AbsoluteUri, uri.AbsoluteUri))
+                    if (string.Equals(proxyAddress.AbsoluteUri, uri.AbsoluteUri, StringComparison.Ordinal))
                     {
                         return false;
                     }

--- a/src/Microsoft.Fx.Portability.Cci/HostEnvironment.cs
+++ b/src/Microsoft.Fx.Portability.Cci/HostEnvironment.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Cci.Extensions
                 if (assembly.AssemblyIdentity.Equals(assembly.CoreAssemblySymbolicIdentity))
                     return assembly.AssemblyIdentity;
 
-                // Adjust the base core assembly identity based on what this assembly believes should be 
+                // Adjust the base core assembly identity based on what this assembly believes should be
                 if (assembly.AssemblyIdentity.Equals(baseCoreAssemblyIdentity))
                     baseCoreAssemblyIdentity = assembly.CoreAssemblySymbolicIdentity;
             }
@@ -250,8 +250,8 @@ namespace Microsoft.Cci.Extensions
             {
                 throw new InvalidOperationException("The Core Assembly can only be set once.");
             }
-            // Lets ignore this if someone passes dummy as nothing good can come from it. We considered making it an error 
-            // but in some logical cases (i.e. facades) the CoreAssembly might be dummy and we don't want to start throwing 
+            // Lets ignore this if someone passes dummy as nothing good can come from it. We considered making it an error
+            // but in some logical cases (i.e. facades) the CoreAssembly might be dummy and we don't want to start throwing
             // in a bunch of cases where if we let it go the right thing will happen.
             if (coreAssembly == Dummy.AssemblyIdentity)
                 return;
@@ -309,7 +309,7 @@ namespace Microsoft.Cci.Extensions
         private static readonly Version s_winmdBclVersion = new Version(255, 255, 255, 255);
         public bool ShouldUnifyToCoreAssembly(AssemblyIdentity assemblyIdentity)
         {
-            // Unify any other potential versions of this core assembly to itself. 
+            // Unify any other potential versions of this core assembly to itself.
             if (assemblyIdentity.Name.UniqueKeyIgnoringCase == this.CoreAssemblySymbolicIdentity.Name.UniqueKeyIgnoringCase)
             {
                 if (assemblyIdentity.PublicKeyToken == null ||
@@ -319,7 +319,7 @@ namespace Microsoft.Cci.Extensions
                 return true;
             }
 
-            // Unify the mscorlib 255.255.255.255 used by winmds back to corefx to avoid the need for yet 
+            // Unify the mscorlib 255.255.255.255 used by winmds back to corefx to avoid the need for yet
             // another facade.
             if (assemblyIdentity.Name.Value == "mscorlib")
             {
@@ -335,8 +335,8 @@ namespace Microsoft.Cci.Extensions
         }
 
         /// <summary>
-        ///  Override ProbeAssemblyReference to ensure we only look in the LibPaths for resolving assemblies and 
-        ///  we don't accidently find some in the GAC or in the framework directory. 
+        ///  Override ProbeAssemblyReference to ensure we only look in the LibPaths for resolving assemblies and
+        ///  we don't accidently find some in the GAC or in the framework directory.
         /// </summary>
         public override AssemblyIdentity ProbeAssemblyReference(IUnit referringUnit, AssemblyIdentity referencedAssembly)
         {
@@ -640,7 +640,7 @@ namespace Microsoft.Cci.Extensions
                 string idPKT = identity.GetPublicKeyToken();
                 string matchingPKT = matchingAssembly.GetPublicKeyToken();
 
-                if (!idPKT.Equals(matchingPKT) && logErrorOrWarningCallback != null)
+                if (!idPKT.Equals(matchingPKT, StringComparison.OrdinalIgnoreCase) && logErrorOrWarningCallback != null)
                 {
                     string message = string.Format(CultureInfo.CurrentCulture, "Found '{0}' with PublicKeyToken '{1}' instead of '{2}'.", identity.Name.Value, matchingPKT, idPKT);
                     logErrorOrWarningCallback(message, ErrorTreatment.TreatAsWarning);

--- a/src/Microsoft.Fx.Portability.Reports.Excel/ExcelOpenXmlOutputWriter.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Excel/ExcelOpenXmlOutputWriter.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Fx.Portability.Reports
                     var summaryData = new List<object>() { analysisResult.GetNameForAssemblyInfo(item.SourceAssembly), item.SourceAssembly.TargetFrameworkMoniker ?? string.Empty };
 
                     // TODO: figure out how to add formatting to cells to show percentages.
-                    summaryData.AddRange(item.UsageData.Select(pui => (object)((pui.PortabilityIndex == 0) ? 0 : double.Parse((pui.PortabilityIndex * 100).ToString("##.##")))));
+                    summaryData.AddRange(item.UsageData.Select(pui => (object)(Math.Round(pui.PortabilityIndex, 2))));
                     summaryPage.AddRow(summaryData.ToArray());
                     tableRowCount++;
                 }

--- a/src/Microsoft.Fx.Portability.Reports.Excel/ExcelSpreadsheetExtensions.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Excel/ExcelSpreadsheetExtensions.cs
@@ -3,6 +3,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -56,7 +57,7 @@ namespace Microsoft.Fx.OpenXmlExtensions
 
             var selection = sheetView.AppendChild(new Selection());
             selection.SequenceOfReferences = new ListValue<StringValue>() { InnerText = range };
-            selection.ActiveCell = range.Substring(0, range.IndexOf(":"));
+            selection.ActiveCell = range.Substring(0, range.IndexOf(":", StringComparison.Ordinal));
 
             var tableDefPart = worksheet.WorksheetPart.AddNewPart<TableDefinitionPart>();
 
@@ -74,8 +75,8 @@ namespace Microsoft.Fx.OpenXmlExtensions
             tableDefPart.Table = new Table()
             {
                 Id = tableID,
-                Name = tableID.ToString(),
-                DisplayName = "Table" + tableID.ToString()
+                Name = tableID.ToString(CultureInfo.CurrentCulture),
+                DisplayName = "Table" + tableID.ToString(CultureInfo.CurrentCulture)
             };
             tableDefPart.Table.Reference = range;
 
@@ -195,7 +196,7 @@ namespace Microsoft.Fx.OpenXmlExtensions
             // Column needs to be 0-based for the GetColumnName method
             var columnCount = row.Descendants<Cell>().Count() - 1;
 
-            return String.Format("{0}{1}", GetColumnName(columnCount), rowCount);
+            return String.Format(CultureInfo.CurrentCulture, "{0}{1}", GetColumnName(columnCount), rowCount);
         }
 
         /// <summary>
@@ -286,11 +287,7 @@ namespace Microsoft.Fx.OpenXmlExtensions
             if (columnStart + columnCount > 26)
                 throw new NotSupportedException("Only 26 colums supported overall!!");
 
-            string range = string.Empty;
-
-            range = string.Format("{0}{1}:{2}{3}", (char)(((uint)'A') + columnStart - 1), rowStart, (char)(((uint)'A') + columnStart + columnCount - 2), rowStart + rowCount - 1);
-
-            return range;
+            return string.Format(CultureInfo.CurrentCulture, "{0}{1}:{2}{3}", (char)(((uint)'A') + columnStart - 1), rowStart, (char)(((uint)'A') + columnStart + columnCount - 2), rowStart + rowCount - 1);
         }
     }
 }

--- a/src/Microsoft.Fx.Portability/ApiPortClient.cs
+++ b/src/Microsoft.Fx.Portability/ApiPortClient.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Fx.Portability
 
             foreach (var errorInput in options.InvalidInputFiles)
             {
-                _progressReport.ReportIssue(string.Format(LocalizedStrings.InvalidFileName, errorInput));
+                _progressReport.ReportIssue(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.InvalidFileName, errorInput));
             }
 
             var results = await GetAnalysisResultAsync(options);
@@ -187,7 +187,7 @@ namespace Microsoft.Fx.Portability
         {
             string filePath = null;
 
-            using (var progressTask = _progressReport.StartTask(string.Format(LocalizedStrings.WritingReport, outputFormat)))
+            using (var progressTask = _progressReport.StartTask(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.WritingReport, outputFormat)))
             {
                 try
                 {
@@ -211,7 +211,7 @@ namespace Microsoft.Fx.Portability
 
                     if (string.IsNullOrEmpty(filename))
                     {
-                        _progressReport.ReportIssue(string.Format(LocalizedStrings.CouldNotWriteReport, outputDirectory, outputFileName, extension));
+                        _progressReport.ReportIssue(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.CouldNotWriteReport, outputDirectory, outputFileName, extension));
                         progressTask.Abort();
 
                         return null;

--- a/src/Microsoft.Fx.Portability/BreakingChangeParser.cs
+++ b/src/Microsoft.Fx.Portability/BreakingChangeParser.cs
@@ -288,7 +288,7 @@ namespace Microsoft.Fx.Portability
                     break;
                 case ParseState.Notes:
                     // Special-case the fact that 'notes' will often come at the end of a comment section and we don't need the closing --> in the note.
-                    if (currentLine.Trim().Equals("-->")) return;
+                    if (string.Equals("-->", currentLine.Trim(), StringComparison.Ordinal)) return;
                     if (currentBreak.Notes == null)
                     {
                         currentBreak.Notes = currentLine;


### PR DESCRIPTION
The official builds use FxCop but we don't have anything at the moment to help the dev experience. Right now, many analyzers are disabled (look at `rule.ruleset`), but we can look at enabling them in the future. This sets the analyzers to catch the items that the official build system uses.