### PR TITLE
Search dependency injection related errors for any portability exceptions

### DIFF
--- a/src/ApiPort/Program.cs
+++ b/src/ApiPort/Program.cs
@@ -8,12 +8,13 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace ApiPort
 {
     public class Program
     {
-        public static int Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
             var productInformation = new ProductInformation("ApiPort_Console");
 
@@ -39,24 +40,26 @@ namespace ApiPort
                     switch (options.Command)
                     {
                         case AppCommands.ListTargets:
-                            client.ListTargetsAsync().Wait();
+                            await client.ListTargetsAsync();
                             break;
                         case AppCommands.AnalyzeAssemblies:
-                            client.AnalyzeAssembliesAsync().Wait();
+                            await client.AnalyzeAssembliesAsync();
                             break;
                         case AppCommands.DocIdSearch:
-                            client.RunDocIdSearchAsync().Wait();
+                            await client.RunDocIdSearchAsync();
                             break;
                         case AppCommands.ListOutputFormats:
-                            client.ListOutputFormatsAsync().Wait();
+                            await client.ListOutputFormatsAsync();
                             break;
                     }
 
                     return 0;
                 }
-                catch (Autofac.Core.DependencyResolutionException ex) when (ex.InnerException is PortabilityAnalyzerException)
+                catch (Autofac.Core.DependencyResolutionException ex) when (GetPortabilityException(ex) is PortabilityAnalyzerException p)
                 {
-                    WriteException(ex.InnerException);
+                    Trace.TraceError(ex.ToString());
+
+                    WriteException(p);
                 }
                 catch (PortabilityAnalyzerException ex)
                 {
@@ -119,6 +122,21 @@ namespace ApiPort
                 WriteError(ex.InnerException.ToString());
             }
 #endif // DEBUG
+        }
+
+        private static PortabilityAnalyzerException GetPortabilityException(Exception e)
+        {
+            while (e != null)
+            {
+                if (e is PortabilityAnalyzerException p)
+                {
+                    return p;
+                }
+
+                e = e.InnerException;
+            }
+
+            return null;
         }
 
         private static IEnumerable<Exception> GetRecursiveInnerExceptions(Exception ex)


### PR DESCRIPTION
If a portability exception was thrown during construction of an object, that exception was swallowed. This adds a check for any inner exceptions from the dependency injection exceptions.

Now the message says:

```
Loading catalog                                   [Failed]

Could not find data file 'catalog.bin'. Either ensure the file is accessible during build or place it next to ApiPort at runtime.
```
Fixes #517 