### PR TITLE
Fixes #479

### DIFF
--- a/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Fx.Portability.Analyzer
         private static readonly HashSet<string> s_systemObjectAssemblies = new HashSet<string>(StringComparer.Ordinal)
         {
             "mscorlib",
-            "System.Runtime"
+            "System.Runtime",
+            "System.Private.CoreLib"
         };
 
         private readonly IDependencyFilter _assemblyFilter;

--- a/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
@@ -206,8 +206,8 @@ namespace Microsoft.Fx.Portability.Analyzer
                 })
                 .Where(assembly => _assemblyFilter.IsFrameworkAssembly(assembly));
 
-            var mscorlibAssembly = microsoftAssemblies.SingleOrDefault(x => string.Equals(x.Name, mscorlib));
-            var systemRuntimeAssembly = microsoftAssemblies.SingleOrDefault(x => string.Equals(x.Name, SystemRuntime));
+            var mscorlibAssembly = microsoftAssemblies.SingleOrDefault(x => string.Equals(x.Name, mscorlib, StringComparison.Ordinal));
+            var systemRuntimeAssembly = microsoftAssemblies.SingleOrDefault(x => string.Equals(x.Name, SystemRuntime, StringComparison.Ordinal));
 
             if (mscorlibAssembly != default(AssemblyReferenceInformation))
             {

--- a/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
@@ -13,6 +13,12 @@ namespace Microsoft.Fx.Portability.Analyzer
 {
     internal class DependencyFinderEngineHelper
     {
+        private static readonly HashSet<string> s_systemObjectAssemblies = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "mscorlib",
+            "System.Runtime"
+        };
+
         private readonly IDependencyFilter _assemblyFilter;
         private readonly MetadataReader _reader;
 
@@ -195,9 +201,6 @@ namespace Microsoft.Fx.Portability.Analyzer
         /// </summary>
         private AssemblyReferenceInformation GetSystemRuntimeAssemblyInformation()
         {
-            const string mscorlib = nameof(mscorlib);
-            const string SystemRuntime = "System.Runtime";
-
             var microsoftAssemblies = _reader.AssemblyReferences
                 .Select(handle =>
                 {
@@ -206,16 +209,11 @@ namespace Microsoft.Fx.Portability.Analyzer
                 })
                 .Where(assembly => _assemblyFilter.IsFrameworkAssembly(assembly));
 
-            var mscorlibAssembly = microsoftAssemblies.SingleOrDefault(x => string.Equals(x.Name, mscorlib, StringComparison.Ordinal));
-            var systemRuntimeAssembly = microsoftAssemblies.SingleOrDefault(x => string.Equals(x.Name, SystemRuntime, StringComparison.Ordinal));
+            var matchingAssembly = microsoftAssemblies.SingleOrDefault(x => s_systemObjectAssemblies.Contains(x.Name));
 
-            if (mscorlibAssembly != default(AssemblyReferenceInformation))
+            if (matchingAssembly != default(AssemblyReferenceInformation))
             {
-                return mscorlibAssembly;
-            }
-            else if (systemRuntimeAssembly != default(AssemblyReferenceInformation))
-            {
-                return systemRuntimeAssembly;
+                return matchingAssembly;
             }
             else
             {

--- a/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Fx.Portability.Analyzer
                     var assembly = _reader.GetAssemblyReference(handle);
                     return _reader.FormatAssemblyInfo(assembly);
                 })
-                .Where(assembly => _assemblyFilter.IsFrameworkAssembly(assembly));
+                .Where(_assemblyFilter.IsFrameworkAssembly);
 
             var matchingAssembly = microsoftAssemblies.SingleOrDefault(x => s_systemObjectAssemblies.Contains(x.Name));
 

--- a/src/Microsoft.Fx.Portability.MetadataReader/Exceptions/SystemObjectNotFoundException.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/Exceptions/SystemObjectNotFoundException.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Fx.Portability.Analyzer.Resources;
+using Microsoft.Fx.Portability.ObjectModel;
+using System.Collections.Generic;
+
+namespace Microsoft.Fx.Portability.Analyzer.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when assembly containing <see cref="System.Object"/>
+    /// cannot be found.
+    /// </summary>
+    public class SystemObjectNotFoundException : PortabilityAnalyzerException
+    {
+        public SystemObjectNotFoundException(IEnumerable<AssemblyReferenceInformation> assemblies)
+            : base(string.Format(LocalizedStrings.MissingSystemObjectAssembly,
+                string.Join(", ", assemblies)))
+        { }
+    }
+}

--- a/src/Microsoft.Fx.Portability.MetadataReader/Exceptions/SystemObjectNotFoundException.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/Exceptions/SystemObjectNotFoundException.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Fx.Portability.Analyzer.Resources;
 using Microsoft.Fx.Portability.ObjectModel;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Microsoft.Fx.Portability.Analyzer.Exceptions
 {
@@ -11,7 +12,7 @@ namespace Microsoft.Fx.Portability.Analyzer.Exceptions
     public class SystemObjectNotFoundException : PortabilityAnalyzerException
     {
         public SystemObjectNotFoundException(IEnumerable<AssemblyReferenceInformation> assemblies)
-            : base(string.Format(LocalizedStrings.MissingSystemObjectAssembly,
+            : base(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.MissingSystemObjectAssembly,
                 string.Join(", ", assemblies)))
         { }
     }

--- a/src/Microsoft.Fx.Portability.MetadataReader/Exceptions/SystemObjectNotFoundException.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/Exceptions/SystemObjectNotFoundException.cs
@@ -14,6 +14,10 @@ namespace Microsoft.Fx.Portability.Analyzer.Exceptions
         public SystemObjectNotFoundException(IEnumerable<AssemblyReferenceInformation> assemblies)
             : base(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.MissingSystemObjectAssembly,
                 string.Join(", ", assemblies)))
-        { }
+        {
+            AssembliesReferenced = assemblies;
+        }
+
+        public IEnumerable<AssemblyReferenceInformation> AssembliesReferenced { get; }
     }
 }

