### PR TITLE
Update ApiPort target conditions to net461

### DIFF
--- a/src/ApiPort/ApiPort.Offline.csproj
+++ b/src/ApiPort/ApiPort.Offline.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Fx.Portability.Offline\Microsoft.Fx.Portability.Offline.csproj" />
     <ProjectReference Include="..\Microsoft.Fx.Portability.Reports.Excel\Microsoft.Fx.Portability.Reports.Excel.csproj" />
-    <ProjectReference Include="..\Microsoft.Fx.Portability.Reports.Html\Microsoft.Fx.Portability.Reports.Html.csproj" Condition=" '$(TargetFramework)' == 'net46' " />
+    <ProjectReference Include="..\Microsoft.Fx.Portability.Reports.Html\Microsoft.Fx.Portability.Reports.Html.csproj" Condition=" '$(TargetFramework)' == 'net461' " />
     <ProjectReference Include="..\Microsoft.Fx.Portability.Reports.Json\Microsoft.Fx.Portability.Reports.Json.csproj" />
   </ItemGroup>
 

--- a/src/ApiPort/ApiPort.props
+++ b/src/ApiPort/ApiPort.props
@@ -14,7 +14,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <DefineConstants>$(DefineConstants);FEATURE_SYSTEM_PROXY;FEATURE_NETWORK_CREDENTIAL</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
#536 retargeted ApiPort to `net461` but left the build conditions testing for `net46`.