### PR TITLE
Fix breaking change parser

### DIFF
--- a/src/Microsoft.Fx.Portability/BreakingChangeParser.cs
+++ b/src/Microsoft.Fx.Portability/BreakingChangeParser.cs
@@ -201,9 +201,12 @@ namespace Microsoft.Fx.Portability
                                 && int.TryParse(contents.Substring(startIndex + 1), out id))
                             {
                                 currentBreak.Id = id.ToString(CultureInfo.InvariantCulture);
+                                state = ParseState.None;
                             }
-
-                            state = ParseState.None;
+                            else
+                            {
+                                ParseNonStateChange(currentBreak, state, currentLine, allowedCategories);
+                            }
                         }
                         // Otherwise, process according to our current state
                         else
@@ -230,7 +233,10 @@ namespace Microsoft.Fx.Portability
                 case ParseState.None:
                     return;
                 case ParseState.OriginalBug:
-                    currentBreak.BugLink = currentLine.Trim();
+                    if (string.IsNullOrEmpty(currentBreak.BugLink))
+                    {
+                        currentBreak.BugLink = currentLine.Trim();
+                    }
                     break;
                 case ParseState.Scope:
                     BreakingChangeImpact scope;
@@ -318,7 +324,7 @@ namespace Microsoft.Fx.Portability
                     {
                         throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.InvalidCategoryDetected, category));
                     }
-                    currentBreak.Categories.Add(category);
+                    currentBreak.Categories.Add(category.Trim());
                     break;
                 default:
                     throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, LocalizedStrings.InvalidBreakingChangeParserState, state.ToString()));

--- a/tests/Microsoft.Fx.Portability.Tests/BreakingChangeParserTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/BreakingChangeParserTests.cs
@@ -179,9 +179,16 @@ namespace Microsoft.Fx.Portability.Tests
 ```".Replace(Environment.NewLine, "\n")
             };
 
-
-
             ValidateParse(GetBreakingChangeMarkdown("CommentsInRecommendedChanges.md"), expected);
+        }
+
+        [Fact]
+        public void BreakingChangeMultipleLinks()
+        {
+            var expected = ListTBC.DeepCopy();
+            expected.BugLink = "https://bugrepro.org/id/105";
+
+            ValidateParse(GetBreakingChangeMarkdown("MultipleBugLinks.md"), expected);
         }
 
         #endregion

--- a/tests/Microsoft.Fx.Portability.Tests/BreakingChangeParserTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/BreakingChangeParserTests.cs
@@ -247,11 +247,11 @@ namespace Microsoft.Fx.Portability.Tests
         private Stream GetBreakingChangeMarkdown(string resourceName)
         {
             var resources = typeof(BreakingChangeParserTests).GetTypeInfo().Assembly.GetManifestResourceNames();
-            string name = null;
 
             try
             {
-                name = resources.Single(n => n.EndsWith(resourceName, StringComparison.Ordinal));
+                var name = resources.Single(n => n.EndsWith(resourceName, StringComparison.Ordinal));
+                return typeof(BreakingChangeParserTests).GetTypeInfo().Assembly.GetManifestResourceStream(name);
             }
             catch (InvalidOperationException)
             {
@@ -266,7 +266,6 @@ namespace Microsoft.Fx.Portability.Tests
                 throw;
             }
 
-            return typeof(BreakingChangeParserTests).GetTypeInfo().Assembly.GetManifestResourceStream(name);
         }
 
         #endregion

--- a/tests/Microsoft.Fx.Portability.Tests/BreakingChangeParserTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/BreakingChangeParserTests.cs
@@ -130,6 +130,20 @@ namespace Microsoft.Fx.Portability.Tests
             ValidateParse(GetBreakingChangeMarkdown("RandomText2.md"), new BreakingChange[0]);
         }
 
+        [Fact]
+        public void CategoryWithSpace()
+        {
+            var expected = new BreakingChange
+            {
+                Title = "List<T>.ForEach",
+                ImpactScope = BreakingChangeImpact.Minor,
+                VersionBroken = Version.Parse("4.6.2"),
+                SourceAnalyzerStatus = BreakingChangeAnalyzerStatus.Available
+            };
+
+            ValidateParse(GetBreakingChangeMarkdown("CategoryWithSpaces.md"), expected);
+        }
+
         #endregion
 
         #region Negative Test Cases
@@ -185,7 +199,8 @@ namespace Microsoft.Fx.Portability.Tests
 
         private Stream GetBreakingChangeMarkdown(string resourceName)
         {
-            var name = typeof(BreakingChangeParserTests).GetTypeInfo().Assembly.GetManifestResourceNames().Single(n => n.EndsWith(resourceName, StringComparison.Ordinal));
+            var resources = typeof(BreakingChangeParserTests).GetTypeInfo().Assembly.GetManifestResourceNames();
+            var name = resources.Single(n => n.EndsWith(resourceName, StringComparison.Ordinal));
             return typeof(BreakingChangeParserTests).GetTypeInfo().Assembly.GetManifestResourceStream(name);
         }
 

--- a/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
@@ -30,23 +30,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="TestAssets\005- ListT.ForEach.md" />
-    <EmbeddedResource Include="TestAssets\006- System.Uri.md" />
-    <EmbeddedResource Include="TestAssets\CategoryWithSpaces.md" />
-    <EmbeddedResource Include="TestAssets\CommentsInRecommendedChanges.md" />
-    <EmbeddedResource Include="TestAssets\CorruptData.md" />
-    <EmbeddedResource Include="TestAssets\DupSections.md" />
-    <EmbeddedResource Include="TestAssets\Empty.md" />
-    <EmbeddedResource Include="TestAssets\MissingApis.md" />
-    <EmbeddedResource Include="TestAssets\MissingData.md" />
-    <EmbeddedResource Include="TestAssets\MultiBreak.md" />
-    <EmbeddedResource Include="TestAssets\PartialData.md" />
-    <EmbeddedResource Include="TestAssets\RandomText.md" />
-    <EmbeddedResource Include="TestAssets\RandomText2.md" />
-    <EmbeddedResource Include="TestAssets\Template.md" />
-    <EmbeddedResource Include="TestAssets\Application.FilterMessage.md" />
-    <EmbeddedResource Include="TestAssets\Json\FormatsHttpContent.json" />
-    <EmbeddedResource Include="TestAssets\Json\DocIdsHttpContent.json" />
+    <EmbeddedResource Include="TestAssets\**\*.md" />
+    <EmbeddedResource Include="TestAssets\**\*.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
@@ -33,6 +33,7 @@
     <EmbeddedResource Include="TestAssets\005- ListT.ForEach.md" />
     <EmbeddedResource Include="TestAssets\006- System.Uri.md" />
     <EmbeddedResource Include="TestAssets\CategoryWithSpaces.md" />
+    <EmbeddedResource Include="TestAssets\CommentsInRecommendedChanges.md" />
     <EmbeddedResource Include="TestAssets\CorruptData.md" />
     <EmbeddedResource Include="TestAssets\DupSections.md" />
     <EmbeddedResource Include="TestAssets\Empty.md" />

--- a/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
@@ -32,6 +32,7 @@
   <ItemGroup>
     <EmbeddedResource Include="TestAssets\005- ListT.ForEach.md" />
     <EmbeddedResource Include="TestAssets\006- System.Uri.md" />
+    <EmbeddedResource Include="TestAssets\CategoryWithSpaces.md" />
     <EmbeddedResource Include="TestAssets\CorruptData.md" />
     <EmbeddedResource Include="TestAssets\DupSections.md" />
     <EmbeddedResource Include="TestAssets\Empty.md" />

--- a/tests/Microsoft.Fx.Portability.Tests/TestAssets/CategoryWithSpaces.md
+++ b/tests/Microsoft.Fx.Portability.Tests/TestAssets/CategoryWithSpaces.md
@@ -1,0 +1,10 @@
+﻿## List<T>.ForEach  
+
+### Scope  
+Minor
+
+###  Version Introduced
+4.6.2
+    
+### Source Analyzer Status
+Available

--- a/tests/Microsoft.Fx.Portability.Tests/TestAssets/CommentsInRecommendedChanges.md
+++ b/tests/Microsoft.Fx.Portability.Tests/TestAssets/CommentsInRecommendedChanges.md
@@ -1,0 +1,32 @@
+## ASP.NET Accessibility Improvements in .NET 4.7.3
+
+### Scope
+Minor
+
+### Version Introduced
+4.7.3
+
+### Source Analyzer Status
+NotPlanned
+
+### Change Description
+Starting with the .NET Framework 4.7.1, ASP.NET has improved how ASP.NET Web Controls work with accessibility technology in Visual Studio to better support ASP.NET customers.
+
+- [x] Quirked
+- [ ] Build-time break
+
+### Recommended Action
+
+In order for the Visual Studio Designer to benefit from these changes
+- Install Visual Studio 2017 15.3 or later, which supports the new accessibility features with the following AppContext Switch by default.
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    ...
+    <!-- AppContextSwitchOverrides value attribute is in the form of 'key1=true|false;key2=true|false  -->
+    <AppContextSwitchOverrides value="...;Switch.UseLegacyAccessibilityFeatures=false" />
+    ...
+  </runtime>
+</configuration>
+```

