### PR TITLE
Update HTML report generation

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -6,5 +6,6 @@
     <add key="nuget" value="https://www.nuget.org/api/v2/" />
     <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="corefx lab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="razorengine-test" value="https://www.myget.org/F/razorengine-test/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Microsoft.Fx.Portability.Reports.Html/CompatibilityResultsModel.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/CompatibilityResultsModel.cs
@@ -8,11 +8,11 @@ namespace Microsoft.Fx.Portability.Reports.Html
 {
     public class CompatibilityResultsModel
     {
-        public string Name { get; private set; }
-        public string Description { get; private set; }
-        public IEnumerable<KeyValuePair<BreakingChange, IEnumerable<MemberInfo>>> Breaks { get; private set; }
-        public int WarningThreshold { get; private set; }
-        public int ErrorThreshold { get; private set; }
+        public string Name { get; }
+        public string Description { get; }
+        public IEnumerable<KeyValuePair<BreakingChange, IEnumerable<MemberInfo>>> Breaks { get; }
+        public int WarningThreshold { get; }
+        public int ErrorThreshold { get; }
 
         public CompatibilityResultsModel(string name, string description, IEnumerable<KeyValuePair<BreakingChange, IEnumerable<MemberInfo>>> breaks, int warningThreshold, int errorThreshold)
         {

--- a/src/Microsoft.Fx.Portability.Reports.Html/CompatibilityResultsModel.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/CompatibilityResultsModel.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Fx.Portability.ObjectModel;
+using System.Collections.Generic;
+
+namespace Microsoft.Fx.Portability.Reports.Html
+{
+    public class CompatibilityResultsModel
+    {
+        public string Name { get; private set; }
+        public string Description { get; private set; }
+        public IEnumerable<KeyValuePair<BreakingChange, IEnumerable<MemberInfo>>> Breaks { get; private set; }
+        public int WarningThreshold { get; private set; }
+        public int ErrorThreshold { get; private set; }
+
+        public CompatibilityResultsModel(string name, string description, IEnumerable<KeyValuePair<BreakingChange, IEnumerable<MemberInfo>>> breaks, int warningThreshold, int errorThreshold)
+        {
+            Name = name;
+            Description = description;
+            Breaks = breaks;
+            WarningThreshold = warningThreshold;
+            ErrorThreshold = errorThreshold;
+        }
+    }
+}

--- a/src/Microsoft.Fx.Portability.Reports.Html/CompatibilitySummaryModel.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/CompatibilitySummaryModel.cs
@@ -9,10 +9,10 @@ namespace Microsoft.Fx.Portability.Reports.Html
 {
     public class CompatibilitySummaryModel
     {
-        public IDictionary<BreakingChange, IEnumerable<MemberInfo>> Breaks { get; private set; }
-        public AssemblyInfo Assembly { get; private set; }
-        public ReportingResult ReportingResult { get; private set; }
-        public int LoopCounter { get; private set; }
+        public IDictionary<BreakingChange, IEnumerable<MemberInfo>> Breaks { get; }
+        public AssemblyInfo Assembly { get; }
+        public ReportingResult ReportingResult { get; }
+        public int LoopCounter { get; }
 
         public CompatibilitySummaryModel(IDictionary<BreakingChange, IEnumerable<MemberInfo>> breaks, AssemblyInfo assembly, ReportingResult reportingResult, int loopCounter)
         {

--- a/src/Microsoft.Fx.Portability.Reports.Html/CompatibilitySummaryModel.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/CompatibilitySummaryModel.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Fx.Portability.ObjectModel;
+using Microsoft.Fx.Portability.Reporting.ObjectModel;
+using System.Collections.Generic;
+
+namespace Microsoft.Fx.Portability.Reports.Html
+{
+    public class CompatibilitySummaryModel
+    {
+        public IDictionary<BreakingChange, IEnumerable<MemberInfo>> Breaks { get; private set; }
+        public AssemblyInfo Assembly { get; private set; }
+        public ReportingResult ReportingResult { get; private set; }
+        public int LoopCounter { get; private set; }
+
+        public CompatibilitySummaryModel(IDictionary<BreakingChange, IEnumerable<MemberInfo>> breaks, AssemblyInfo assembly, ReportingResult reportingResult, int loopCounter)
+        {
+            Breaks = breaks;
+            Assembly = assembly;
+            ReportingResult = reportingResult;
+            LoopCounter = loopCounter;
+        }
+    }
+}

--- a/src/Microsoft.Fx.Portability.Reports.Html/CompatibilitySummaryModel.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/CompatibilitySummaryModel.cs
@@ -12,14 +12,12 @@ namespace Microsoft.Fx.Portability.Reports.Html
         public IDictionary<BreakingChange, IEnumerable<MemberInfo>> Breaks { get; }
         public AssemblyInfo Assembly { get; }
         public ReportingResult ReportingResult { get; }
-        public int LoopCounter { get; }
 
-        public CompatibilitySummaryModel(IDictionary<BreakingChange, IEnumerable<MemberInfo>> breaks, AssemblyInfo assembly, ReportingResult reportingResult, int loopCounter)
+        public CompatibilitySummaryModel(IDictionary<BreakingChange, IEnumerable<MemberInfo>> breaks, AssemblyInfo assembly, ReportingResult reportingResult)
         {
             Breaks = breaks;
             Assembly = assembly;
             ReportingResult = reportingResult;
-            LoopCounter = loopCounter;
         }
     }
 }

--- a/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Text;
 using System;
 using Microsoft.Fx.Portability.Reports.Html;
+using Microsoft.Fx.Portability.Reports.Html.Resources;
 
 namespace Microsoft.Fx.Portability.Reports
 {
@@ -99,6 +100,17 @@ namespace Microsoft.Fx.Portability.Reports
                 var razor = s_razorService.RunCompile(template, name, typeof(T), model);
 
                 return Raw(razor);
+            }
+
+            public IEncodedString TargetSupportCell(TargetSupportedIn supportStatus)
+            {
+                var supported = supportStatus.SupportedIn != null
+                             && supportStatus.Target.Version >= supportStatus.SupportedIn;
+
+                var className = supported ? "IconSuccessEncoded" : "IconErrorEncoded";
+                var title = supported ? LocalizedStrings.Supported : LocalizedStrings.NotSupported;
+
+                return Raw($"<td class=\"{className}\" title=\"{title}\"></td>");
             }
 
             public IEncodedString WriteStyledBreakingChangeCount(int breaks, int warningThreshold, int errorThreshold)

--- a/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Fx.Portability.Reports
                 return Raw($"<td class=\"{className}\" title=\"{title}\"></td>");
             }
 
-            public IEncodedString WriteStyledBreakingChangeCount(int breaks, int warningThreshold, int errorThreshold)
+            public IEncodedString BreakingChangeCountCell(int breaks, int warningThreshold, int errorThreshold)
             {
                 var className = "";
                 if (breaks <= warningThreshold)
@@ -125,7 +125,7 @@ namespace Microsoft.Fx.Portability.Reports
                     className = breaks <= errorThreshold ? "FewBreakingChanges" : "ManyBreakingChanges";
                 }
 
-                return Raw($"<span class=\"{className}\">{breaks}</span>");
+                return Raw($"<td class=\"textCentered {className}\">{breaks}</td>");
             }
         }
 

--- a/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
@@ -19,21 +19,18 @@ namespace Microsoft.Fx.Portability.Reports
         private static readonly IRazorEngineService s_razorService = CreateService();
 
         private readonly ITargetMapper _targetMapper;
-        private readonly ResultFormatInformation _formatInformation;
 
         public HtmlReportWriter(ITargetMapper targetMapper)
         {
             _targetMapper = targetMapper;
-
-            _formatInformation = new ResultFormatInformation
-            {
-                DisplayName = "HTML",
-                MimeType = "text/html",
-                FileExtension = ".html"
-            };
         }
 
-        public ResultFormatInformation Format { get { return _formatInformation; } }
+        public ResultFormatInformation Format { get; } = new ResultFormatInformation
+        {
+            DisplayName = "HTML",
+            MimeType = "text/html",
+            FileExtension = ".html"
+        };
 
         public void WriteStream(Stream stream, AnalyzeResponse response)
         {
@@ -74,7 +71,6 @@ namespace Microsoft.Fx.Portability.Reports
                     return reader.ReadToEnd();
                 }
             }
-
         }
 
         public class HtmlHelper
@@ -103,6 +99,21 @@ namespace Microsoft.Fx.Portability.Reports
                 var razor = s_razorService.RunCompile(template, name, typeof(T), model);
 
                 return Raw(razor);
+            }
+
+            public IEncodedString WriteStyledBreakingChangeCount(int breaks, int warningThreshold, int errorThreshold)
+            {
+                var className = "";
+                if (breaks <= warningThreshold)
+                {
+                    className = "NoBreakingChanges";
+                }
+                else
+                {
+                    className = breaks <= errorThreshold ? "FewBreakingChanges" : "ManyBreakingChanges";
+                }
+
+                return Raw($"<span class=\"{className}\">{breaks}</span>");
             }
         }
 

--- a/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
@@ -20,18 +20,19 @@ namespace Microsoft.Fx.Portability.Reports
         private static readonly IRazorEngineService s_razorService = CreateService();
 
         private readonly ITargetMapper _targetMapper;
+        private static readonly ResultFormatInformation _formatInformation = new ResultFormatInformation
+        {
+            DisplayName = "HTML",
+            MimeType = "text/html",
+            FileExtension = ".html"
+        };
 
         public HtmlReportWriter(ITargetMapper targetMapper)
         {
             _targetMapper = targetMapper;
         }
 