--- a/src/Microsoft.Fx.Portability.MetadataReader/Microsoft.Fx.Portability.MetadataReader.csproj
+++ b/src/Microsoft.Fx.Portability.MetadataReader/Microsoft.Fx.Portability.MetadataReader.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <Description>Metadata reader for binaries using System.Reflection.Metadata</Description>
+    <RootNamespace>Microsoft.Fx.Portability.Analyzer</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +12,21 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Fx.Portability\Microsoft.Fx.Portability.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+      <Compile Update="Resources\LocalizedStrings.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>LocalizedStrings.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <EmbeddedResource Update="Resources\LocalizedStrings.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>LocalizedStrings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Fx.Portability.MetadataReader/ReflectionMetadataDependencyInfo.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/ReflectionMetadataDependencyInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Fx.Portability.Analyzer.Exceptions;
 using Microsoft.Fx.Portability.Analyzer.Resources;
 using Microsoft.Fx.Portability.ObjectModel;
 using System;
@@ -136,8 +137,10 @@ namespace Microsoft.Fx.Portability.Analyzer
             {
                 // InvalidPEAssemblyExceptions may be expected and indicative of a non-PE file
                 if (exc is InvalidPEAssemblyException) throw;
+                // Occurs when we cannot find the System.Object assembly.
+                if (exc is SystemObjectNotFoundException) throw;
 
-                // Other exceptions are unexpected, though, and wil benefit from
+                // Other exceptions are unexpected, though, and will benefit from
                 // more details on the scenario that hit them
                 throw new PortabilityAnalyzerException(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.MetadataParsingExceptionMessage, file.Name), exc);
             }

