### PR TITLE
Add resource strings

### DIFF
--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/LocalizedStrings.Designer.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/LocalizedStrings.Designer.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Fx.Portability.Reports.Html.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Retargeting compatibility issues are breaking changes that only manifest when code is targeted to run on a newer .Net Framework version. This can happen if an application does not have a &lt;a href=&quot;https://msdn.microsoft.com/en-us/library/system.runtime.versioning.targetframeworkattribute%28v=vs.110%29.aspx&quot;&gt;TargetFrameworkAttribute&lt;/a&gt; or when the application is rebuilt with a newer toolset..
+        ///   Looks up a localized string similar to Retargeting compatibility issues are breaking changes that only manifest when code is targeted to run on a newer .Net Framework version. This can happen if an application does not have a &lt;a href=&quot;https://docs.microsoft.com/dotnet/api/system.runtime.versioning.targetframeworkattribute&quot;&gt;TargetFrameworkAttribute&lt;/a&gt; or when the application is rebuilt with a newer toolset..
         /// </summary>
         public static string RetargetingCompatIssueDescriptionPart1 {
             get {

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/LocalizedStrings.Designer.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/LocalizedStrings.Designer.cs
@@ -169,11 +169,29 @@ namespace Microsoft.Fx.Portability.Reports.Html.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to PackageId.
+        /// </summary>
+        public static string PackageIdHeader {
+            get {
+                return ResourceManager.GetString("PackageIdHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Portability Summary.
         /// </summary>
         public static string PortabilitySummaryPageTitle {
             get {
                 return ResourceManager.GetString("PortabilitySummaryPageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Recommended changes.
+        /// </summary>
+        public static string RecommendedChanges {
+            get {
+                return ResourceManager.GetString("RecommendedChanges", resourceCulture);
             }
         }
         
@@ -219,6 +237,15 @@ namespace Microsoft.Fx.Portability.Reports.Html.Resources {
         public static string SubmissionId {
             get {
                 return ResourceManager.GetString("SubmissionId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Target type.
+        /// </summary>
+        public static string TargetTypeHeader {
+            get {
+                return ResourceManager.GetString("TargetTypeHeader", resourceCulture);
             }
         }
     }

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/LocalizedStrings.resx
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/LocalizedStrings.resx
@@ -153,8 +153,14 @@
   <data name="NotSupported" xml:space="preserve">
     <value>Not supported</value>
   </data>
+  <data name="PackageIdHeader" xml:space="preserve">
+    <value>PackageId</value>
+  </data>
   <data name="PortabilitySummaryPageTitle" xml:space="preserve">
     <value>Portability Summary</value>
+  </data>
+  <data name="RecommendedChanges" xml:space="preserve">
+    <value>Recommended changes</value>
   </data>
   <data name="RetargetingCompatIssueDescriptionPart1" xml:space="preserve">
     <value>Retargeting compatibility issues are breaking changes that only manifest when code is targeted to run on a newer .Net Framework version. This can happen if an application does not have a &lt;a href="https://msdn.microsoft.com/en-us/library/system.runtime.versioning.targetframeworkattribute%28v=vs.110%29.aspx"&gt;TargetFrameworkAttribute&lt;/a&gt; or when the application is rebuilt with a newer toolset.</value>
@@ -170,5 +176,8 @@
   </data>
   <data name="SubmissionId" xml:space="preserve">
     <value>Submission Id</value>
+  </data>
+  <data name="TargetTypeHeader" xml:space="preserve">
+    <value>Target type</value>
   </data>
 </root>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/LocalizedStrings.resx
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/LocalizedStrings.resx
@@ -163,7 +163,7 @@
     <value>Recommended changes</value>
   </data>
   <data name="RetargetingCompatIssueDescriptionPart1" xml:space="preserve">
-    <value>Retargeting compatibility issues are breaking changes that only manifest when code is targeted to run on a newer .Net Framework version. This can happen if an application does not have a &lt;a href="https://msdn.microsoft.com/en-us/library/system.runtime.versioning.targetframeworkattribute%28v=vs.110%29.aspx"&gt;TargetFrameworkAttribute&lt;/a&gt; or when the application is rebuilt with a newer toolset.</value>
+    <value>Retargeting compatibility issues are breaking changes that only manifest when code is targeted to run on a newer .Net Framework version. This can happen if an application does not have a &lt;a href="https://docs.microsoft.com/dotnet/api/system.runtime.versioning.targetframeworkattribute"&gt;TargetFrameworkAttribute&lt;/a&gt; or when the application is rebuilt with a newer toolset.</value>
   </data>
   <data name="RetargetingCompatIssueDescriptionPart2" xml:space="preserve">
     <value>These issues are less impactful than runtime compatibility issues because they can typically be worked around easily, either by using a &lt;a href="https://msdn.microsoft.com/en-us/library/system.runtime.versioning.targetframeworkattribute%28v=vs.110%29.aspx"&gt;TargetFrameworkAttribute&lt;/a&gt; on the assembly, using a &lt;a href="https://msdn.microsoft.com/en-us/library/bb398202.aspx"&gt;TargetFrameworkVersion&lt;/a&gt; in the project file, or using older tools at build-time, depending on the particular issue. See issue details below for more information on how these breaking changes can be avoided.</value>


### PR DESCRIPTION
@conniey #513 lacked 3 strings for `Microsoft.Fx.Portability.Reports.Html` (RazorEngine will throw without them).