### PR TITLE
Ensure offline ApiPort loads report writers

### DIFF
--- a/src/ApiPort/DependencyBuilder.Offline.cs
+++ b/src/ApiPort/DependencyBuilder.Offline.cs
@@ -15,6 +15,7 @@ namespace ApiPort
         static partial void RegisterOfflineModule(ContainerBuilder builder)
         {
             builder.RegisterModule(new OfflineDataModule(DefaultOutputFormatInstanceName));
+            TryLoadReportWriters(builder);
         }
 
         private static void TryLoadReportWriters(ContainerBuilder builder)

--- a/src/ApiPort/DependencyBuilder.Offline.cs
+++ b/src/ApiPort/DependencyBuilder.Offline.cs
@@ -15,10 +15,10 @@ namespace ApiPort
         static partial void RegisterOfflineModule(ContainerBuilder builder)
         {
             builder.RegisterModule(new OfflineDataModule(DefaultOutputFormatInstanceName));
-            TryLoadReportWriters(builder);
+            LoadReportWriters(builder);
         }
 
-        private static void TryLoadReportWriters(ContainerBuilder builder)
+        private static void LoadReportWriters(ContainerBuilder builder)
         {
             foreach (var path in Directory.EnumerateFiles(GetApplicationDirectory(), "Microsoft.Fx.Portability.Reports.*.dll"))
             {


### PR DESCRIPTION
ApiPort.Offline currently doesn't load report writers (and thus doesn't write reports) because `DependencyBuilder.TryLoadReportWriters` is never called.