### PR TITLE
Flexible service endpoint (HTTPS default)

### DIFF
--- a/samples/SearchFxApi/Program.cs
+++ b/samples/SearchFxApi/Program.cs
@@ -14,7 +14,7 @@ namespace SearchFxApi
     {
         private static void Main(string[] args)
         {
-            var analysisService = new ApiPortService("portability.dot.net", new ProductInformation("MyAPIQueryProgram"));
+            var analysisService = new ApiPortService("https://portability.dot.net", new ProductInformation("MyAPIQueryProgram"));
 
             Console.Write("Enter API you want to search for:  ");
             var api = Console.ReadLine();

--- a/src/ApiPort.VisualStudio/ServiceProvider.cs
+++ b/src/ApiPort.VisualStudio/ServiceProvider.cs
@@ -27,7 +27,7 @@ namespace ApiPortVS
     {
         private static Guid OutputWindowGuid = new Guid(0xe2fc797f, 0x1dd3, 0x476c, 0x89, 0x17, 0x86, 0xcd, 0x31, 0x33, 0xc4, 0x69);
         private static readonly DirectoryInfo AssemblyDirectory = new FileInfo(typeof(ServiceProvider).Assembly.Location).Directory;
-        private const string DefaultEndpoint = @"portability.dot.net/";
+        private const string DefaultEndpoint = @"https://portability.dot.net/";
 
         private readonly IContainer _container;
 

--- a/src/ApiPort/CommandLine/ConsoleDefaultApiPortOptions.cs
+++ b/src/ApiPort/CommandLine/ConsoleDefaultApiPortOptions.cs
@@ -18,7 +18,7 @@ namespace ApiPort.CommandLine
     {
         public ConsoleDefaultApiPortOptions()
         {
-            ServiceEndpoint = "portability.dot.net";
+            ServiceEndpoint = "https://portability.dot.net";
             Description = string.Empty;
             OutputFileName = "ApiPortAnalysis";
             RequestFlags = AnalyzeRequestFlags.None;

--- a/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
+++ b/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <Target Name="DownloadContent" BeforeTargets="BeforeBuild">
-    <Warning Text="Could not find catalog.bin. Please run build\restore.ps1 to download the file" Condition="!Exists($(CatalogDataFile))" />
+    <Warning Text="Could not find catalog.bin. Please run init.ps1 to download the file" Condition="!Exists($(CatalogDataFile))" />
   </Target>
 
 </Project>

--- a/src/Microsoft.Fx.Portability/ApiPortService.cs
+++ b/src/Microsoft.Fx.Portability/ApiPortService.cs
@@ -25,8 +25,6 @@ namespace Microsoft.Fx.Portability
             internal const string DefaultResultFormat = "/api/resultformat/default";
         }
 
-        const string UriScheme = "https";
-
         private static readonly TimeSpan Timeout = TimeSpan.FromMinutes(10);
         private readonly CompressedHttpClient _client;
 
@@ -41,7 +39,11 @@ namespace Microsoft.Fx.Portability
                 throw new ArgumentNullException(nameof(proxyProvider));
             }
 
-            var uri = new UriBuilder(UriScheme, endpoint).Uri;
+            // Create the URI directly from a string (rather than using a hard-coded scheme or port) because 
+            // even though production use of ApiPort should always use HTTPS, developers using a non-production
+            // portability service URL (via the -e command line parameter) may need to specify a different 
+            // scheme or port.
+            var uri = new Uri(endpoint);
             var proxy = proxyProvider.GetProxy(uri);
             
             // replace the handler with the proxy aware handler
@@ -61,7 +63,7 @@ namespace Microsoft.Fx.Portability
 
             _client = new CompressedHttpClient(info, messageHandler)
             {
-                BaseAddress = new UriBuilder(UriScheme, endpoint).Uri,
+                BaseAddress = new Uri(endpoint),
                 Timeout = Timeout
             };
         }
@@ -75,7 +77,7 @@ namespace Microsoft.Fx.Portability
 
             _client = new CompressedHttpClient(info)
             {
-                BaseAddress = new UriBuilder(UriScheme, endpoint).Uri,
+                BaseAddress = new Uri(endpoint),
                 Timeout = Timeout
             };
         }
@@ -94,7 +96,7 @@ namespace Microsoft.Fx.Portability
 
             _client = new CompressedHttpClient(info, httpMessageHandler)
             {
-                BaseAddress = new UriBuilder(UriScheme, endpoint).Uri,
+                BaseAddress = new Uri(endpoint),
                 Timeout = Timeout
             };
         }

--- a/tests/Microsoft.Fx.Portability.Tests/ApiPortServiceTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ApiPortServiceTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Fx.Portability.Tests
             var productInformation = new ProductInformation("ApiPort_Tests", typeof(ApiPortServiceTests));
 
             //Create a fake ApiPortService which uses the TestHandler to send back the response message
-            _apiPortService = new ApiPortService("localhost", httpMessageHandler, productInformation);
+            _apiPortService = new ApiPortService("http://localhost", httpMessageHandler, productInformation);
         }
 
         public void Dispose()


### PR DESCRIPTION
Updates the recent HTTPS service endpoint changes to allow any scheme or port to be specified via the -e command line parameter, but *defaults* to HTTPS.

This allows developers to target a local version of the API Portability service (which currently would be listening on HTTP).