### PR TITLE
Upgrade NuGet packages.

### DIFF
--- a/src/ApiPort.VisualStudio.2015/ApiPort.VisualStudio.2015.csproj
+++ b/src/ApiPort.VisualStudio.2015/ApiPort.VisualStudio.2015.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.4.0" />
+    <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="14.0.25424">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/ApiPort.VisualStudio.2017/ApiPort.VisualStudio.2017.csproj
+++ b/src/ApiPort.VisualStudio.2017/ApiPort.VisualStudio.2017.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.4.0" />
-    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="15.0.26606">
+    <PackageReference Include="Autofac" Version="4.6.2" />
+    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="15.4.27004">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" Version="15.3.224">

--- a/src/ApiPort.VisualStudio.Common/ApiPort.VisualStudio.Common.csproj
+++ b/src/ApiPort.VisualStudio.Common/ApiPort.VisualStudio.Common.csproj
@@ -21,7 +21,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="14.0.25424" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.14.0" Version="14.3.25407" />
-    <PackageReference Include="NuGet.VisualStudio" Version="4.3.0">
+    <PackageReference Include="NuGet.VisualStudio" Version="4.4.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
+++ b/src/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
@@ -61,10 +61,10 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.4.0" />
+    <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
     <PackageReference Include="Microsoft.Tpl.Dataflow" Version="4.5.24" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.1.192" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.5.100" />
     <PackageReference Include="VSLangProj140" Version="14.0.25029" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.14.0" Version="14.3.25407" />
   </ItemGroup>

--- a/src/ApiPort.Vsix/ApiPort.Vsix.csproj
+++ b/src/ApiPort.Vsix/ApiPort.Vsix.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK.VsixSuppression" Version="14.1.33" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.1.192" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.5.100" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ApiPort.VisualStudio\ApiPort.VisualStudio.csproj">

--- a/src/ApiPort/ApiPort.props
+++ b/src/ApiPort/ApiPort.props
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.4.0" />
+    <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="Autofac.Configuration" Version="4.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />

--- a/src/Microsoft.Fx.Portability.MetadataReader/Microsoft.Fx.Portability.MetadataReader.csproj
+++ b/src/Microsoft.Fx.Portability.MetadataReader/Microsoft.Fx.Portability.MetadataReader.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
+++ b/src/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.4.0" />
+    <PackageReference Include="Autofac" Version="4.6.2" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Microsoft.Fx.Portability.Reports.Html.csproj
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Microsoft.Fx.Portability.Reports.Html.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommonMark.NET" Version="0.10.0" />
-    <PackageReference Include="RazorEngine" Version="3.6.1" />
+    <PackageReference Include="CommonMark.NET" Version="0.15.1" />
+    <PackageReference Include="RazorEngine" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
+++ b/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
@@ -17,8 +17,8 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.2" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'== 'netstandard1.3'">

--- a/tests/ApiPort.Tests/ApiPort.Tests.csproj
+++ b/tests/ApiPort.Tests/ApiPort.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
   </PropertyGroup>
 
@@ -11,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ApiPortVS.Tests/ApiPortVS.Tests.csproj
+++ b/tests/ApiPortVS.Tests/ApiPortVS.Tests.csproj
@@ -8,25 +8,25 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NSubstitute" Version="2.0.3" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="EnvDTE100" Version="10.0.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
     <PackageReference Include="Microsoft.Tpl.Dataflow" Version="4.5.24" />
-    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="15.0.26606" />
+    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="15.4.27004" />
     <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="7.10.6071" />
     <PackageReference Include="Microsoft.VisualStudio.SDK.VsixSuppression" Version="14.1.33" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="7.10.6071" />
     <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop" Version="7.10.6070" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" Version="15.3.224" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.4.4" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Fx.Portability.Cci.Tests/Microsoft.Fx.Portability.Cci.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Cci.Tests/Microsoft.Fx.Portability.Cci.Tests.csproj
@@ -8,16 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NSubstitute" Version="2.0.3" />
-    <PackageReference Include="Castle.Core" Version="4.1.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
@@ -8,18 +8,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0" />
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.4.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NSubstitute" Version="2.0.3" />
-    <PackageReference Include="Castle.Core" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="System.Diagnostics.FileVersionInfo " Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Fx.Portability.Offline.Tests/Microsoft.Fx.Portability.Offline.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Offline.Tests/Microsoft.Fx.Portability.Offline.Tests.csproj
@@ -15,13 +15,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.3.0" />
-    <PackageReference Include="NSubstitute" Version="2.0.3" />
-    <PackageReference Include="Castle.Core" Version="4.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Fx.Portability.Reports.Html.Tests/Microsoft.Fx.Portability.Reports.Html.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Reports.Html.Tests/Microsoft.Fx.Portability.Reports.Html.Tests.csproj
@@ -6,13 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.3.0" />
-    <PackageReference Include="NSubstitute" Version="2.0.3" />
-    <PackageReference Include="Castle.Core" Version="4.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
@@ -15,15 +15,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.3.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NSubstitute" Version="2.0.3" />
-    <PackageReference Include="Castle.Core" Version="4.1.0" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="System.Diagnostics.FileVersionInfo " Version="4.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Test packages

xunit       => v2.3.1
NSubstitute => v3.1.0
Microsoft.TestPlatform.TestHost => v15.5.0
Microsoft.NET.Test.Sdk          => v15.5.0

Upgrade Microsoft.CodeAnalysis.CSharp to v2.4.0

Upgrade System.Reflection.Metadata to v1.5.2

Upgrade System.Collections.Immutable to v1.4.0

Upgrade RazorEngine to v3.10.0

Upgrade CommonMark.NET to v0.15.1

Upgrade Autofac to v4.6.2

Upgrade System.Net.Http to v4.3.3

Upgrade Microsoft.VSSDK.BuildTools to v15.5.100

Upgrade NuGet.VisualStudio to v4.4.0

Upgrade Microsoft.VisualStudio.ComponentModelHost to v15.4.27004

Some packages are not upgraded to latest version because projects target Visual
Studio 2015.