### PR TITLE
Fix issue where Autofac cannot resolve IApiPortService

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ dependencies.
 |Branch|Build Status|
 |---|---|
 |master|[![][BuildStatus-Master]][myget]|
-|dev|![][BuildStatus-Dev]|
+|dev|[![][BuildStatus-Dev]][myget]|
 
 For a quick introduction, check out [this video on Channel 9][Channel 9 Video]:
 
@@ -17,7 +17,7 @@ For a quick introduction, check out [this video on Channel 9][Channel 9 Video]:
 ### Windows
 There is a Visual Studio extension available for VS2017 and VS2015: [.NET Portability Analyzer](https://marketplace.visualstudio.com/items?itemName=ConnieYau.NETPortabilityAnalyzer)
 
-Download and build yourself:
+Download and build for yourself:
 1. Install [Visual Studio 2017 with .NET Core Workload][Visual Studio 2017]
 2. Building:
    * Visual Studio: `PortabilityTools.sln`
@@ -37,19 +37,18 @@ Download and build yourself:
 * [Introduction](docs/HowTo)
 * [Platform Portability](docs/HowTo/PlatformPortability.md)
 * [Breaking Changes](docs/HowTo/BreakingChanges.md)
-* [.NET Portability Analyzer (Console application)](docs/Console/README.md)
+* [.NET Portability Analyzer (Console application)](docs/Console)
     * [.NET Core application](docs/Console/README.md#using-net-core-application)
-* [.NET Portability Analyzer (Visual Studio extension)](docs/VSExtension/README.md)
+* [.NET Portability Analyzer (Visual Studio extension)](docs/VSExtension)
 
 ## Projects
 
 | Project | Description |
 | :------ | :---------- |
-| ApiPort | Console tool to access portability webservice |
-| ApiPort.Core | Cross-platform .NET Core application |
+| ApiPort | Cross-platform console tool to access portability service |
 | ApiPort.Vsix | Visual Studio Extension |
 | Microsoft.Fx.Portability | Provides common types for API Port |
-| Microsoft.Fx.Portability.MetadataReader | Implements a dependency finder based off of [System.Reflection.Metadata][System.Reflection.Metadata]. The library  will generate DocIds that conform to [these specifications][DocId]. |
+| Microsoft.Fx.Portability.MetadataReader | Implements a dependency finder based off of [System.Reflection.Metadata][System.Reflection.Metadata]. The library will generate DocIds that conform to [these specifications][DocId]. |
 | Microsoft.Fx.Portability.Offline | Provides access to data in an offline setting so network calls are not needed |
 | Microsoft.Fx.Portability.Reporting.Excel | Provides support for an Excel spreadsheet report for ApiPort |
 | Microsoft.Fx.Portability.Reporting.Html | Provides support for an HTML report for ApiPort |
@@ -57,12 +56,15 @@ Download and build yourself:
 
 ### Builds
 
-The libraries are continuously published to [dotnet-apiport MyGet gallery][myget]. The Visual Studio extension is published to [Open VSIX Gallery][VSIX Gallery].  The latest version number of each library can be seen in that gallery.
+|     | Location |
+| :--- | :--- |
+| Libraries | [MyGet][myget] |
+| Visual Studio Extension |  [Open VSIX Gallery][VSIX Gallery] |
 
 ## How to Engage, Contribute and Provide Feedback
 
 Here are some ways to contribute:
-* [Update/Add recommended changes](docs/RecommendedChanges/README.md)
+* [Update/Add recommended changes](docs/RecommendedChanges)
 * Try things out!
 * File issues
 * Join in design conversations
@@ -73,15 +75,9 @@ Want to get more familiar with what's going on in the code?
 Looking for something to work on? The list of [up-for-grabs issues][Issues-Open]
 is a great place to start.
 
-We're re-using the same contributing approach as .NET Core. You can check out
-the .NET Core [contributing guide][Contributing Guide] at the corefx repo wiki
-for more details.
-
 * [How to Contribute][Contributing Guide]
     * [Contributing Guide][Contributing Guide]
     * [Developer Guide][Developer Guide]
-
-You are also encouraged to start a discussion on the .NET Foundation forums!
 
 ## Related Projects
 

--- a/docs/Console/README.md
+++ b/docs/Console/README.md
@@ -8,7 +8,7 @@ understands the following commands:
 | analyze | Analyzes the portability of an application | [Examples](#apiportexe-analyze-scenarios) |
 | listTargets | Lists .NET platforms available for analysis | `ApiPort.exe listTargets` |
 | listOutputFormats | Lists available report output formats |`ApiPort.exe listOutputFormats` |
-| docIdSearch | Searches for matching docIds | `ApiPort.exe docIdSearch <options>` |
+| docId | Searches for matching docIds | `ApiPort.exe docId <options>` |
 | dump | Outputs the analysis request that will be sent to the service | [Example](#see-the-data-being-transmitted) |
 
 ## `ApiPort.exe analyze` Scenarios

--- a/docs/Console/README.md
+++ b/docs/Console/README.md
@@ -3,15 +3,13 @@
 The console tool helps you determine how flexible your application.  The tool
 understands the following commands:
 
-  * `ApiPort.exe analyze <options>`
-    * Analyzes the portability of an application
-    * [Examples](#apiportexe-analyze-scenarios)
-  * `ApiPort.exe listTargets`
-    * Lists .NET platforms available for analysis
-  * `ApiPort.exe listOutputFormats`
-    * Lists available report output formats
-  * `ApiPort.exe DocIdSearch <options>`
-    * Searches for matching docIds
+| Command | Description | Example |
+| :--- | :--- | :--- |
+| analyze | Analyzes the portability of an application | [Examples](#apiportexe-analyze-scenarios) |
+| listTargets | Lists .NET platforms available for analysis | `ApiPort.exe listTargets` |
+| listOutputFormats | Lists available report output formats |`ApiPort.exe listOutputFormats` |
+| docIdSearch | Searches for matching docIds | `ApiPort.exe docIdSearch <options>` |
+| dump | Outputs the analysis request that will be sent to the service | [Example](#see-the-data-being-transmitted) |
 
 ## `ApiPort.exe analyze` Scenarios
 
@@ -43,7 +41,8 @@ report format**
 ApiPort.exe analyze -f C:\git\Application\bin\Debug
 ```
 
-This will analyze all assemblies that exist under `C:\git\Application\bin\Debug`
+This will analyze all
+assemblies that exist under `C:\git\Application\bin\Debug`
 recursively, and analyzes those assemblies against the default .NET platforms.
 (**Note:** The default platforms can be obtained by running `ApiPort.exe
 listTargets` and looking for targets that have an (\*) in them.)
@@ -57,7 +56,7 @@ ApiPort.exe analyze -f C:\git\Application\bin\Debug -b
 The `-b` flag will show any APIs that may have different behavior between
 versions of .NET Framework due to breaking changes that have been made.  The
 entire list of breaking changes in .NET Framework can be found by examining
-[Application Compatibility in the .NET Framework](https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/application-compatibility). 
+[Application Compatibility in the .NET Framework](https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/application-compatibility).
 For the list of breaking changes we analyze against, look [here](../HowTo/BreakingChanges.md).
 
 **Analyzing a directory and show any non-portable APIs**

--- a/docs/VSExtension/README.md
+++ b/docs/VSExtension/README.md
@@ -8,7 +8,7 @@ __Features__
 
 * Analysis of a single project, solution, or binaries
 * Analysis against multiple .NET platforms simultaneously
-* Generation of multiple analysis reports in different formats. Supported 
+* Generation of multiple analysis reports in different formats. Supported
 formats are:
     * JSON
     * HTML
@@ -44,7 +44,7 @@ performing the following:
 
 After the analysis is complete, if there are any APIs that are not supported on
 the selected platforms, check the "Output" window.  There should be some
-informational messages containing the API that is not supported and the line 
+informational messages containing the API that is not supported and the line
 mapping in source code.  If you double-click on that message, it will take you
 to that location in source.
 
@@ -98,9 +98,9 @@ A list of changes can be found in the [Changelog](Changelog.md).
 [BinaryAnalysis]: img/analyzeToolbar.png
 [OptionsPane]: img/optionsPanel.png
 [PlatformPortability]: ../HowTo/PlatformPortability.md
-[PrivacyPolicy]: ../LicenseTerms/Microsoft%20.NET%20Portability%20Analyzer%20Privacy%20Statement.txt
+[PrivacyPolicy]: ../LicenseTerms/Microsoft%20.NET%20Portability%20Analyzer%20CLI%20Privacy%20Statement.txt
 [ReportToolWindow]: img/report.toolWindow.png
 [SampleReport]: img/analysisReport.png
 [SolutionExplorer-ContextMenu]: img/analysisContextMenu.png
 [SourceCodeMapping]: img/sourceMapping.output.png
-[VSGallery]: https://visualstudiogallery.msdn.microsoft.com/1177943e-cfb7-4822-a8a6-e56c7905292b
+[VSGallery]: https://marketplace.visualstudio.com/items?itemName=ConnieYau.NETPortabilityAnalyzer

--- a/src/ApiPort/DependencyBuilder.cs
+++ b/src/ApiPort/DependencyBuilder.cs
@@ -55,7 +55,7 @@ namespace ApiPort
                     .As<IApiPortService>()
                     .SingleInstance();
             }
-            else if (options.Command == AppCommand.AnalyzeAssemblies)
+            else
             {
                 builder.Register(context =>
                     new ApiPortService(


### PR DESCRIPTION
* Console tool could not resolve `ApiPortClient` for commands other than `analyze` and `dump` because IApiPortService was not registered.
* This always registers ApiPortService if the command is not dump
* This also updates some READMEs that had broken links and makes it more concise. Hopefully
