### PR TITLE
Consistent text alignment in REPL

### DIFF
--- a/src/ApiPort/DocIdSearchRepl.cs
+++ b/src/ApiPort/DocIdSearchRepl.cs
@@ -20,12 +20,15 @@ namespace ApiPort
 
         public async Task DocIdSearchAsync()
         {
+            var countOption = $"{LocalizedStrings.ReplOptionCount}[{LocalizedStrings.Number}]";
+            var optionColumnWidth = Math.Max(countOption.Length, LocalizedStrings.ReplOptionExit.Length);
+
             Console.WriteLine();
             Console.WriteLine(LocalizedStrings.ReplEnterQuery);
             Console.WriteLine();
             Console.WriteLine(LocalizedStrings.ReplOptionsHeader);
-            Console.WriteLine($"  {LocalizedStrings.ReplOptionExit}               {LocalizedStrings.ReplOptionExit_Text}");
-            Console.WriteLine($"  {LocalizedStrings.ReplOptionCount}{LocalizedStrings.ReplOptionCount_Text}");
+            Console.WriteLine($"  {LocalizedStrings.ReplOptionExit.PadRight(optionColumnWidth)}\t{LocalizedStrings.ReplOptionExit_Text}");
+            Console.WriteLine($"  {countOption.PadRight(optionColumnWidth)}\t{LocalizedStrings.ReplOptionCount_Text}");
             Console.WriteLine();
 
             Console.CancelKeyPress += ConsoleCancelKeyPress;

--- a/src/ApiPort/Resources/LocalizedStrings.Designer.cs
+++ b/src/ApiPort/Resources/LocalizedStrings.Designer.cs
@@ -362,6 +362,15 @@ namespace ApiPort.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to number.
+        /// </summary>
+        internal static string Number {
+            get {
+                return ResourceManager.GetString("Number", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to options.
         /// </summary>
         internal static string Options {
@@ -479,7 +488,7 @@ namespace ApiPort.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [number]  Display [number] of search results..
+        ///   Looks up a localized string similar to Display [number] of search results..
         /// </summary>
         internal static string ReplOptionCount_Text {
             get {

--- a/src/ApiPort/Resources/LocalizedStrings.resx
+++ b/src/ApiPort/Resources/LocalizedStrings.resx
@@ -341,7 +341,7 @@ Versions marked with an asterisk (*) implies that these are default targets if n
     <value>#count=</value>
   </data>
   <data name="ReplOptionCount_Text" xml:space="preserve">
-    <value>[number]  Display [number] of search results.</value>
+    <value>Display [number] of search results.</value>
   </data>
   <data name="ReplOptionExit" xml:space="preserve">
     <value>#q</value>
@@ -357,5 +357,8 @@ Versions marked with an asterisk (*) implies that these are default targets if n
   </data>
   <data name="UnknownCommand" xml:space="preserve">
     <value>Unknown command: {0}</value>
+  </data>
+  <data name="Number" xml:space="preserve">
+    <value>number</value>
   </data>
 </root>


### PR DESCRIPTION
A small fix to ensure `DocIdSearchRepl`'s text alignment remains consistent across localizations.