--- a/tests/Microsoft.Fx.Portability.Tests/TestAssets/MultipleBugLinks.md
+++ b/tests/Microsoft.Fx.Portability.Tests/TestAssets/MultipleBugLinks.md
@@ -1,0 +1,36 @@
+﻿## 5: List<T>.ForEach
+
+### Scope
+Minor
+
+### Version Introduced
+4.5
+    
+### Source Analyzer Status
+Available
+
+### Change Description
+Beginning in .NET 4.5, a List&lt;T&gt;.ForEach enumerator will throw an InvalidOperationException exception if an element in the calling collection is modified. Previously, this would not throw an exception but could lead to race conditions.
+
+- [x] Quirked
+- [ ] Build-time break
+
+### Recommended Action
+Ideally, code should be fixed such that Lists are not modifed while enumerating their elements, as that is never a safe operation. To revert to the previous behavior, though, an app may target .NET 4.0.
+
+### Affected APIs
+* M:System.Collections.Generic.List`1.ForEach(System.Action{`0})
+
+[More information](https://msdn.microsoft.com/en-us/library/hh367887\(v=vs.110\).aspx#core)
+
+<!--
+	### Bug
+	https://bugrepro.org/id/105 
+	https://bugrepro.org/id/1000/shouldnotparse
+
+	### Notes
+    This introduces an exception, but requires retargeting
+    Source analyzer status: Pri 1, source and binary done (MikeRou)
+-->
+
+


### PR DESCRIPTION
Fixes issues in breaking change parser where:
* Comments in suggestions were not being parsed
* Would not trim whitespaces in categories and treat them as different categories.
* Adds tests