--- a/src/Microsoft.Fx.Portability.MetadataReader/Resources/LocalizedStrings.Designer.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/Resources/LocalizedStrings.Designer.cs
@@ -11,8 +11,8 @@
 namespace Microsoft.Fx.Portability.Analyzer.Resources {
     using System;
     using System.Reflection;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -20,7 +20,7 @@ namespace Microsoft.Fx.Portability.Analyzer.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class LocalizedStrings {
@@ -40,7 +40,7 @@ namespace Microsoft.Fx.Portability.Analyzer.Resources {
         public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Fx.Portability.MetadataReader.Resources.LocalizedStrings", typeof(LocalizedStrings).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Fx.Portability.Analyzer.Resources.LocalizedStrings", typeof(LocalizedStrings).GetTypeInfo().Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -76,6 +76,16 @@ namespace Microsoft.Fx.Portability.Analyzer.Resources {
         public static string MetadataParsingExceptionMessage {
             get {
                 return ResourceManager.GetString("MetadataParsingExceptionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot locate assembly information for System.Object. Microsoft assemblies found are:
+        ///{0}.
+        /// </summary>
+        public static string MissingSystemObjectAssembly {
+            get {
+                return ResourceManager.GetString("MissingSystemObjectAssembly", resourceCulture);
             }
         }
     }

--- a/src/Microsoft.Fx.Portability.MetadataReader/Resources/LocalizedStrings.resx
+++ b/src/Microsoft.Fx.Portability.MetadataReader/Resources/LocalizedStrings.resx
@@ -123,4 +123,8 @@
   <data name="MetadataParsingExceptionMessage" xml:space="preserve">
     <value>An unexpected error was encountered while parsing the metadata for the PE file located at {0}.</value>
   </data>
+  <data name="MissingSystemObjectAssembly" xml:space="preserve">
+    <value>Cannot locate assembly information for System.Object. Microsoft assemblies found are:
+{0}</value>
+  </data>
 </root>

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Fx.Portability.Resources {
     using System;
     using System.Reflection;
     
-    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -365,15 +364,6 @@ namespace Microsoft.Fx.Portability.Resources {
         public static string MissingAssembliesPageTitle {
             get {
                 return ResourceManager.GetString("MissingAssembliesPageTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot locate assembly info for System.Object.
-        /// </summary>
-        public static string MissingAssemblyInfo {
-            get {
-                return ResourceManager.GetString("MissingAssemblyInfo", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
+++ b/src/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
@@ -350,9 +350,6 @@
   <data name="TooManyTargetsMessage" xml:space="preserve">
     <value>Excel output format supports up to {0} targets for analysis at a time.</value>
   </data>
-  <data name="MissingAssemblyInfo" xml:space="preserve">
-    <value>Cannot locate assembly info for System.Object</value>
-  </data>
   <data name="FrameworkNameHeader" xml:space="preserve">
     <value>Framework</value>
     <comment>Framework name header column in Excel</comment>

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -103,12 +103,13 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         public void VerifyDotNetFrameworkFilter()
         {
             var dependencyFinder = new ReflectionMetadataDependencyFinder(new DotNetFrameworkFilter());
-            var assemblyToTest = TestAssembly.Create("FilterApis.cs", false, new[] { typeof(Image).GetTypeInfo().Assembly.Location });
+            var assemblyToTest = TestAssembly.Create("FilterApis.cs");
 
             var expected = FilterApisDocIds
                 .Concat(new[] {
-                    "M:System.Drawing.Image.FromFile(System.String,System.Boolean)",
-                    "T:System.Drawing.Image"
+                    "M:System.Uri.TryCreate(System.String,System.UriKind,System.Uri@)",
+                    "T:System.Uri",
+                    "T:System.UriKind"
                 })
                 .OrderBy(x => x, StringComparer.Ordinal);
 
@@ -141,7 +142,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
 
             var assemblyName = "FilterApis";
             var dependencyFinder = new ReflectionMetadataDependencyFinder(new AssemblyNameFilter(assemblyName));
-            var assemblyToTest = TestAssembly.Create($"{assemblyName}.cs", false, new[] { typeof(Image).GetTypeInfo().Assembly.Location });
+            var assemblyToTest = TestAssembly.Create($"{assemblyName}.cs");
             var progressReporter = Substitute.For<IProgressReporter>();
 
             var dependencies = dependencyFinder.FindDependencies(new[] { assemblyToTest }, progressReporter);

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/TestAssembly.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/TestAssembly.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         private class CSharpCompileAssemblyFile : IAssemblyFile
         {
             private static readonly Assembly s_assembly = typeof(CSharpCompileAssemblyFile).GetTypeInfo().Assembly;
-            private static readonly IEnumerable<MetadataReference> s_references = new[] { typeof(object).GetTypeInfo().Assembly.Location, typeof(Uri).GetTypeInfo().Assembly.Location }
+            private static readonly IEnumerable<MetadataReference> s_references = new[] { typeof(object).GetTypeInfo().Assembly.Location, typeof(Uri).GetTypeInfo().Assembly.Location, typeof(Console).GetTypeInfo().Assembly.Location }
+                                                                     .Distinct()
                                                                      .Select(r => MetadataReference.CreateFromFile(r))
                                                                      .ToList();
 
@@ -75,7 +76,10 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
                 var tfm = CSharpSyntaxTree.ParseText(TFM);
                 var tree = CSharpSyntaxTree.ParseText(text);
                 var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: allowUnsafe);
-                var references = additionalReferences.Select(x => MetadataReference.CreateFromFile(x)).Concat(s_references);
+                var references = additionalReferences
+                                    .Select(x => MetadataReference.CreateFromFile(x))
+                                    .Concat(s_references);
+
                 var compilation = CSharpCompilation.Create(assemblyName, new[] { tree, tfm }, references, options);
 
                 using (var stream = new MemoryStream())

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Tests/FilterApis.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Tests/FilterApis.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -10,7 +9,7 @@ namespace Foo
     {
         public static void Test()
         {
-            Image image = Image.FromFile("SomeTestFile.png", true);
+            Uri.TryCreate("randomUri", UriKind.Relative, out Uri testResult);
 
             Console.WriteLine(Microsoft.Bar.Test<int>.Get());
             Console.WriteLine(Other.Test<int>.Get());

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Tests/FilterApis.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Tests/FilterApis.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -9,8 +10,7 @@ namespace Foo
     {
         public static void Test()
         {
-            Uri uri;
-            Uri.TryCreate("uri", UriKind.RelativeOrAbsolute, out uri);
+            Image image = Image.FromFile("SomeTestFile.png", true);
 
             Console.WriteLine(Microsoft.Bar.Test<int>.Get());
             Console.WriteLine(Other.Test<int>.Get());


### PR DESCRIPTION
* Fixes #479 by examining assembly references for mscorlib and System.Runtime assemblies for System.Object.
* Adds tests for SystemObjectNotFoundException

/cc @twsouthwick 