### PR TITLE
Explicitly require TLS 1.2

### DIFF
--- a/src/Microsoft.Fx.Portability/ApiPortService.cs
+++ b/src/Microsoft.Fx.Portability/ApiPortService.cs
@@ -47,6 +47,9 @@ namespace Microsoft.Fx.Portability
             // replace the handler with the proxy aware handler
             var clientHandler = new HttpClientHandler
             {
+#if FEATURE_CLIENT_HANDLER_SET_SSL_PROTOCOLS
+                SslProtocols = CompressedHttpClient.SupportedSSLProtocols,
+#endif
                 Proxy = proxy,
                 AutomaticDecompression = (DecompressionMethods.GZip | DecompressionMethods.Deflate)
             };

--- a/src/Microsoft.Fx.Portability/ApiPortService.cs
+++ b/src/Microsoft.Fx.Portability/ApiPortService.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Fx.Portability
             // replace the handler with the proxy aware handler
             var clientHandler = new HttpClientHandler
             {
-#if FEATURE_CLIENT_HANDLER_SET_SSL_PROTOCOLS
+#if !FEATURE_SERVICE_POINT_MANAGER
                 SslProtocols = CompressedHttpClient.SupportedSSLProtocols,
 #endif
                 Proxy = proxy,

--- a/src/Microsoft.Fx.Portability/CompressedHttpClient.cs
+++ b/src/Microsoft.Fx.Portability/CompressedHttpClient.cs
@@ -21,17 +21,17 @@ namespace Microsoft.Fx.Portability
 {
     internal class CompressedHttpClient : HttpClient
     {
-        internal const SslProtocols SupportedSSLProtocols = SslProtocols.Tls12;
-
 #if FEATURE_SERVICE_POINT_MANAGER
         internal const SecurityProtocolType SupportedSecurityProtocols = SecurityProtocolType.Tls12;
+#else
+        internal const SslProtocols SupportedSSLProtocols = SslProtocols.Tls12;
 #endif
 
         /// <param name="productName">Product name that will be displayed in the User Agent string of requests</param>
         /// <param name="productVersion">Product version that will be displayed in the User Agent string of requests</param>
         public CompressedHttpClient(ProductInformation info)
             : this(info, new HttpClientHandler {
-#if FEATURE_CLIENT_HANDLER_SET_SSL_PROTOCOLS
+#if !FEATURE_SERVICE_POINT_MANAGER
                 SslProtocols = SupportedSSLProtocols, 
 #endif
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate

--- a/src/Microsoft.Fx.Portability/CompressedHttpClient.cs
+++ b/src/Microsoft.Fx.Portability/CompressedHttpClient.cs
@@ -14,22 +14,38 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Security.Authentication;
 using System.Threading.Tasks;
 
 namespace Microsoft.Fx.Portability
 {
     internal class CompressedHttpClient : HttpClient
     {
+        internal const SslProtocols SupportedSSLProtocols = SslProtocols.Tls12;
+
+#if FEATURE_SERVICE_POINT_MANAGER
+        internal const SecurityProtocolType SupportedSecurityProtocols = SecurityProtocolType.Tls12;
+#endif
+
         /// <param name="productName">Product name that will be displayed in the User Agent string of requests</param>
         /// <param name="productVersion">Product version that will be displayed in the User Agent string of requests</param>
         public CompressedHttpClient(ProductInformation info)
-            : this(info, new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate })
+            : this(info, new HttpClientHandler {
+#if FEATURE_CLIENT_HANDLER_SET_SSL_PROTOCOLS
+                SslProtocols = SupportedSSLProtocols, 
+#endif
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            })
         {
         }
 
         public CompressedHttpClient(ProductInformation info, HttpMessageHandler handler)
             : base(handler)
         {
+#if FEATURE_SERVICE_POINT_MANAGER
+            ServicePointManager.SecurityProtocol = SupportedSecurityProtocols;
+#endif
+
             DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             DefaultRequestHeaders.AcceptLanguage.TryParseAdd(CultureInfo.CurrentCulture.ToString());
 

--- a/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
+++ b/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup Condition="'$(TargetFramework)'== 'net46'">
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE;FEATURE_ASSEMBLY_LOCATION;FEATURE_XML_SCHEMA;FEATURE_SERVICE_POINT_MANAGER</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.1" />

--- a/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
+++ b/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
@@ -9,10 +9,6 @@
   <PropertyGroup Condition="'$(TargetFramework)'== 'net46'">
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE;FEATURE_ASSEMBLY_LOCATION;FEATURE_XML_SCHEMA;FEATURE_SERVICE_POINT_MANAGER</DefineConstants>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
-    <DefineConstants>$(DefineConstants);FEATURE_CLIENT_HANDLER_SET_SSL_PROTOCOLS</DefineConstants>
-  </PropertyGroup>
   
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />

--- a/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
+++ b/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
@@ -7,9 +7,13 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'== 'net46'">
-    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE;FEATURE_ASSEMBLY_LOCATION;FEATURE_XML_SCHEMA</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE;FEATURE_ASSEMBLY_LOCATION;FEATURE_XML_SCHEMA;FEATURE_SERVICE_POINT_MANAGER</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
+    <DefineConstants>$(DefineConstants);FEATURE_CLIENT_HANDLER_SET_SSL_PROTOCOLS</DefineConstants>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.1" />


### PR DESCRIPTION
ApiPort already uses TLS 1.2 by default, this just makes that requirement explicit so that we're always sure to use the TLS 1.2 protocol.

The PR is slightly complicated by the fact the NetCore and NetFX have different ways of doing this.