-        public ResultFormatInformation Format { get; } = new ResultFormatInformation
-        {
-            DisplayName = "HTML",
-            MimeType = "text/html",
-            FileExtension = ".html"
-        };
+        public ResultFormatInformation Format => _formatInformation;
 
         public void WriteStream(Stream stream, AnalyzeResponse response)
         {

--- a/src/Microsoft.Fx.Portability.Reports.Html/Microsoft.Fx.Portability.Reports.Html.csproj
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Microsoft.Fx.Portability.Reports.Html.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommonMark.NET" Version="0.15.1" />
-    <PackageReference Include="RazorEngine" Version="3.10.0" />
+    <PackageReference Include="RazorEngine" Version="4.5.1-alpha002" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Microsoft.Fx.Portability.Reports.Html.csproj
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Microsoft.Fx.Portability.Reports.Html.csproj
@@ -17,11 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Resources\_PortabilityReport.cshtml" />
-    <EmbeddedResource Include="Resources\ReportTemplate.cshtml" />
-    <EmbeddedResource Include="Resources\_Scripts.cshtml" />
-    <EmbeddedResource Include="Resources\_Styles.cshtml" />
-    <EmbeddedResource Include="Resources\_BreakingChangesReport.cshtml" />
+    <EmbeddedResource Include="Resources\*.cshtml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/LocalizedStrings.Designer.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/LocalizedStrings.Designer.cs
@@ -61,11 +61,38 @@ namespace Microsoft.Fx.Portability.Reports.Html.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Header for assembly name entries.
+        ///   Looks up a localized string similar to Assembly.
+        /// </summary>
+        public static string Assembly {
+            get {
+                return ResourceManager.GetString("Assembly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Assembly.
         /// </summary>
         public static string AssemblyHeader {
             get {
                 return ResourceManager.GetString("AssemblyHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} is an invalid assembly..
+        /// </summary>
+        public static string AssemblyIsInvalid {
+            get {
+                return ResourceManager.GetString("AssemblyIsInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Available NuGet Packages .
+        /// </summary>
+        public static string AvailableNuGetPackages {
+            get {
+                return ResourceManager.GetString("AvailableNuGetPackages", resourceCulture);
             }
         }
         
@@ -97,11 +124,29 @@ namespace Microsoft.Fx.Portability.Reports.Html.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Collapse.
+        /// </summary>
+        public static string Collapse {
+            get {
+                return ResourceManager.GetString("Collapse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Framework Compatibility.
         /// </summary>
         public static string CompatibilityPageTitle {
             get {
                 return ResourceManager.GetString("CompatibilityPageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Contents.
+        /// </summary>
+        public static string Contents {
+            get {
+                return ResourceManager.GetString("Contents", resourceCulture);
             }
         }
         
@@ -115,11 +160,38 @@ namespace Microsoft.Fx.Portability.Reports.Html.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Edge.
+        /// </summary>
+        public static string Edge {
+            get {
+                return ResourceManager.GetString("Edge", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Edge Compatibility Issues.
+        /// </summary>
+        public static string EdgeCompatibilityIssues {
+            get {
+                return ResourceManager.GetString("EdgeCompatibilityIssues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Edge issues are those that will only impact a small minority of customers that use the given API in very specific ways. See issue details for more information..
         /// </summary>
         public static string EdgeCompatIssueDescription {
             get {
                 return ResourceManager.GetString("EdgeCompatIssueDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Edge Retargeting Issues.
+        /// </summary>
+        public static string EdgeRetargetingIssues {
+            get {
+                return ResourceManager.GetString("EdgeRetargetingIssues", resourceCulture);
             }
         }
         
@@ -133,11 +205,92 @@ namespace Microsoft.Fx.Portability.Reports.Html.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Expand.
+        /// </summary>
+        public static string Expand {
+            get {
+                return ResourceManager.GetString("Expand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hide columns:.
+        /// </summary>
+        public static string HideColumns {
+            get {
+                return ResourceManager.GetString("HideColumns", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hide rows:.
+        /// </summary>
+        public static string HideRows {
+            get {
+                return ResourceManager.GetString("HideRows", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hide rows that don&apos;t have problems.
+        /// </summary>
+        public static string HideRowsWithNoProblems {
+            get {
+                return ResourceManager.GetString("HideRowsWithNoProblems", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to .NET Portability Report.
         /// </summary>
         public static string HtmlReportTitle {
             get {
                 return ResourceManager.GetString("HtmlReportTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ignored Assemblies:.
+        /// </summary>
+        public static string IgnoredAssemblies {
+            get {
+                return ResourceManager.GetString("IgnoredAssemblies", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid content for breaking-change-count tag: {0}.
+        /// </summary>
+        public static string InvalidBreakingChangeCountTagContent {
+            get {
+                return ResourceManager.GetString("InvalidBreakingChangeCountTagContent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid error-threshold attribute: {0}.
+        /// </summary>
+        public static string InvalidErrorThresholdAttribute {
+            get {
+                return ResourceManager.GetString("InvalidErrorThresholdAttribute", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Major.
+        /// </summary>
+        public static string Major {
+            get {
+                return ResourceManager.GetString("Major", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Major Compatibility Issues.
+        /// </summary>
+        public static string MajorCompatibilityIssues {
+            get {
+                return ResourceManager.GetString("MajorCompatibilityIssues", resourceCulture);
             }
         }
         
@@ -151,11 +304,74 @@ namespace Microsoft.Fx.Portability.Reports.Html.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Major Retargeting Issues.
+        /// </summary>
+        public static string MajorRetargetingIssues {
+            get {
+                return ResourceManager.GetString("MajorRetargetingIssues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minor.
+        /// </summary>
+        public static string Minor {
+            get {
+                return ResourceManager.GetString("Minor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minor Compatibility Issues.
+        /// </summary>
+        public static string MinorCompatibilityIssues {
+            get {
+                return ResourceManager.GetString("MinorCompatibilityIssues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Minor issues are those that will only impact customers using the given feature in a particular way. See issue details for more information..
         /// </summary>
         public static string MinorCompatIssueDescription {
             get {
                 return ResourceManager.GetString("MinorCompatIssueDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minor Retargeting Issues.
+        /// </summary>
+        public static string MinorRetargetingIssues {
+            get {
+                return ResourceManager.GetString("MinorRetargetingIssues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Missing Assemblies.
+        /// </summary>
+        public static string MissingAssemblies {
+            get {
+                return ResourceManager.GetString("MissingAssemblies", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to More info.
+        /// </summary>
+        public static string MoreInfo {
+            get {
+                return ResourceManager.GetString("MoreInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No {0} detected..
+        /// </summary>
+        public static string NoCompatIssuesDetected {
+            get {
+                return ResourceManager.GetString("NoCompatIssuesDetected", resourceCulture);
             }
         }
         
@@ -178,6 +394,15 @@ namespace Microsoft.Fx.Portability.Reports.Html.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Per Assembly Overview:.
+        /// </summary>
+        public static string PerAssemblyOverview {
+            get {
+                return ResourceManager.GetString("PerAssemblyOverview", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Portability Summary.
         /// </summary>
         public static string PortabilitySummaryPageTitle {
@@ -192,6 +417,15 @@ namespace Microsoft.Fx.Portability.Reports.Html.Resources {
         public static string RecommendedChanges {
             get {
                 return ResourceManager.GetString("RecommendedChanges", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Retargeting Compatibility Issues.
+        /// </summary>
+        public static string RetargetingCompatibilityIssues {
+            get {
+                return ResourceManager.GetString("RetargetingCompatibilityIssues", resourceCulture);
             }
         }
         
@@ -214,7 +448,7 @@ namespace Microsoft.Fx.Portability.Reports.Html.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Retargeting compatibility issues are breaking changes that only manifest when code is targeted to run on a newer .Net Framework version. These issues are less impactful than runtime compatibility issues because they can typically be worked around easily, either by using a TargetFrameworkAttribute on the assembly, using a TargetFrameworkVersion in the project file, or using older tools at build-time, depending on the particular issue. See issue details below for more information on how these breaking changes [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to Retargeting compatibility issues are breaking changes that only manifest when code is targeted to run on a newer .NET Framework version. These issues are less impactful than runtime compatibility issues because they can typically be worked around easily, either by using a TargetFrameworkAttribute on the assembly, using a TargetFrameworkVersion in the project file, or using older tools at build-time, depending on the particular issue. See issue details below for more information on how these breaking changes [rest of string was truncated]&quot;;.
         /// </summary>
         public static string RetargetingCompatIssueDescriptionPlainText {
             get {
@@ -223,11 +457,56 @@ namespace Microsoft.Fx.Portability.Reports.Html.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Runtime compatibility issues are those that will occur simply by running code on a new .Net Framework version. These are the variety of breaking changes most likely to impact applications since they cannot be quirked away and do not depend on an application being recompiled..
+        ///   Looks up a localized string similar to Retargeting Issues.
+        /// </summary>
+        public static string RetargetingIssues {
+            get {
+                return ResourceManager.GetString("RetargetingIssues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Retargeting Compatibility Issues ({0}).
+        /// </summary>
+        public static string RetargetingIssuesHeader {
+            get {
+                return ResourceManager.GetString("RetargetingIssuesHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Runtime Compatibility Issues.
+        /// </summary>
+        public static string RuntimeCompatibilityIssues {
+            get {
+                return ResourceManager.GetString("RuntimeCompatibilityIssues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Runtime compatibility issues are those that will occur simply by running code on a new .NET Framework version. These are the variety of breaking changes most likely to impact applications since they cannot be quirked away and do not depend on an application being recompiled..
         /// </summary>
         public static string RuntimeCompatIssueDescription {
             get {
                 return ResourceManager.GetString("RuntimeCompatIssueDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Runtime Issues.
+        /// </summary>
+        public static string RuntimeIssues {
+            get {
+                return ResourceManager.GetString("RuntimeIssues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Runtime Compatibility Issues ({0}).
+        /// </summary>
+        public static string RuntimeIssuesHeader {
+            get {
+                return ResourceManager.GetString("RuntimeIssuesHeader", resourceCulture);
             }
         }
         
@@ -237,6 +516,24 @@ namespace Microsoft.Fx.Portability.Reports.Html.Resources {
         public static string SubmissionId {
             get {
                 return ResourceManager.GetString("SubmissionId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Submission Overview:.
+        /// </summary>
+        public static string SubmissionOverview {
+            get {
+                return ResourceManager.GetString("SubmissionOverview", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Supported.
+        /// </summary>
+        public static string Supported {
+            get {
+                return ResourceManager.GetString("Supported", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/LocalizedStrings.resx
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/LocalizedStrings.resx
@@ -118,7 +118,11 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AssemblyHeader" xml:space="preserve">
-    <value>Header for assembly name entries</value>
+    <value>Assembly</value>
+    <comment>Header for assembly name entries</comment>
+  </data>
+  <data name="AvailableNuGetPackages" xml:space="preserve">
+    <value>Available NuGet Packages </value>
   </data>
   <data name="BackToSummary" xml:space="preserve">
     <value>Back to Summary</value>
@@ -129,26 +133,74 @@
   <data name="CatalogLastUpdated" xml:space="preserve">
     <value>API Catalog last updated on</value>
   </data>
+  <data name="Collapse" xml:space="preserve">
+    <value>Collapse</value>
+  </data>
   <data name="CompatibilityPageTitle" xml:space="preserve">
     <value>Framework Compatibility</value>
+  </data>
+  <data name="Contents" xml:space="preserve">
+    <value>Contents</value>
   </data>
   <data name="CouldNotLocate" xml:space="preserve">
     <value>Could not locate: {0}</value>
   </data>
+  <data name="EdgeCompatibilityIssues" xml:space="preserve">
+    <value>Edge Compatibility Issues</value>
+  </data>
   <data name="EdgeCompatIssueDescription" xml:space="preserve">
     <value>Edge issues are those that will only impact a small minority of customers that use the given API in very specific ways. See issue details for more information.</value>
+  </data>
+  <data name="EdgeRetargetingIssues" xml:space="preserve">
+    <value>Edge Retargeting Issues</value>
   </data>
   <data name="ExistingResources" xml:space="preserve">
     <value>Existing resources:</value>
   </data>
+  <data name="Expand" xml:space="preserve">
+    <value>Expand</value>
+  </data>
+  <data name="HideColumns" xml:space="preserve">
+    <value>Hide columns:</value>
+  </data>
+  <data name="HideRows" xml:space="preserve">
+    <value>Hide rows:</value>
+  </data>
+  <data name="HideRowsWithNoProblems" xml:space="preserve">
+    <value>Hide rows that don't have problems</value>
+  </data>
   <data name="HtmlReportTitle" xml:space="preserve">
     <value>.NET Portability Report</value>
+  </data>
+  <data name="InvalidBreakingChangeCountTagContent" xml:space="preserve">
+    <value>Invalid content for breaking-change-count tag: {0}</value>
+  </data>
+  <data name="InvalidErrorThresholdAttribute" xml:space="preserve">
+    <value>Invalid error-threshold attribute: {0}</value>
+  </data>
+  <data name="MajorCompatibilityIssues" xml:space="preserve">
+    <value>Major Compatibility Issues</value>
   </data>
   <data name="MajorCompatIssueDescription" xml:space="preserve">
     <value>Major issues are those that are likely to impact most customers using the given feature or API.</value>
   </data>
+  <data name="MajorRetargetingIssues" xml:space="preserve">
+    <value>Major Retargeting Issues</value>
+  </data>
+  <data name="MinorCompatibilityIssues" xml:space="preserve">
+    <value>Minor Compatibility Issues</value>
+  </data>
   <data name="MinorCompatIssueDescription" xml:space="preserve">
     <value>Minor issues are those that will only impact customers using the given feature in a particular way. See issue details for more information.</value>
+  </data>
+  <data name="MinorRetargetingIssues" xml:space="preserve">
+    <value>Minor Retargeting Issues</value>
+  </data>
+  <data name="MoreInfo" xml:space="preserve">
+    <value>More info</value>
+  </data>
+  <data name="NoCompatIssuesDetected" xml:space="preserve">
+    <value>No {0} detected.</value>
   </data>
   <data name="NotSupported" xml:space="preserve">
     <value>Not supported</value>
@@ -169,15 +221,63 @@
     <value>These issues are less impactful than runtime compatibility issues because they can typically be worked around easily, either by using a &lt;a href="https://msdn.microsoft.com/en-us/library/system.runtime.versioning.targetframeworkattribute%28v=vs.110%29.aspx"&gt;TargetFrameworkAttribute&lt;/a&gt; on the assembly, using a &lt;a href="https://msdn.microsoft.com/en-us/library/bb398202.aspx"&gt;TargetFrameworkVersion&lt;/a&gt; in the project file, or using older tools at build-time, depending on the particular issue. See issue details below for more information on how these breaking changes can be avoided.</value>
   </data>
   <data name="RetargetingCompatIssueDescriptionPlainText" xml:space="preserve">
-    <value>Retargeting compatibility issues are breaking changes that only manifest when code is targeted to run on a newer .Net Framework version. These issues are less impactful than runtime compatibility issues because they can typically be worked around easily, either by using a TargetFrameworkAttribute on the assembly, using a TargetFrameworkVersion in the project file, or using older tools at build-time, depending on the particular issue. See issue details below for more information on how these breaking changes can be avoided.</value>
+    <value>Retargeting compatibility issues are breaking changes that only manifest when code is targeted to run on a newer .NET Framework version. These issues are less impactful than runtime compatibility issues because they can typically be worked around easily, either by using a TargetFrameworkAttribute on the assembly, using a TargetFrameworkVersion in the project file, or using older tools at build-time, depending on the particular issue. See issue details below for more information on how these breaking changes can be avoided.</value>
+  </data>
+  <data name="RetargetingIssuesHeader" xml:space="preserve">
+    <value>Retargeting Compatibility Issues ({0})</value>
   </data>
   <data name="RuntimeCompatIssueDescription" xml:space="preserve">
-    <value>Runtime compatibility issues are those that will occur simply by running code on a new .Net Framework version. These are the variety of breaking changes most likely to impact applications since they cannot be quirked away and do not depend on an application being recompiled.</value>
+    <value>Runtime compatibility issues are those that will occur simply by running code on a new .NET Framework version. These are the variety of breaking changes most likely to impact applications since they cannot be quirked away and do not depend on an application being recompiled.</value>
+  </data>
+  <data name="RuntimeIssuesHeader" xml:space="preserve">
+    <value>Runtime Compatibility Issues ({0})</value>
   </data>
   <data name="SubmissionId" xml:space="preserve">
     <value>Submission Id</value>
   </data>
+  <data name="Supported" xml:space="preserve">
+    <value>Supported</value>
+  </data>
   <data name="TargetTypeHeader" xml:space="preserve">
     <value>Target type</value>
+  </data>
+  <data name="MissingAssemblies" xml:space="preserve">
+    <value>Missing Assemblies</value>
+  </data>
+  <data name="Assembly" xml:space="preserve">
+    <value>Assembly</value>
+  </data>
+  <data name="AssemblyIsInvalid" xml:space="preserve">
+    <value>{0} is an invalid assembly.</value>
+  </data>
+  <data name="Edge" xml:space="preserve">
+    <value>Edge</value>
+  </data>
+  <data name="IgnoredAssemblies" xml:space="preserve">
+    <value>Ignored Assemblies:</value>
+  </data>
+  <data name="Major" xml:space="preserve">
+    <value>Major</value>
+  </data>
+  <data name="Minor" xml:space="preserve">
+    <value>Minor</value>
+  </data>
+  <data name="PerAssemblyOverview" xml:space="preserve">
+    <value>Per Assembly Overview:</value>
+  </data>
+  <data name="RetargetingCompatibilityIssues" xml:space="preserve">
+    <value>Retargeting Compatibility Issues</value>
+  </data>
+  <data name="RetargetingIssues" xml:space="preserve">
+    <value>Retargeting Issues</value>
+  </data>
+  <data name="RuntimeCompatibilityIssues" xml:space="preserve">
+    <value>Runtime Compatibility Issues</value>
+  </data>
+  <data name="RuntimeIssues" xml:space="preserve">
+    <value>Runtime Issues</value>
+  </data>
+  <data name="SubmissionOverview" xml:space="preserve">
+    <value>Submission Overview:</value>
   </data>
 </root>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/ReportTemplate.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/ReportTemplate.cshtml
@@ -5,12 +5,7 @@
 
 @model Microsoft.Fx.Portability.Reports.RazorHtmlObject
 
-@using Microsoft.Fx.Portability
-@using Microsoft.Fx.Portability.Reporting.ObjectModel
 @using Microsoft.Fx.Portability.Reports.Html.Resources
-@using System.IO
-@using System.Linq
-@using System.Runtime.Versioning
 
 @{
     ViewBag.Title = LocalizedStrings.HtmlReportTitle;
@@ -55,7 +50,7 @@
             </p>
 
             <div id="toc">
-                <h2>Contents</h2>
+                <h2>@LocalizedStrings.Contents</h2>
                 <ul>
                     @if (includeBreakingChanges)
                     {

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/ReportTemplate.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/ReportTemplate.cshtml
@@ -16,7 +16,7 @@
 }
 
 <!DOCTYPE html>
-<html xmlns:msxsl="urn:schemas-microsoft-com:xslt">
+<html lang="en-us" xmlns:msxsl="urn:schemas-microsoft-com:xslt">
 <head>
     <meta content="en-us" http-equiv="Content-Language" />
     <meta content="text/html; charset=utf-16" http-equiv="Content-Type" />

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/ReportTemplate.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/ReportTemplate.cshtml
@@ -1,7 +1,7 @@
-﻿<!--
+﻿@*
    Copyright (c) Microsoft. All rights reserved.
    Licensed under the MIT license. See LICENSE file in the project root for full license information.
--->
+*@
 
 @model Microsoft.Fx.Portability.Reports.RazorHtmlObject
 

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_BreakingChangesReport.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_BreakingChangesReport.cshtml
@@ -50,14 +50,11 @@
                     var minorRetargetingIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Minor && b.Key.IsRetargeting);
                     var edgeRetargetingIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Edge && b.Key.IsRetargeting);
 
-                    // Determine if the row is important or not (based on issue counts)
-                    var rowClass = (majorIssues.Count() > 0 || minorIssues.Count() > 0) ? string.Empty : "lowPriRow";
-
                     // Create a link to compat details if they will exist
                     var link = (majorIssues.Count() + minorIssues.Count() + edgeIssues.Count() + majorRetargetingIssues.Count() + minorRetargetingIssues.Count() + edgeRetargetingIssues.Count()) > 0 ?
                                 "#Compat-" + assembly :
                                 "#" + LocalizedStrings.CompatibilityPageTitle;
-                    <tr class="@rowClass">
+                    <tr>
                         <td>
                             <strong>
                                 <a href="@link">
@@ -69,12 +66,12 @@
                                 </a>
                             </strong>
                         </td>
-                        <td class="textCentered">@Html.WriteStyledBreakingChangeCount(majorIssues.Count(), 0, 2)</td>
-                        <td class="textCentered">@Html.WriteStyledBreakingChangeCount(minorIssues.Count(), 0, 3)</td>
-                        <td class="textCentered">@Html.WriteStyledBreakingChangeCount(edgeIssues.Count(), 0, 100)</td>
-                        <td class="textCentered">@Html.WriteStyledBreakingChangeCount(majorRetargetingIssues.Count(), 0, 2)</td>
-                        <td class="textCentered">@Html.WriteStyledBreakingChangeCount(minorRetargetingIssues.Count(), 0, 3)</td>
-                        <td class="textCentered">@Html.WriteStyledBreakingChangeCount(edgeRetargetingIssues.Count(), 0, 100)</td>
+                        @Html.BreakingChangeCountCell(majorIssues.Count(), 0, 2)
+                        @Html.BreakingChangeCountCell(minorIssues.Count(), 0, 3)
+                        @Html.BreakingChangeCountCell(edgeIssues.Count(), 0, 100)
+                        @Html.BreakingChangeCountCell(majorRetargetingIssues.Count(), 0, 2)
+                        @Html.BreakingChangeCountCell(minorRetargetingIssues.Count(), 0, 3)
+                        @Html.BreakingChangeCountCell(edgeRetargetingIssues.Count(), 0, 100)
                     </tr>
                 }
             }

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_BreakingChangesReport.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_BreakingChangesReport.cshtml
@@ -19,21 +19,21 @@
     <a name="@LocalizedStrings.CompatibilityPageTitle"></a>@LocalizedStrings.CompatibilityPageTitle
 </h2>
 <div id="summary-compat-byassembly">
-    <h3 class="compat-subheader">Per Assembly Overview:</h3>
+    <h3 class="compat-subheader">@LocalizedStrings.PerAssemblyOverview</h3>
     <table>
         <tbody>
             <tr>
                 <th rowspan="2">@LocalizedStrings.AssemblyHeader</th>
-                <th colspan="3" class="textCentered"><abbr title="@LocalizedStrings.RuntimeCompatIssueDescription">Runtime Issues</abbr></th>
-                <th colspan="3" class="textCentered"><abbr title="@LocalizedStrings.RetargetingCompatIssueDescriptionPlainText">Retargeting Issues</abbr></th>
+                <th colspan="3" class="textCentered"><abbr title="@LocalizedStrings.RuntimeCompatIssueDescription">@LocalizedStrings.RuntimeIssues</abbr></th>
+                <th colspan="3" class="textCentered"><abbr title="@LocalizedStrings.RetargetingCompatIssueDescriptionPlainText">@LocalizedStrings.RetargetingIssues</abbr></th>
             </tr>
             <tr>
-                <th><abbr title="@LocalizedStrings.MajorCompatIssueDescription">Major</abbr></th>
-                <th><abbr title="@LocalizedStrings.MinorCompatIssueDescription">Minor</abbr></th>
-                <th><abbr title="@LocalizedStrings.EdgeCompatIssueDescription">Edge</abbr></th>
-                <th><abbr title="@LocalizedStrings.MajorCompatIssueDescription">Major</abbr></th>
-                <th><abbr title="@LocalizedStrings.MinorCompatIssueDescription">Minor</abbr></th>
-                <th><abbr title="@LocalizedStrings.EdgeCompatIssueDescription">Edge</abbr></th>
+                <th><abbr title="@LocalizedStrings.MajorCompatIssueDescription">@LocalizedStrings.Major</abbr></th>
+                <th><abbr title="@LocalizedStrings.MinorCompatIssueDescription">@LocalizedStrings.Minor</abbr></th>
+                <th><abbr title="@LocalizedStrings.EdgeCompatIssueDescription">@LocalizedStrings.Edge</abbr></th>
+                <th><abbr title="@LocalizedStrings.MajorCompatIssueDescription">@LocalizedStrings.Major</abbr></th>
+                <th><abbr title="@LocalizedStrings.MinorCompatIssueDescription">@LocalizedStrings.Minor</abbr></th>
+                <th><abbr title="@LocalizedStrings.EdgeCompatIssueDescription">@LocalizedStrings.Edge</abbr></th>
             </tr>
 
             @*Writing the summary body information here.*@
@@ -85,10 +85,10 @@
 @if (Model.OrderedBreakingChangeSkippedAssemblies.Count() > 0)
 {
     <div id="summary-compat-skippedassemblies">
-        <h3 class="compat-subheader">Ignored Assemblies:</h3>
+        <h3 class="compat-subheader">@LocalizedStrings.IgnoredAssemblies</h3>
         <table>
             <tr>
-                <th>Assembly</th>
+                <th>@LocalizedStrings.Assembly</th>
             </tr>
             @foreach (AssemblyInfo assembly in Model.OrderedBreakingChangeSkippedAssemblies)
             {
@@ -106,7 +106,7 @@
     </div>
 }
 <div id="summary-compat-bybreakingchange">
-    <h3 class="compat-subheader">Submission Overview:</h3>
+    <h3 class="compat-subheader">@LocalizedStrings.SubmissionOverview</h3>
 
     @Html.Partial("_CompatibilitySummary", new CompatibilitySummaryModel(Model.BreakingChangesSummary, null, null, 0))
 </div>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_BreakingChangesReport.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_BreakingChangesReport.cshtml
@@ -105,15 +105,13 @@
 <div id="summary-compat-bybreakingchange">
     <h3 class="compat-subheader">@LocalizedStrings.SubmissionOverview</h3>
 
-    @Html.Partial("_CompatibilitySummary", new CompatibilitySummaryModel(Model.BreakingChangesSummary, null, null, 0))
+    @Html.Partial("_CompatibilitySummary", new CompatibilitySummaryModel(Model.BreakingChangesSummary, null, null))
 </div>
 <div id="CompatDetails">
     @{
-        var loopCounter = 1;
-
         foreach (var kvp in Model.OrderedBreakingChangesByAssembly)
         {
-            @Html.Partial("_CompatibilitySummary", new CompatibilitySummaryModel(kvp.Value, kvp.Key, reportingResult, loopCounter++))
+            @Html.Partial("_CompatibilitySummary", new CompatibilitySummaryModel(kvp.Value, kvp.Key, reportingResult))
         }
     }
 </div>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_BreakingChangesReport.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_BreakingChangesReport.cshtml
@@ -1,149 +1,18 @@
-﻿<!--
-   Copyright (c) Microsoft. All rights reserved.
-   Licensed under the MIT license. See LICENSE file in the project root for full license information.
--->
+﻿@*
+    Copyright (c) Microsoft. All rights reserved.
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*@
 
 @model Microsoft.Fx.Portability.Reports.RazorHtmlObject
 
 @using Microsoft.Fx.Portability
 @using Microsoft.Fx.Portability.ObjectModel
-@using Microsoft.Fx.Portability.Reporting.ObjectModel
+@using Microsoft.Fx.Portability.Reports.Html
 @using Microsoft.Fx.Portability.Reports.Html.Resources
-@using System.IO
 @using System.Linq
-@using System.Runtime.Versioning
 
 @{
     var reportingResult = Model.ReportingResult;
-}
-
-@helper WriteStyledBreakingChangeCount(IEnumerable<KeyValuePair<BreakingChange, IEnumerable<MemberInfo>>> breaks, int warningThreshold, int errorThreshold)
-{
-    var count = breaks.Count();
-    var colorClass = count <= warningThreshold ? "NoBreakingChanges" : (count <= errorThreshold ? "FewBreakingChanges" : "ManyBreakingChanges");
-    <span class="@colorClass">@count</span>
-}
-
-@helper WriteAssembly(AssemblyInfo assembly, string friendlyName = null)
-{
-    var nameToDisplay = friendlyName ?? assembly.ToString();
-    <span class="assembly-name">@nameToDisplay</span>
-    if (!string.IsNullOrEmpty(assembly.TargetFrameworkMoniker))
-    {
-        <span class="assembly-tfm">(@assembly.TargetFrameworkMoniker)</span>
-    }
-}
-
-@helper WriteCompatibilityResults(string name, string description, IEnumerable<KeyValuePair<BreakingChange, IEnumerable<MemberInfo>>> breaks, int warningThreshold, int errorThreshold)
-{
-    <h4><abbr title="@description">@name</abbr> - @WriteStyledBreakingChangeCount(breaks, warningThreshold, errorThreshold)</h4>
-    <div id="BreakDetails" class="BreakDetails">
-        @if (breaks.Count() > 0)
-        {
-            <table>
-                <colgroup>
-                    <col span="1" class="BreakingChangeID">
-                    <col span="1" class="APIColumn">
-                    <col span="2" class="LongDescriptionColumn">
-                </colgroup>
-                <tbody>
-                    <tr>
-                        <th>ID</th>
-                        <th>API</th>
-                        <th>Details</th>
-                        <th>Recommendation</th>
-                        <th class="NarrowHeader"><div>Quirked</div></th>
-                        <th class="NarrowHeader"><div>Version Introduced</div></th>
-                        <th class="NarrowHeader"><div>Version Reverted</div></th>
-                        <th class="NarrowHeader"><div>Analyzer Status</div></th>
-                        <th class="NarrowHeader"><div>Link</div></th>
-                    </tr>
-                    @foreach (KeyValuePair<BreakingChange, IEnumerable<MemberInfo>> b in breaks)
-                    {
-                        <tr>
-                            <td>@b.Key.Id</td>
-                            <td class="MemberNames">
-                                <ul>
-                                    @foreach (string member in @b.Value.Select(m => m.ToString()).Distinct().OrderBy(s => s)) // Distinct because the members can appear multiple times if they exist in multiple referenced assemblies
-                                    {
-                                        // Remove the docid member/type prefix
-                                        var index = member.IndexOf(":");
-                                        var fixedName = index > -1 ? member.Substring(index + 1) : member;
-                                        <li>@fixedName</li>
-                                    }
-                                </ul>
-                            </td>
-                            <td>@{WriteLiteral(Html.ConvertMarkdownToHtml(b.Key.Details));}</td>
-                            <td>@{WriteLiteral(Html.ConvertMarkdownToHtml(b.Key.Suggestion));}</td>
-                            <td>@b.Key.IsQuirked</td>
-                            <td>@b.Key.VersionBroken</td>
-                            <td>@b.Key.VersionFixed</td>
-                            <td>@b.Key.SourceAnalyzerStatus</td>
-                            <td>
-                                @if (!string.IsNullOrWhiteSpace(b.Key.Link))
-                                {
-                                    <a href="@b.Key.Link">More info</a>
-                                }
-                            </td>
-                        </tr>
-                    }
-                </tbody>
-            </table>
-        }
-        else
-        {
-            <p class="CompatMessage GoodMessage">No @name.ToLowerInvariant() detected.</p>
-        }
-    </div>
-}
-
-@helper WriteCompatSummary(IDictionary<BreakingChange, IEnumerable<MemberInfo>> breaks, AssemblyInfo assembly, ReportingResult reportingResult, int loopCounter)
-{
-    var majorIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Major && !b.Key.IsRetargeting);
-    var minorIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Minor && !b.Key.IsRetargeting);
-    var edgeIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Edge && !b.Key.IsRetargeting);
-    var totalCompatIssues = majorIssues.Count() + minorIssues.Count() + edgeIssues.Count();
-    var majorRetargetingIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Major && b.Key.IsRetargeting);
-    var minorRetargetingIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Minor && b.Key.IsRetargeting);
-    var edgeRetargetingIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Edge && b.Key.IsRetargeting);
-    var totalRetargetingIssues = majorRetargetingIssues.Count() + minorRetargetingIssues.Count() + edgeRetargetingIssues.Count();
-
-    // Don't bother writing details for assemblies without issues
-    if (totalCompatIssues + totalRetargetingIssues == 0)
-    {
-        return;
-    }
-
-    var runtimeIssuesDivName = "RuntimeIssues" + loopCounter.ToString();
-    var retargetingIssuesDivName = "RetargetingIssues" + loopCounter.ToString();
-    var runtimeIssuesButtonName = "Toggle" + runtimeIssuesDivName;
-    var retargetingIssuesButtonName = "Toggle" + retargetingIssuesDivName;
-
-    <div id="assemblyCompatDetails">
-        @if (assembly != null)
-        {
-            <h3><a name="Compat-@assembly">@WriteAssembly(assembly, reportingResult.GetNameForAssemblyInfo(assembly))</a></h3>
-        }
-        <h3>Runtime Compatibility Issues (@totalCompatIssues) <button class="ToggleButton" id="@runtimeIssuesButtonName">&#8212</button></h3>
-        <div id="@runtimeIssuesDivName">
-            <p>@LocalizedStrings.RuntimeCompatIssueDescription</p>
-            @WriteCompatibilityResults("Major Compatibility Issues", LocalizedStrings.MajorCompatIssueDescription, majorIssues, 0, 2)
-            @WriteCompatibilityResults("Minor Compatibility Issues", LocalizedStrings.MinorCompatIssueDescription, minorIssues, 0, 3)
-            @WriteCompatibilityResults("Edge Compatibility Issues", LocalizedStrings.EdgeCompatIssueDescription, edgeIssues, 0, 100)
-        </div>
-        <h3>Retargeting Compatibility Issues (@totalRetargetingIssues) <button class="ToggleButton" id="@retargetingIssuesButtonName">+</button></h3>
-        <div class="BeginToggledOff" id="@retargetingIssuesDivName">
-            <p>@Html.Raw(LocalizedStrings.RetargetingCompatIssueDescriptionPart1)</p>
-            <p>@Html.Raw(LocalizedStrings.RetargetingCompatIssueDescriptionPart2)</p>
-            @WriteCompatibilityResults("Major Retargeting Issues", LocalizedStrings.MajorCompatIssueDescription, majorRetargetingIssues, 0, 2)
-            @WriteCompatibilityResults("Minor Retargeting Issues", LocalizedStrings.MinorCompatIssueDescription, minorRetargetingIssues, 0, 3)
-            @WriteCompatibilityResults("Edge Retargeting Issues", LocalizedStrings.EdgeCompatIssueDescription, edgeRetargetingIssues, 0, 100)
-        </div>
-    </div>
-    <p>
-        <a href="#@LocalizedStrings.CompatibilityPageTitle">@LocalizedStrings.BackToSummary</a>
-    </p>
-    <br />
 }
 
 <h2>
@@ -170,8 +39,8 @@
             @*Writing the summary body information here.*@
             @foreach (var kvp in Model.OrderedBreakingChangesByAssembly)
             {
-                var assm = kvp.Key;
-                if (!Model.OrderedBreakingChangeSkippedAssemblies.Contains(assm))
+                var assembly = kvp.Key;
+                if (!Model.OrderedBreakingChangeSkippedAssemblies.Contains(assembly))
                 {
                     var breaks = kvp.Value;
                     var majorIssues = breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Major && !b.Key.IsRetargeting);
@@ -186,16 +55,26 @@
 
                     // Create a link to compat details if they will exist
                     var link = (majorIssues.Count() + minorIssues.Count() + edgeIssues.Count() + majorRetargetingIssues.Count() + minorRetargetingIssues.Count() + edgeRetargetingIssues.Count()) > 0 ?
-                                "#Compat-" + assm :
+                                "#Compat-" + assembly :
                                 "#" + LocalizedStrings.CompatibilityPageTitle;
                     <tr class="@rowClass">
-                        <td><strong><a href="@link">@WriteAssembly(assm, reportingResult.GetNameForAssemblyInfo(assm))</a></strong></td>
-                        <td class="textCentered">@WriteStyledBreakingChangeCount(majorIssues, 0, 2)</td>
-                        <td class="textCentered">@WriteStyledBreakingChangeCount(minorIssues, 0, 3)</td>
-                        <td class="textCentered">@WriteStyledBreakingChangeCount(edgeIssues, 0, 100)</td>
-                        <td class="textCentered">@WriteStyledBreakingChangeCount(majorRetargetingIssues, 0, 2)</td>
-                        <td class="textCentered">@WriteStyledBreakingChangeCount(minorRetargetingIssues, 0, 3)</td>
-                        <td class="textCentered">@WriteStyledBreakingChangeCount(edgeRetargetingIssues, 0, 100)</td>
+                        <td>
+                            <strong>
+                                <a href="@link">
+                                    <span class="assembly-name">@reportingResult.GetNameForAssemblyInfo(assembly)</span>
+                                    @if (!string.IsNullOrEmpty(assembly.TargetFrameworkMoniker))
+                                    {
+                                        <span class="assembly-tfm">(@assembly.TargetFrameworkMoniker)</span>
+                                    }
+                                </a>
+                            </strong>
+                        </td>
+                        <td class="textCentered">@Html.WriteStyledBreakingChangeCount(majorIssues.Count(), 0, 2)</td>
+                        <td class="textCentered">@Html.WriteStyledBreakingChangeCount(minorIssues.Count(), 0, 3)</td>
+                        <td class="textCentered">@Html.WriteStyledBreakingChangeCount(edgeIssues.Count(), 0, 100)</td>
+                        <td class="textCentered">@Html.WriteStyledBreakingChangeCount(majorRetargetingIssues.Count(), 0, 2)</td>
+                        <td class="textCentered">@Html.WriteStyledBreakingChangeCount(minorRetargetingIssues.Count(), 0, 3)</td>
+                        <td class="textCentered">@Html.WriteStyledBreakingChangeCount(edgeRetargetingIssues.Count(), 0, 100)</td>
                     </tr>
                 }
             }
@@ -211,10 +90,16 @@
             <tr>
                 <th>Assembly</th>
             </tr>
-            @foreach(AssemblyInfo a in Model.OrderedBreakingChangeSkippedAssemblies)
+            @foreach (AssemblyInfo assembly in Model.OrderedBreakingChangeSkippedAssemblies)
             {
                 <tr>
-                    <td>@WriteAssembly(a)</td>
+                    <td>
+                        <span class="assembly-name">@assembly</span>
+                        @if (!string.IsNullOrEmpty(assembly.TargetFrameworkMoniker))
+                        {
+                            <span class="assembly-tfm">(@assembly.TargetFrameworkMoniker)</span>
+                        }
+                    </td>
                 </tr>
             }
         </table>
@@ -223,7 +108,7 @@
 <div id="summary-compat-bybreakingchange">
     <h3 class="compat-subheader">Submission Overview:</h3>
 
-    @WriteCompatSummary(Model.BreakingChangesSummary, null, null, 0)
+    @Html.Partial("_CompatibilitySummary", new CompatibilitySummaryModel(Model.BreakingChangesSummary, null, null, 0))
 </div>
 <div id="CompatDetails">
     @{
@@ -231,7 +116,7 @@
 
         foreach (var kvp in Model.OrderedBreakingChangesByAssembly)
         {
-            @WriteCompatSummary(kvp.Value, kvp.Key, reportingResult, loopCounter++)
+            @Html.Partial("_CompatibilitySummary", new CompatibilitySummaryModel(kvp.Value, kvp.Key, reportingResult, loopCounter++))
         }
     }
 </div>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_CompatibilityResults.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_CompatibilityResults.cshtml
@@ -1,12 +1,14 @@
 ﻿@*
-   Copyright (c) Microsoft. All rights reserved.
-   Licensed under the MIT license. See LICENSE file in the project root for full license information.
+    Copyright (c) Microsoft. All rights reserved.
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 *@
 
 @model Microsoft.Fx.Portability.Reports.Html.CompatibilityResultsModel
 
 @using Microsoft.Fx.Portability
 @using Microsoft.Fx.Portability.ObjectModel
+@using Microsoft.Fx.Portability.Reports.Html.Resources
+@using System.Globalization
 @using System.Linq
 
 <h4><abbr title="@Model.Description">@Model.Name</abbr> - @Html.WriteStyledBreakingChangeCount(Model.Breaks.Count(), Model.WarningThreshold, Model.ErrorThreshold)</h4>
@@ -66,6 +68,6 @@
     }
     else
     {
-        <p class="CompatMessage GoodMessage">No @Model.Name.ToLowerInvariant() detected.</p>
+        <p class="CompatMessage GoodMessage">@string.Format(CultureInfo.CurrentCulture, LocalizedStrings.NoCompatIssuesDetected, Model.Name.ToLowerInvariant()).</p>
     }
 </div>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_CompatibilityResults.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_CompatibilityResults.cshtml
@@ -11,8 +11,8 @@
 @using System.Globalization
 @using System.Linq
 
-<h4><abbr title="@Model.Description">@Model.Name</abbr> - @Html.WriteStyledBreakingChangeCount(Model.Breaks.Count(), Model.WarningThreshold, Model.ErrorThreshold)</h4>
-<div id="BreakDetails" class="BreakDetails">
+<h4><abbr title="@Model.Description">@Model.Name</abbr> - @Model.Breaks.Count()</h4>
+<div class="BreakDetails">
     @if (Model.Breaks.Count() > 0)
     {
         <table>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_CompatibilityResults.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_CompatibilityResults.cshtml
@@ -1,0 +1,71 @@
+﻿@*
+   Copyright (c) Microsoft. All rights reserved.
+   Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*@
+
+@model Microsoft.Fx.Portability.Reports.Html.CompatibilityResultsModel
+
+@using Microsoft.Fx.Portability
+@using Microsoft.Fx.Portability.ObjectModel
+@using System.Linq
+
+<h4><abbr title="@Model.Description">@Model.Name</abbr> - @Html.WriteStyledBreakingChangeCount(Model.Breaks.Count(), Model.WarningThreshold, Model.ErrorThreshold)</h4>
+<div id="BreakDetails" class="BreakDetails">
+    @if (Model.Breaks.Count() > 0)
+    {
+        <table>
+            <colgroup>
+                <col span="1" class="BreakingChangeID">
+                <col span="1" class="APIColumn">
+                <col span="2" class="LongDescriptionColumn">
+            </colgroup>
+            <tbody>
+                <tr>
+                    <th>ID</th>
+                    <th>API</th>
+                    <th>Details</th>
+                    <th>Recommendation</th>
+                    <th class="NarrowHeader"><div>Quirked</div></th>
+                    <th class="NarrowHeader"><div>Version Introduced</div></th>
+                    <th class="NarrowHeader"><div>Version Reverted</div></th>
+                    <th class="NarrowHeader"><div>Analyzer Status</div></th>
+                    <th class="NarrowHeader"><div>Link</div></th>
+                </tr>
+                @foreach (KeyValuePair<BreakingChange, IEnumerable<MemberInfo>> b in Model.Breaks)
+                {
+                    <tr>
+                        <td>@b.Key.Id</td>
+                        <td class="MemberNames">
+                            <ul>
+                                @* .Distinct because the members can appear multiple times if they exist in multiple referenced assemblies *@
+                                @foreach (string member in @b.Value.Select(m => m.ToString()).Distinct().OrderBy(s => s))
+                                {
+                                    // Remove the docid member/type prefix
+                                    var index = member.IndexOf(":");
+                                    var fixedName = index > -1 ? member.Substring(index + 1) : member;
+                                    <li>@fixedName</li>
+                                }
+                            </ul>
+                        </td>
+                        <td>@{WriteLiteral(Html.ConvertMarkdownToHtml(b.Key.Details));}</td>
+                        <td>@{WriteLiteral(Html.ConvertMarkdownToHtml(b.Key.Suggestion));}</td>
+                        <td>@b.Key.IsQuirked</td>
+                        <td>@b.Key.VersionBroken</td>
+                        <td>@b.Key.VersionFixed</td>
+                        <td>@b.Key.SourceAnalyzerStatus</td>
+                        <td>
+                            @if (!string.IsNullOrWhiteSpace(b.Key.Link))
+                            {
+                                <a href="@b.Key.Link">More info</a>
+                            }
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+    else
+    {
+        <p class="CompatMessage GoodMessage">No @Model.Name.ToLowerInvariant() detected.</p>
+    }
+</div>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_CompatibilitySummary.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_CompatibilitySummary.cshtml
@@ -1,0 +1,64 @@
+﻿@*
+   Copyright (c) Microsoft. All rights reserved.
+   Licensed under the MIT license. See LICENSE file in the project root for full license information.
+*@
+
+@model Microsoft.Fx.Portability.Reports.Html.CompatibilitySummaryModel
+
+@using Microsoft.Fx.Portability
+@using Microsoft.Fx.Portability.Reports.Html
+@using Microsoft.Fx.Portability.Reports.Html.Resources
+@using System.Linq
+
+@{
+    var majorIssues = Model.Breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Major && !b.Key.IsRetargeting);
+    var minorIssues = Model.Breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Minor && !b.Key.IsRetargeting);
+    var edgeIssues = Model.Breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Edge && !b.Key.IsRetargeting);
+    var totalCompatIssues = majorIssues.Count() + minorIssues.Count() + edgeIssues.Count();
+    var majorRetargetingIssues = Model.Breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Major && b.Key.IsRetargeting);
+    var minorRetargetingIssues = Model.Breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Minor && b.Key.IsRetargeting);
+    var edgeRetargetingIssues = Model.Breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Edge && b.Key.IsRetargeting);
+    var totalRetargetingIssues = majorRetargetingIssues.Count() + minorRetargetingIssues.Count() + edgeRetargetingIssues.Count();
+
+    var runtimeIssuesDivName = "RuntimeIssues" + Model.LoopCounter.ToString();
+    var retargetingIssuesDivName = "RetargetingIssues" + Model.LoopCounter.ToString();
+    var runtimeIssuesButtonName = "Toggle" + runtimeIssuesDivName;
+    var retargetingIssuesButtonName = "Toggle" + retargetingIssuesDivName;
+}
+
+@if (totalCompatIssues + totalRetargetingIssues > 0)
+{
+    <div id="assemblyCompatDetails">
+        @if (Model.Assembly != null)
+        {
+            <h3>
+                <a name="Compat-@Model.Assembly">
+                    <span class="assembly-name">@Model.ReportingResult.GetNameForAssemblyInfo(Model.Assembly)</span>
+                    @if (!string.IsNullOrEmpty(Model.Assembly.TargetFrameworkMoniker))
+                    {
+                        <span class="assembly-tfm">(@Model.Assembly.TargetFrameworkMoniker)</span>
+                    }
+                </a>
+            </h3>
+        }
+        <h3>Runtime Compatibility Issues (@totalCompatIssues) <button class="ToggleButton" id="@runtimeIssuesButtonName">&#8212</button></h3>
+        <div id="@runtimeIssuesDivName">
+            <p>@LocalizedStrings.RuntimeCompatIssueDescription</p>
+            @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel("Major Compatibility Issues", LocalizedStrings.MajorCompatIssueDescription, majorIssues, 0, 2))
+            @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel("Minor Compatibility Issues", LocalizedStrings.MinorCompatIssueDescription, minorIssues, 0, 3))
+            @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel("Edge Compatibility Issues", LocalizedStrings.EdgeCompatIssueDescription, edgeIssues, 0, 100))
+        </div>
+        <h3>Retargeting Compatibility Issues (@totalRetargetingIssues) <button class="ToggleButton" id="@retargetingIssuesButtonName">+</button></h3>
+        <div class="BeginToggledOff" id="@retargetingIssuesDivName">
+            <p>@Html.Raw(LocalizedStrings.RetargetingCompatIssueDescriptionPart1)</p>
+            <p>@Html.Raw(LocalizedStrings.RetargetingCompatIssueDescriptionPart2)</p>
+            @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel("Major Retargeting Issues", LocalizedStrings.MajorCompatIssueDescription, majorRetargetingIssues, 0, 2))
+            @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel("Minor Retargeting Issues", LocalizedStrings.MinorCompatIssueDescription, minorRetargetingIssues, 0, 3))
+            @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel("Edge Retargeting Issues", LocalizedStrings.EdgeCompatIssueDescription, edgeRetargetingIssues, 0, 100))
+        </div>
+    </div>
+    <p>
+        <a href="#@LocalizedStrings.CompatibilityPageTitle">@LocalizedStrings.BackToSummary</a>
+    </p>
+    <br />
+}

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_CompatibilitySummary.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_CompatibilitySummary.cshtml
@@ -28,7 +28,7 @@
 
 @if (totalCompatIssues + totalRetargetingIssues > 0)
 {
-    <div id="assemblyCompatDetails">
+    <div>
         @if (Model.Assembly != null)
         {
             <h3>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_CompatibilitySummary.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_CompatibilitySummary.cshtml
@@ -20,10 +20,10 @@
     var edgeRetargetingIssues = Model.Breaks.Where(b => b.Key.ImpactScope == BreakingChangeImpact.Edge && b.Key.IsRetargeting);
     var totalRetargetingIssues = majorRetargetingIssues.Count() + minorRetargetingIssues.Count() + edgeRetargetingIssues.Count();
 
-    var runtimeIssuesDivName = "RuntimeIssues" + Model.LoopCounter.ToString();
-    var retargetingIssuesDivName = "RetargetingIssues" + Model.LoopCounter.ToString();
-    var runtimeIssuesButtonName = "Toggle" + runtimeIssuesDivName;
-    var retargetingIssuesButtonName = "Toggle" + retargetingIssuesDivName;
+    var runtimeIssuesDivId = Guid.NewGuid().ToString();
+    var retargetingIssuesDivId = Guid.NewGuid().ToString();
+    var runtimeIssuesButtonId = "Toggle" + runtimeIssuesDivId;
+    var retargetingIssuesButtonId = "Toggle" + retargetingIssuesDivId;
 }
 
 @if (totalCompatIssues + totalRetargetingIssues > 0)
@@ -43,9 +43,9 @@
         }
         <h3>
             @LocalizedStrings.RuntimeCompatibilityIssues (@totalCompatIssues)
-            <button class="ToggleButton" id="@runtimeIssuesButtonName" title="@LocalizedStrings.Collapse">&#8212</button>
+            <button class="ToggleButton" id="@runtimeIssuesButtonId" title="@LocalizedStrings.Collapse">&#8212</button>
         </h3>
-            <div id="@runtimeIssuesDivName">
+            <div id="@runtimeIssuesDivId">
                 <p>@LocalizedStrings.RuntimeCompatIssueDescription</p>
                 @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel(LocalizedStrings.MajorCompatibilityIssues, LocalizedStrings.MajorCompatIssueDescription, majorIssues, 0, 2))
                 @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel(LocalizedStrings.MinorCompatibilityIssues, LocalizedStrings.MinorCompatIssueDescription, minorIssues, 0, 3))
@@ -53,9 +53,9 @@
             </div>
         <h3>
             @LocalizedStrings.RetargetingCompatibilityIssues (@totalRetargetingIssues)
-            <button class="ToggleButton" id="@retargetingIssuesButtonName" title="@LocalizedStrings.Expand">+</button>
+            <button class="ToggleButton" id="@retargetingIssuesButtonId" title="@LocalizedStrings.Expand">+</button>
         </h3>
-        <div class="BeginToggledOff" id="@retargetingIssuesDivName">
+        <div class="BeginToggledOff" id="@retargetingIssuesDivId">
             <p>@Html.Raw(LocalizedStrings.RetargetingCompatIssueDescriptionPart1)</p>
             <p>@Html.Raw(LocalizedStrings.RetargetingCompatIssueDescriptionPart2)</p>
             @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel(LocalizedStrings.MajorRetargetingIssues, LocalizedStrings.MajorCompatIssueDescription, majorRetargetingIssues, 0, 2))

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_CompatibilitySummary.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_CompatibilitySummary.cshtml
@@ -41,20 +41,26 @@
                 </a>
             </h3>
         }
-        <h3>Runtime Compatibility Issues (@totalCompatIssues) <button class="ToggleButton" id="@runtimeIssuesButtonName">&#8212</button></h3>
-        <div id="@runtimeIssuesDivName">
-            <p>@LocalizedStrings.RuntimeCompatIssueDescription</p>
-            @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel("Major Compatibility Issues", LocalizedStrings.MajorCompatIssueDescription, majorIssues, 0, 2))
-            @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel("Minor Compatibility Issues", LocalizedStrings.MinorCompatIssueDescription, minorIssues, 0, 3))
-            @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel("Edge Compatibility Issues", LocalizedStrings.EdgeCompatIssueDescription, edgeIssues, 0, 100))
-        </div>
-        <h3>Retargeting Compatibility Issues (@totalRetargetingIssues) <button class="ToggleButton" id="@retargetingIssuesButtonName">+</button></h3>
+        <h3>
+            @LocalizedStrings.RuntimeCompatibilityIssues (@totalCompatIssues)
+            <button class="ToggleButton" id="@runtimeIssuesButtonName" title="@LocalizedStrings.Collapse">&#8212</button>
+        </h3>
+            <div id="@runtimeIssuesDivName">
+                <p>@LocalizedStrings.RuntimeCompatIssueDescription</p>
+                @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel(LocalizedStrings.MajorCompatibilityIssues, LocalizedStrings.MajorCompatIssueDescription, majorIssues, 0, 2))
+                @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel(LocalizedStrings.MinorCompatibilityIssues, LocalizedStrings.MinorCompatIssueDescription, minorIssues, 0, 3))
+                @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel(LocalizedStrings.EdgeCompatibilityIssues, LocalizedStrings.EdgeCompatIssueDescription, edgeIssues, 0, 100))
+            </div>
+        <h3>
+            @LocalizedStrings.RetargetingCompatibilityIssues (@totalRetargetingIssues)
+            <button class="ToggleButton" id="@retargetingIssuesButtonName" title="@LocalizedStrings.Expand">+</button>
+        </h3>
         <div class="BeginToggledOff" id="@retargetingIssuesDivName">
             <p>@Html.Raw(LocalizedStrings.RetargetingCompatIssueDescriptionPart1)</p>
             <p>@Html.Raw(LocalizedStrings.RetargetingCompatIssueDescriptionPart2)</p>
-            @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel("Major Retargeting Issues", LocalizedStrings.MajorCompatIssueDescription, majorRetargetingIssues, 0, 2))
-            @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel("Minor Retargeting Issues", LocalizedStrings.MinorCompatIssueDescription, minorRetargetingIssues, 0, 3))
-            @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel("Edge Retargeting Issues", LocalizedStrings.EdgeCompatIssueDescription, edgeRetargetingIssues, 0, 100))
+            @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel(LocalizedStrings.MajorRetargetingIssues, LocalizedStrings.MajorCompatIssueDescription, majorRetargetingIssues, 0, 2))
+            @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel(LocalizedStrings.MinorRetargetingIssues, LocalizedStrings.MinorCompatIssueDescription, minorRetargetingIssues, 0, 3))
+            @Html.Partial("_CompatibilityResults", new CompatibilityResultsModel(LocalizedStrings.EdgeRetargetingIssues, LocalizedStrings.EdgeCompatIssueDescription, edgeRetargetingIssues, 0, 100))
         </div>
     </div>
     <p>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
@@ -57,12 +57,11 @@
 </table>
 <div id="details">
         <h3>@LocalizedStrings.HideRows</h3>
-        <form>
+        <label>@LocalizedStrings.HideRowsWithNoProblems
             <input type="checkbox" id="row_visibility_checkbox" onchange="ToggleRowVisibility(this)">
-            <label for="row_visibility_checkbox">@LocalizedStrings.HideRowsWithNoProblems</label>
-        </form>
+        </label>
 
-        @{ 
+        @{
             var detailColumnHeaders = new List<string>();
             detailColumnHeaders.Add(LocalizedStrings.TargetTypeHeader);
             detailColumnHeaders.AddRange(Model.TargetHeaders);
@@ -187,7 +186,7 @@
                 nugetColumnHeaders.Add(LocalizedStrings.AssemblyHeader);
             }
         }
-    
+
         <table>
             <tbody>
                 <tr>
@@ -219,13 +218,13 @@
                         {
                             <td>@nugetPackage.AssemblyInfo</td>
                         }
-                      
+
                     </tr>
                 }
-            
+
             </tbody>
         </table>
-    
+
 
         <p>
             <a href="#@LocalizedStrings.PortabilitySummaryPageTitle">@LocalizedStrings.BackToSummary</a>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
@@ -1,74 +1,17 @@
-﻿<!--
+﻿@*
    Copyright (c) Microsoft. All rights reserved.
    Licensed under the MIT license. See LICENSE file in the project root for full license information.
--->
+*@
 
 @model Microsoft.Fx.Portability.Reports.RazorHtmlObject
 
-@using Microsoft.Fx.Portability.Reporting.ObjectModel
 @using Microsoft.Fx.Portability.Reports.Html.Resources
 @using System.Collections.Generic;
 @using System.IO
 @using System.Linq
-@using System.Runtime.Versioning
 
 @{
     var reportingResult = Model.ReportingResult;
-}
-
-@helper WriteTableDataStringWithStyle(string docId, string data, string cellStyle)
-{
-    <td style="@cellStyle">@data</td>
-    @* TODO: Add back in logic to create URIs when finished abstracting IReportWriter. *@
-    @*
-        var serviceHeaders = Model.ReportingResult.Headers;
-        <td style="@cellStyle">
-            @if (serviceHeaders.HasApiEndpoint)
-            {
-                <a href="@serviceHeaders.GetDocIdUrl(docId).AbsoluteUri">@data</a>
-            }
-            else
-            {
-                @data
-            }
-        </td>
-    *@
-}
-
-@helper WriteTableDataString(string docId, string data)
-{
-    <td>@data</td>
-    @* TODO: Add back in logic to create URIs when finished abstracting IReportWriter. *@
-    @*
-        var serviceHeaders = Model.ReportingResult.Headers;
-        <td>
-            @if (serviceHeaders.HasApiEndpoint)
-            {
-                <a href="@serviceHeaders.GetDocIdUrl(docId).AbsoluteUri">@data</a>
-            }
-            else
-            {
-                @data
-            }
-        </td>*@
-}
-
-@helper WriteTableVersionsRow(IEnumerable<Version> usedVersions)
-{
-    foreach (var version in Model.GetMatchingTargetsAndSupportedVersions(usedVersions))
-    {
-        var className = version.SupportedIn == null || version.Target.Version < version.SupportedIn ? "IconErrorEncoded" : "IconSuccessEncoded";
-        <td class="@className"></td>
-    }
-}
-
-@helper WriteAssembly(Microsoft.Fx.Portability.ObjectModel.AssemblyInfo assembly)
-{
-    <span class="assembly-name">@assembly</span>
-    if (!string.IsNullOrEmpty(assembly.TargetFrameworkMoniker))
-    {
-        <span class="assembly-tfm">(@assembly.TargetFrameworkMoniker)</span>
-    }
 }
 
 <h2 _locid="SummaryTitle">
@@ -88,7 +31,13 @@
         @foreach (var assembly in Model.OrderedAssembliesByIdentity)
         {
             <tr>
-                <td><strong><a href="#@assembly.SourceAssembly">@WriteAssembly(assembly.SourceAssembly)</a></strong></td>
+                <td><strong><a href="#@assembly.SourceAssembly">
+                    <span class="assembly-name">@assembly.SourceAssembly</span>
+                    @if (!string.IsNullOrEmpty(assembly.SourceAssembly.TargetFrameworkMoniker))
+                    {
+                        <span class="assembly-tfm">(@assembly.SourceAssembly.TargetFrameworkMoniker)</span>
+                    }
+                </a></strong></td>
                 @foreach (var usageData in @assembly.UsageData)
                 {
                     <td class="text-center">@usageData.PortabilityIndex.ToString("P2")</td>
@@ -149,7 +98,13 @@
             }
 
             var assemblyName = reportingResult.GetNameForAssemblyInfo(assembly.SourceAssembly);
-            <a name="@assembly.SourceAssembly"><h3>@WriteAssembly(assembly.SourceAssembly)</h3></a>
+            <a name="@assembly.SourceAssembly"><h3>
+                <span class="assembly-name">@assembly.SourceAssembly</span>
+                @if (!string.IsNullOrEmpty(@assembly.SourceAssembly.TargetFrameworkMoniker))
+                {
+                    <span class="assembly-tfm">(@assembly.SourceAssembly.TargetFrameworkMoniker)</span>
+                }
+            </h3></a>
             var usedUnresolvedAssembly = Model.GetUnresolvedAssemblies(assembly);
             if (usedUnresolvedAssembly.Count > 0)
             {
@@ -176,20 +131,28 @@
                     @*  IsMissing  => the type is entirely unsupported
                         !IsMissing => only some members are unsupported *@
                     @foreach (var type in Model.MatchingMissingTypes(assembly))
-                {
+                    {
                     var name = Model.RemoveTypeOrMemberPrefix(type.TypeName);
-                        <tr>
-                            @WriteTableDataString(type.TypeName, name)
-                            @WriteTableVersionsRow(type.TargetVersionStatus)
-                            <td>@type.RecommendedChanges</td>
-                        </tr>
+                    <tr>
+                        <td>@name</td>
+                        @foreach (var version in Model.GetMatchingTargetsAndSupportedVersions(type.TargetVersionStatus))
+                        {
+                            var className = version.SupportedIn == null || version.Target.Version < version.SupportedIn ? "IconErrorEncoded" : "IconSuccessEncoded";
+                            <td class="@className"></td>
+                        }
+                        <td>@type.RecommendedChanges</td>
+                    </tr>
                         @*write a row for each of the type's missing members*@
                     foreach (var member in type.MissingMembers.OrderBy(y => y.MemberName).ToList())
                     {
                         var formattedName = member.MemberName.Substring(type.TypeName.Length + 1);
                         <tr>
-                            @WriteTableDataStringWithStyle(member.DocId, formattedName, "padding-left:2em")
-                            @WriteTableVersionsRow(member.TargetVersionStatus)
+                            <td style="padding-left:2em">@formattedName</td>
+                            @foreach (var version in Model.GetMatchingTargetsAndSupportedVersions(member.TargetVersionStatus))
+                            {
+                                var className = version.SupportedIn == null || version.Target.Version < version.SupportedIn ? "IconErrorEncoded" : "IconSuccessEncoded";
+                                <td class="@className"></td>
+                            }
                             <td>@member.RecommendedChanges</td>
                         </tr>
                     }

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
@@ -6,7 +6,8 @@
 @model Microsoft.Fx.Portability.Reports.RazorHtmlObject
 
 @using Microsoft.Fx.Portability.Reports.Html.Resources
-@using System.Collections.Generic;
+@using System.Collections.Generic
+@using System.Globalization
 @using System.IO
 @using System.Linq
 
@@ -47,7 +48,7 @@
         @foreach (var invalidAssembly in reportingResult.GetAssembliesWithError())
         {
             var fileName = Path.GetFileName(invalidAssembly);
-            var message = string.Format("{0} is an invalid assembly.", fileName);
+            var message = string.Format(CultureInfo.CurrentCulture, LocalizedStrings.AssemblyIsInvalid, fileName);
             <tr>
                 <td>@message</td>
             </tr>
@@ -55,10 +56,10 @@
     </tbody>
 </table>
 <div id="details">
-        <h3>Hide rows:</h3>
+        <h3>@LocalizedStrings.HideRows</h3>
         <form>
             <input type="checkbox" id="row_visibility_checkbox" onchange="ToggleRowVisibility(this)">
-            <label for="row_visibility_checkbox">Hide rows that don't have problems</label>
+            <label for="row_visibility_checkbox">@LocalizedStrings.HideRowsWithNoProblems</label>
         </form>
 
         @{ 
@@ -67,7 +68,7 @@
             detailColumnHeaders.AddRange(Model.TargetHeaders);
             detailColumnHeaders.Add(LocalizedStrings.RecommendedChanges);
 
-        <h3>Hide columns:</h3>
+        <h3>@LocalizedStrings.HideColumns</h3>
         <form>
             @* It doesn't make sense to hide the first column (Target type), which lists
                 names of the types and members that have possible problems in porting. *@
@@ -175,7 +176,7 @@
 @if (Model.NuGetPackages != null && Model.NuGetPackages.Any())
 {
     <div id="nugetpackageinfo">
-        <h3>Available NuGet Packages</h3>
+        <h3>@LocalizedStrings.AvailableNuGetPackages</h3>
         @{
             bool showAssemblyName = Model.NuGetPackages.Any(p => !string.IsNullOrEmpty(p.AssemblyInfo));
 

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
@@ -132,34 +132,34 @@
                         !IsMissing => only some members are unsupported *@
                     @foreach (var type in Model.MatchingMissingTypes(assembly))
                     {
-                    var name = Model.RemoveTypeOrMemberPrefix(type.TypeName);
-                    <tr>
-                        <td>@name</td>
-                        @foreach (var version in Model.GetMatchingTargetsAndSupportedVersions(type.TargetVersionStatus))
-                        {
-                            @Html.TargetSupportCell(version);
-                        }
-                        <td>@type.RecommendedChanges</td>
-                    </tr>
-                        @*write a row for each of the type's missing members*@
-                    foreach (var member in type.MissingMembers.OrderBy(y => y.MemberName).ToList())
-                    {
-                        var formattedName = member.MemberName.Substring(type.TypeName.Length + 1);
+                        var name = Model.RemoveTypeOrMemberPrefix(type.TypeName);
                         <tr>
-                            <td style="padding-left:2em">@formattedName</td>
-                            @foreach (var version in Model.GetMatchingTargetsAndSupportedVersions(member.TargetVersionStatus))
+                            <td>@name</td>
+                            @foreach (var version in Model.GetMatchingTargetsAndSupportedVersions(type.TargetVersionStatus))
                             {
                                 @Html.TargetSupportCell(version);
                             }
-                            <td>@member.RecommendedChanges</td>
+                            <td>@type.RecommendedChanges</td>
                         </tr>
-                    }
-                    <tr>
-                        @foreach (var column in detailColumnHeaders)
+                        @*write a row for each of the type's missing members*@
+                        foreach (var member in type.MissingMembers.OrderBy(y => y.MemberName).ToList())
                         {
-                            <td>&nbsp;</td>
+                            var formattedName = member.MemberName.Substring(type.TypeName.Length + 1);
+                            <tr>
+                                <td style="padding-left:2em">@formattedName</td>
+                                @foreach (var version in Model.GetMatchingTargetsAndSupportedVersions(member.TargetVersionStatus))
+                                {
+                                    @Html.TargetSupportCell(version);
+                                }
+                                <td>@member.RecommendedChanges</td>
+                            </tr>
                         }
-                    </tr>
+                        <tr>
+                            @foreach (var column in detailColumnHeaders)
+                            {
+                                <td>&nbsp;</td>
+                            }
+                        </tr>
                     }
                 </tbody>
             </table>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_PortabilityReport.cshtml
@@ -138,8 +138,7 @@
                         <td>@name</td>
                         @foreach (var version in Model.GetMatchingTargetsAndSupportedVersions(type.TargetVersionStatus))
                         {
-                            var className = version.SupportedIn == null || version.Target.Version < version.SupportedIn ? "IconErrorEncoded" : "IconSuccessEncoded";
-                            <td class="@className"></td>
+                            @Html.TargetSupportCell(version);
                         }
                         <td>@type.RecommendedChanges</td>
                     </tr>
@@ -151,8 +150,7 @@
                             <td style="padding-left:2em">@formattedName</td>
                             @foreach (var version in Model.GetMatchingTargetsAndSupportedVersions(member.TargetVersionStatus))
                             {
-                                var className = version.SupportedIn == null || version.Target.Version < version.SupportedIn ? "IconErrorEncoded" : "IconSuccessEncoded";
-                                <td class="@className"></td>
+                                @Html.TargetSupportCell(version);
                             }
                             <td>@member.RecommendedChanges</td>
                         </tr>

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Scripts.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Scripts.cshtml
@@ -1,7 +1,9 @@
 ﻿@*
-   Copyright (c) Microsoft. All rights reserved.
-   Licensed under the MIT license. See LICENSE file in the project root for full license information.
+    Copyright (c) Microsoft. All rights reserved.
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 *@
+
+@using Microsoft.Fx.Portability.Reports.Html.Resources
 
 <script>
     // Toggle the element controlled by a toggle button on or off
@@ -12,16 +14,19 @@
         if (currentClass === null) {
             // If the element has no class, then it's on. Turn it off.
             element.setAttribute('class', 'ToggledOff');
+            this.setAttribute('title', '@LocalizedStrings.Expand');
             this.innerHTML = '+';
         }
         else if (currentClass.search(/\bToggledOff\b/) > -1) {
             // If it has ToggledOff as a class, then it's off. Turn it on.
             element.setAttribute('class', currentClass.replace(/\bToggledOff\b/, '').trim());
+            this.setAttribute('title', '@LocalizedStrings.Collapse');
             this.innerHTML = '&#8212';
         }
         else {
             // If it doesn't have ToggledOff as a class, then it's on. Turn it off.
             element.setAttribute('class', currentClass.concat(' ToggledOff').trim());
+            this.setAttribute('title', '@LocalizedStrings.Expand');
             this.innerHTML = '+';
         }
     }
@@ -77,7 +82,7 @@
         for (var table = 0; table < tables.length; table++) {
             var rows = tables[table].getElementsByTagName('tr');
             if (style === '') { // show all rows
-                for(var row = 0; row < rows.length; row++)
+                for (var row = 0; row < rows.length; row++)
                     if (rows[row].style.display === 'none') rows[row].style.display = style; // show previously hidden rows
             } else {
                 var row = 1;
@@ -111,7 +116,7 @@
                         typeRow.style.display = style; // hide the type row
                         rows[j].style.display = style;  // hide the blank separator row
                     }
-                    row = j+1;
+                    row = j + 1;
                 }
             }
         }

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Scripts.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Scripts.cshtml
@@ -1,7 +1,7 @@
-﻿<!--
+﻿@*
    Copyright (c) Microsoft. All rights reserved.
    Licensed under the MIT license. See LICENSE file in the project root for full license information.
--->
+*@
 
 <script>
     // Toggle the element controlled by a toggle button on or off

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Styles.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Styles.cshtml
@@ -1,7 +1,7 @@
-﻿<!--
+﻿@*
    Copyright (c) Microsoft. All rights reserved.
    Licensed under the MIT license. See LICENSE file in the project root for full license information.
--->
+*@
 
 <style>
     /* Body style, for the entire document */

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Styles.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Styles.cshtml
@@ -49,11 +49,6 @@
         background-color: transparent;
     }
 
-    /* Color all hyperlinks one color */
-    a {
-        color: #1382CE;
-    }
-
     /* Paragraph text (for longer informational messages) */
     p {
         font-size: 10pt;
@@ -72,42 +67,21 @@
         font-size: 10pt;
     }
 
-        table th {
-            background: #E7E7E8;
-            text-align: left;
-            text-decoration: none;
-            font-weight: normal;
-            vertical-align: bottom;
-            padding: 3px 6px 3px 6px;
-        }
-
-        table td {
-            vertical-align: top;
-            padding: 3px 6px 5px 5px;
-            margin: 0px;
-            border: 1px solid #E7E7E8;
-            background: #F7F7F8;
-        }
-
-    .lowPriRow td {
-        background: #F0F0F0;
+    table th {
+        background: #E7E7E8;
+        text-align: left;
+        text-decoration: none;
+        font-weight: normal;
+        vertical-align: bottom;
+        padding: 3px 6px 3px 6px;
     }
 
-    .lowPriRow a {
-        color: #6f9bba;
-    }
-
-
-    .lowPriRow .NoBreakingChanges {
-        color: #4e7e4e;
-    }
-
-    .lowPriRow .FewBreakingChanges {
-        color: #eeb550;
-    }
-
-    .lowPriRow .ManyBreakingChanges {
-        color: #ff7070;
+    table td {
+        vertical-align: top;
+        padding: 3px 6px 5px 5px;
+        margin: 0px;
+        border: 1px solid #E7E7E8;
+        background: #F7F7F8;
     }
 
     .BreakDetails table {
@@ -145,17 +119,23 @@
     }
 
     .NoBreakingChanges {
-        color: #006400;
+        -moz-box-shadow: inset 0px 0px 0px 2px green;
+        -webkit-box-shadow: inset 0px 0px 0px 2px green;
+        box-shadow: inset 0px 0px 0px 2px green;
         font-weight: bold;
     }
 
     .FewBreakingChanges {
-        color: #ffa500;
+        -moz-box-shadow: inset 0px 0px 0px 2px orange;
+        -webkit-box-shadow: inset 0px 0px 0px 2px orange;
+        box-shadow: inset 0px 0px 0px 2px orange;
         font-weight: bold;
     }
 
     .ManyBreakingChanges {
-        color: #dd0000;
+        -moz-box-shadow: inset 0px 0px 0px 2px #dd0000;
+        -webkit-box-shadow: inset 0px 0px 0px 2px #dd0000;
+        box-shadow: inset 0px 0px 0px 2px #dd0000;
         font-weight: bold;
     }
 
@@ -174,17 +154,18 @@
 
     .ToggleButton {
         font-size: 16px;
+        font-family: monospace;
         padding: 0px 3px;
         color: #ffffff;
         border-radius: 4px;
         border: 1px solid #657298;
-        background-color: #9bb4d7;
+        background-color: #657298;
         display: inline-block;
     }
 
-        .ToggleButton:hover {
-            background-color: #7892c2;
-        }
+    .ToggleButton:hover {
+        background-color: #7892c2;
+    }
 
     .ToggledOff {
         display: none;
@@ -207,11 +188,11 @@
         text-decoration: none;
     }
 
-        .localLink:hover {
-            color: #1382CE;
-            background: #FFFF99;
-            text-decoration: none;
-        }
+    .localLink:hover {
+        color: #1382CE;
+        background: #FFFF99;
+        text-decoration: none;
+    }
 
     /* Center text, used in the over views cells that contain message level counts */
     .textCentered {

--- a/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Styles.cshtml
+++ b/src/Microsoft.Fx.Portability.Reports.Html/Resources/_Styles.cshtml
@@ -181,19 +181,6 @@
         padding-bottom: 4px;
     }
 
-    /* Local link is a style for hyperlinks that link to file:/// content, there are lots so color them as 'normal' text until the user mouse overs */
-    .localLink {
-        color: #1E1E1F;
-        background: #EEEEED;
-        text-decoration: none;
-    }
-
-    .localLink:hover {
-        color: #1382CE;
-        background: #FFFF99;
-        text-decoration: none;
-    }
-
     /* Center text, used in the over views cells that contain message level counts */
     .textCentered {
         text-align: center;

--- a/src/Microsoft.Fx.Portability.Reports.Html/nuget.config
+++ b/src/Microsoft.Fx.Portability.Reports.Html/nuget.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="razorengine-test" value="https://www.myget.org/F/razorengine-test/api/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/src/Microsoft.Fx.Portability.Reports.Html/nuget.config
+++ b/src/Microsoft.Fx.Portability.Reports.Html/nuget.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="razorengine-test" value="https://www.myget.org/F/razorengine-test/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/tests/Microsoft.Fx.Portability.Reports.Html.Tests/HtmlReportWriterTests.cs
+++ b/tests/Microsoft.Fx.Portability.Reports.Html.Tests/HtmlReportWriterTests.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Fx.Portability.Reports.Html.Tests
         [InlineData("_Scripts.cshtml")]
         [InlineData("_Styles.cshtml")]
         [InlineData("_BreakingChangesReport.cshtml")]
+        [InlineData("_CompatibilityResults.cshtml")]
+        [InlineData("_CompatibilitySummary.cshtml")]
         [Theory]
         public void CanFindTemplates(string templateName)
         {
@@ -39,21 +41,15 @@ namespace Microsoft.Fx.Portability.Reports.Html.Tests
             var mapper = Substitute.For<ITargetMapper>();
             var writer = new HtmlReportWriter(mapper);
 
-            var response = new AnalyzeResponse
-            {
-                MissingDependencies = new List<MemberInfo>
-                {
-                    new MemberInfo { MemberDocId = "Type1.doc1", DefinedInAssemblyIdentity = "Assembly1", TypeDocId = "Type1" },
-                    new MemberInfo { MemberDocId = "Type2.doc2", DefinedInAssemblyIdentity = "Assembly2", TypeDocId = "Type2" }
-                },
-                SubmissionId = Guid.NewGuid().ToString(),
-                Targets = new List<FrameworkName> { new FrameworkName("target1", Version.Parse("1.0.0.0")) },
-                UnresolvedUserAssemblies = new List<string> { "UnresolvedAssembly", "UnresolvedAssembly2", "UnresolvedAssembly3" },
-                BreakingChangeSkippedAssemblies = new List<AssemblyInfo>(),
-                BreakingChanges = new List<BreakingChangeDependency>(),
-            };
+            var response = GetAnalyzeResponse();
 
-            var reportingResult = new ReportingResult(response.Targets, response.MissingDependencies, response.SubmissionId, AnalyzeRequestFlags.NoTelemetry);
+            // setting all show... flags renders every section of the report
+            var flags = AnalyzeRequestFlags.NoTelemetry
+                      | AnalyzeRequestFlags.ShowBreakingChanges
+                      | AnalyzeRequestFlags.ShowNonPortableApis
+                      | AnalyzeRequestFlags.ShowRetargettingIssues;
+
+            var reportingResult = new ReportingResult(response.Targets, response.MissingDependencies, response.SubmissionId, flags);
             response.ReportingResult = reportingResult;
 
             var tempFile = Path.GetTempFileName();
@@ -80,5 +76,64 @@ namespace Microsoft.Fx.Portability.Reports.Html.Tests
                 }
             }
         }
+
+        // an AnalyzeResponse with data for every part of the report
+        private static AnalyzeResponse GetAnalyzeResponse() => new AnalyzeResponse
+        {
+            SubmissionId = Guid.NewGuid().ToString(),
+            CatalogLastUpdated = DateTime.Now,
+            MissingDependencies = new List<MemberInfo>
+            {
+                new MemberInfo { MemberDocId = "MissingType1.Member()", DefinedInAssemblyIdentity = "Assembly1", TypeDocId = "MissingType1" },
+            },
+            Targets = new List<FrameworkName>
+            {
+                new FrameworkName("target1", Version.Parse("1.0.0.0"), "profile"),
+            },
+            UnresolvedUserAssemblies = new List<string> { "UnresolvedAssembly" },
+            BreakingChangeSkippedAssemblies = new List<AssemblyInfo>
+            {
+                new AssemblyInfo
+                {
+                    AssemblyIdentity = "breaking change skipped assembly",
+                    FileVersion = "42.42.42",
+                    IsExplicitlySpecified = true,
+                    Location = "C:/",
+                    TargetFrameworkMoniker = "tfm"
+                }
+            },
+            BreakingChanges = new List<BreakingChangeDependency>
+            {
+                new BreakingChangeDependency
+                {
+                    Break = new BreakingChange
+                    {
+                        ApplicableApis = new[] { "all of them" },
+                        Categories = new[] { "categories" },
+                        Details = "details",
+                        Id = "42",
+                        VersionBroken = Version.Parse("1.0"),
+                        VersionFixed = Version.Parse("1.1"),
+                        ImpactScope = BreakingChangeImpact.Edge
+                    },
+                    DependantAssembly = new AssemblyInfo
+                    {
+                        AssemblyIdentity = "DependentAssembly",
+                        FileVersion = Version.Parse("42.42.42").ToString(),
+                        IsExplicitlySpecified = true,
+                        Location = "c:/foo/bar",
+                        TargetFrameworkMoniker = "TFM"
+                    },
+                    Member = new MemberInfo
+                    {
+                        DefinedInAssemblyIdentity = "DependentAssembly",
+                        IsSupportedAcrossTargets = false,
+                        MemberDocId = "M:Foo.NotSupported",
+                        RecommendedChanges = "don't use this",
+                        TypeDocId = "T:Foo"
+                    }
+                }
+            }
+        };
     }
 }


### PR DESCRIPTION
This makes some changes to `Microsoft.Fx.Portability.Reports.Html`:
 - update RazorEngine dependency to the latest (unofficial) prerelease
 - helpers become inline Razor or `HtmlHelper` methods 
 - compatibility results and summary content become partial views
 - report creation test generates all report sections
 - more string literals moved to resources
 - alt text added to buttons and success/error icons