### PR TITLE
Fix Code Analysis warnings

### DIFF
--- a/src/ApiPort.VisualStudio.2015/ProjectBuilder2015.cs
+++ b/src/ApiPort.VisualStudio.2015/ProjectBuilder2015.cs
@@ -113,7 +113,7 @@ namespace ApiPortVS.VS2015
             return null;
         }
 
-        private UnconfiguredProject GetUnconfiguredProject(Project project)
+        private static UnconfiguredProject GetUnconfiguredProject(Project project)
         {
             return (project as IVsBrowseObjectContext)?.UnconfiguredProject;
         }

--- a/src/ApiPort.VisualStudio.2017/ProjectBuilder2015.cs
+++ b/src/ApiPort.VisualStudio.2017/ProjectBuilder2015.cs
@@ -134,7 +134,7 @@ namespace ApiPortVS.VS2017
             return outputs.Any() ? outputs : null;
         }
 
-        private UnconfiguredProject GetUnconfiguredProject(Project project)
+        private static UnconfiguredProject GetUnconfiguredProject(Project project)
         {
             return (project as IVsBrowseObjectContext)?.UnconfiguredProject;
         }

--- a/src/ApiPort.VisualStudio.Common/SourceMapping/CciMetadataTraverser.cs
+++ b/src/ApiPort.VisualStudio.Common/SourceMapping/CciMetadataTraverser.cs
@@ -120,7 +120,7 @@ namespace ApiPortVS.SourceMapping
                 .Select(t => t.Item1);
         }
 
-        private IEnumerable<Version> GetTargetStatus(MissingInfo missingInfo)
+        private static IEnumerable<Version> GetTargetStatus(MissingInfo missingInfo)
         {
             var memberInfo = missingInfo as MissingMemberInfo;
             var typeInfo = missingInfo as MissingTypeInfo;

--- a/src/ApiPort.VisualStudio/AnalyzeMenu.cs
+++ b/src/ApiPort.VisualStudio/AnalyzeMenu.cs
@@ -97,7 +97,7 @@ namespace ApiPortVS
             ContextMenuItemBeforeQueryStatus(sender, _dte.Solution.GetProjects(), false);
         }
 
-        private void ContextMenuItemBeforeQueryStatus(object sender, IEnumerable<Project> projects, bool checkDependencies)
+        private static void ContextMenuItemBeforeQueryStatus(object sender, IEnumerable<Project> projects, bool checkDependencies)
         {
             var menuItem = sender as Microsoft.VisualStudio.Shell.OleMenuCommand;
             if (menuItem == null)

--- a/src/ApiPort.VisualStudio/Reporting/VsBrowserReportViewer.cs
+++ b/src/ApiPort.VisualStudio/Reporting/VsBrowserReportViewer.cs
@@ -41,7 +41,7 @@ namespace ApiPortVS.Reporting
             }
         }
 
-        private bool IsHtml(string url)
+        private static bool IsHtml(string url)
         {
             var extension = Path.GetExtension(url);
 

--- a/src/ApiPort.VisualStudio/ServiceProvider.cs
+++ b/src/ApiPort.VisualStudio/ServiceProvider.cs
@@ -152,7 +152,7 @@ namespace ApiPortVS
             _container.Dispose();
         }
 
-        private void RegisterVisualStudioComponents(ContainerBuilder builder, ApiPortVSPackage serviceProvider)
+        private static void RegisterVisualStudioComponents(ContainerBuilder builder, ApiPortVSPackage serviceProvider)
         {
             builder.RegisterInstance(serviceProvider)
                 .As<IResultToolbar>()

--- a/src/ApiPort/ConsoleProgressReporter.cs
+++ b/src/ApiPort/ConsoleProgressReporter.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace ApiPort
 {
-    public class ConsoleProgressReporter : IProgressReporter
+    public sealed class ConsoleProgressReporter : IProgressReporter
     {
         private readonly List<string> _issuesReported = new List<string>();
         private readonly List<ConsoleProgressTask> _progressTasks = new List<ConsoleProgressTask>();

--- a/src/ApiPort/EmptyDependencyFinder.cs
+++ b/src/ApiPort/EmptyDependencyFinder.cs
@@ -17,12 +17,12 @@ namespace ApiPort
             return new EmptyDependencyInfo();
         }
 
-        public IDependencyInfo FindDependencies(IEnumerable<FileInfo> inputAssemblyPaths, IProgressReporter progressReport)
+        public static IDependencyInfo FindDependencies(IEnumerable<FileInfo> inputAssemblyPaths, IProgressReporter progressReport)
         {
             return new EmptyDependencyInfo();
         }
 
-        public IDependencyInfo FindDependencies(byte[] file, IProgressReporter progressReport)
+        public static IDependencyInfo FindDependencies(byte[] file, IProgressReporter progressReport)
         {
             return new EmptyDependencyInfo();
         }

--- a/src/ApiPort/Proxy/ProxyProvider.cs
+++ b/src/ApiPort/Proxy/ProxyProvider.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Fx.Portability.Proxy
         /// <summary>
         /// Gets the proxy from environment variables.
         /// </summary>
-        private IWebProxy GetWebProxyFromEnvironment()
+        private static IWebProxy GetWebProxyFromEnvironment()
         {
             // Try reading from the environment variable http_proxy. This would be specified as http://<username>:<password>@proxy.com
             var host = Environment.GetEnvironmentVariable(ProxyConstants.HttpProxy);
@@ -206,7 +206,7 @@ namespace Microsoft.Fx.Portability.Proxy
             }
         }
 
-        private T GetValueFromProxyConfiguration<T>(IConfigurationRoot configuration, params string[] pathSegments)
+        private static T GetValueFromProxyConfiguration<T>(IConfigurationRoot configuration, params string[] pathSegments)
             where T : class
         {
             var concatonatedWithProxy = new[] { ProxyConstants.ProxySection }.Concat(pathSegments);

--- a/src/Microsoft.Fx.Portability.Cci/HostEnvironment.cs
+++ b/src/Microsoft.Fx.Portability.Cci/HostEnvironment.cs
@@ -438,7 +438,7 @@ namespace Microsoft.Cci.Extensions
             return host.LoadAssemblies(paths);
         }
 
-        private string GetCoreAssemblyFile(string coreAssemblySimpleName, IEnumerable<string> contractSet)
+        private static string GetCoreAssemblyFile(string coreAssemblySimpleName, IEnumerable<string> contractSet)
         {
             var coreAssemblyFile = contractSet.FirstOrDefault(c => Path.GetFileNameWithoutExtension(c).EndsWith(coreAssemblySimpleName, StringComparison.OrdinalIgnoreCase) == true);
             if (string.IsNullOrEmpty(coreAssemblyFile))
@@ -519,7 +519,7 @@ namespace Microsoft.Cci.Extensions
             TraceErrorWithLevel(LoadErrorTreatment, format, arguments);
         }
 
-        public void TraceErrorWithLevel(ErrorTreatment level, string format, params object[] arguments)
+        public static void TraceErrorWithLevel(ErrorTreatment level, string format, params object[] arguments)
         {
             switch (level)
             {

--- a/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Fx.Portability.Analyzer
             };
         }
 
-        private string GetPrefix(MemberReference memberReference)
+        private static string GetPrefix(MemberReference memberReference)
         {
             switch (memberReference.GetKind())
             {

--- a/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfo.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/MemberMetadataInfo.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Fx.Portability.Analyzer
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        private string GetDocIdSafeMemberName(string name)
+        private static string GetDocIdSafeMemberName(string name)
         {
             char[] newName = new char[name.Length];
             for (int i = 0; i < name.Length; i++)
@@ -318,7 +318,7 @@ namespace Microsoft.Fx.Portability.Analyzer
             return sb.ToString();
         }
 
-        private bool CalculateGenericArgsOffset(string displayName, int pos, out int numGenericArgs, out int offsetStringAfterGenericMarker)
+        private static bool CalculateGenericArgsOffset(string displayName, int pos, out int numGenericArgs, out int offsetStringAfterGenericMarker)
         {
             Debug.Assert(displayName[pos] == '`');
 

--- a/src/Microsoft.Fx.Portability.MetadataReader/ReflectionMetadataDependencyInfo.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/ReflectionMetadataDependencyInfo.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Fx.Portability.Analyzer
         /// </summary>
         /// <param name="peReader"></param>
         /// <returns></returns>
-        private MetadataReader GetMetadataReader(PEReader peReader)
+        private static MetadataReader GetMetadataReader(PEReader peReader)
         {
             try
             {

--- a/src/Microsoft.Fx.Portability.MetadataReader/StringParameterValueTypeProvider.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/StringParameterValueTypeProvider.cs
@@ -42,21 +42,21 @@ namespace Microsoft.Fx.Portability
             return string.Empty;
         }
 
-        public string GetGenericInstance(string genericType, ImmutableArray<string> typestrings)
+        public static string GetGenericInstance(string genericType, ImmutableArray<string> typestrings)
         {
             return string.Empty;
         }
 
         public string GetGenericInstantiation(string genericType, ImmutableArray<string> typeArguments) => throw new NotImplementedException();
 
-        public string GetGenericMethodParameter(int index)
+        public static string GetGenericMethodParameter(int index)
         {
             return string.Empty;
         }
 
         public string GetGenericMethodParameter(object genericContext, int index) => throw new NotImplementedException();
 
-        public string GetGenericTypeParameter(int index)
+        public static string GetGenericTypeParameter(int index)
         {
             return string.Empty;
         }

--- a/src/Microsoft.Fx.Portability.Offline/OfflineApiPortService.cs
+++ b/src/Microsoft.Fx.Portability.Offline/OfflineApiPortService.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Fx.Portability
             return WrapResponse(format);
         }
 
-        private Task<ServiceResponse<T>> WrapResponse<T>(T data)
+        private static Task<ServiceResponse<T>> WrapResponse<T>(T data)
         {
             var response = new ServiceResponse<T>(data);
 
@@ -111,12 +111,12 @@ namespace Microsoft.Fx.Portability
             throw new NotImplementedException();
         }
 
-        public Task<ServiceResponse<AnalyzeResponse>> GetAnalysisAsync(string submissionId)
+        public static Task<ServiceResponse<AnalyzeResponse>> GetAnalysisAsync(string submissionId)
         {
             throw new NotImplementedException();
         }
 
-        public Task<ServiceResponse<byte[]>> GetAnalysisAsync(string submissionId, string format)
+        public static Task<ServiceResponse<byte[]>> GetAnalysisAsync(string submissionId, string format)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.Fx.Portability.Reports.Excel/ExcelOpenXmlOutputWriter.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Excel/ExcelOpenXmlOutputWriter.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Fx.Portability.Reports
             summaryPage.AddRow(LocalizedStrings.HowToReadTheExcelTable);
         }
 
-        private void GenerateUnreferencedAssembliesPage(Worksheet missingAssembliesPage, ReportingResult analysisResult)
+        private static void GenerateUnreferencedAssembliesPage(Worksheet missingAssembliesPage, ReportingResult analysisResult)
         {
             List<string> missingAssembliesPageHeader = new List<string>() { LocalizedStrings.AssemblyHeader, LocalizedStrings.UsedBy, LocalizedStrings.MissingAssemblyStatus };
             int detailsRows = 0;
@@ -408,7 +408,7 @@ namespace Microsoft.Fx.Portability.Reports
             };
         }
 
-        private object AddSubmissionLink(string submissionId)
+        private static object AddSubmissionLink(string submissionId)
         {
             return submissionId;
 
@@ -430,7 +430,7 @@ namespace Microsoft.Fx.Portability.Reports
 #endif
         }
 
-        private object AddLink(string docId)
+        private static object AddLink(string docId)
         {
             return docId;
 

--- a/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
@@ -77,17 +77,17 @@ namespace Microsoft.Fx.Portability.Reports
 
         public class HtmlHelper
         {
-            public string ConvertMarkdownToHtml(string markdown)
+            public static string ConvertMarkdownToHtml(string markdown)
             {
                 return CommonMark.CommonMarkConverter.Convert(markdown);
             }
 
-            public IEncodedString Raw(string rawString)
+            public static IEncodedString Raw(string rawString)
             {
                 return new RawString(rawString);
             }
 
-            public IEncodedString Partial(string name)
+            public static IEncodedString Partial(string name)
             {
                 var template = Resolve(name);
                 var razor = s_razorService.RunCompile(template, name);
@@ -95,7 +95,7 @@ namespace Microsoft.Fx.Portability.Reports
                 return Raw(razor);
             }
 
-            public IEncodedString Partial<T>(string name, T model)
+            public static IEncodedString Partial<T>(string name, T model)
             {
                 var template = Resolve(name);
                 var razor = s_razorService.RunCompile(template, name, typeof(T), model);
@@ -103,7 +103,7 @@ namespace Microsoft.Fx.Portability.Reports
                 return Raw(razor);
             }
 
-            public IEncodedString TargetSupportCell(TargetSupportedIn supportStatus)
+            public static IEncodedString TargetSupportCell(TargetSupportedIn supportStatus)
             {
                 var supported = supportStatus.SupportedIn != null
                              && supportStatus.Target.Version >= supportStatus.SupportedIn;
@@ -114,7 +114,7 @@ namespace Microsoft.Fx.Portability.Reports
                 return Raw($"<td class=\"{className}\" title=\"{title}\"></td>");
             }
 
-            public IEncodedString BreakingChangeCountCell(int breaks, int warningThreshold, int errorThreshold)
+            public static IEncodedString BreakingChangeCountCell(int breaks, int warningThreshold, int errorThreshold)
             {
                 var className = "";
                 if (breaks <= warningThreshold)

--- a/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
@@ -77,17 +77,21 @@ namespace Microsoft.Fx.Portability.Reports
 
         public class HtmlHelper
         {
-            public static string ConvertMarkdownToHtml(string markdown)
+            // Disabling warning because marking this as static results in Razor
+            // compilation errors when generating the Razor page.
+#pragma warning disable CA1822 // Mark members as static
+
+            public string ConvertMarkdownToHtml(string markdown)
             {
                 return CommonMark.CommonMarkConverter.Convert(markdown);
             }
 
-            public static IEncodedString Raw(string rawString)
+            public IEncodedString Raw(string rawString)
             {
                 return new RawString(rawString);
             }
 
-            public static IEncodedString Partial(string name)
+            public IEncodedString Partial(string name)
             {
                 var template = Resolve(name);
                 var razor = s_razorService.RunCompile(template, name);
@@ -95,7 +99,7 @@ namespace Microsoft.Fx.Portability.Reports
                 return Raw(razor);
             }
 
-            public static IEncodedString Partial<T>(string name, T model)
+            public IEncodedString Partial<T>(string name, T model)
             {
                 var template = Resolve(name);
                 var razor = s_razorService.RunCompile(template, name, typeof(T), model);
@@ -103,7 +107,7 @@ namespace Microsoft.Fx.Portability.Reports
                 return Raw(razor);
             }
 
-            public static IEncodedString TargetSupportCell(TargetSupportedIn supportStatus)
+            public IEncodedString TargetSupportCell(TargetSupportedIn supportStatus)
             {
                 var supported = supportStatus.SupportedIn != null
                              && supportStatus.Target.Version >= supportStatus.SupportedIn;
@@ -114,7 +118,7 @@ namespace Microsoft.Fx.Portability.Reports
                 return Raw($"<td class=\"{className}\" title=\"{title}\"></td>");
             }
 
-            public static IEncodedString BreakingChangeCountCell(int breaks, int warningThreshold, int errorThreshold)
+            public IEncodedString BreakingChangeCountCell(int breaks, int warningThreshold, int errorThreshold)
             {
                 var className = "";
                 if (breaks <= warningThreshold)
@@ -128,6 +132,7 @@ namespace Microsoft.Fx.Portability.Reports
 
                 return Raw($"<td class=\"textCentered {className}\">{breaks}</td>");
             }
+#pragma warning restore CA1822 // Mark members as static
         }
 
         public abstract class HtmlSupportTemplateBase<T> : TemplateBase<T>

--- a/src/Microsoft.Fx.Portability.Reports.Html/RazorHtmlObject.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/RazorHtmlObject.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Fx.Portability.Reports
             NuGetPackages = response.NuGetPackages;
         }
 
-        private IDictionary<BreakingChange, IEnumerable<MemberInfo>> GetBreakingChangesSummary(IEnumerable<KeyValuePair<AssemblyInfo, IDictionary<BreakingChange, IEnumerable<MemberInfo>>>> orderedBreakingChangesByAssembly)
+        private static IDictionary<BreakingChange, IEnumerable<MemberInfo>> GetBreakingChangesSummary(IEnumerable<KeyValuePair<AssemblyInfo, IDictionary<BreakingChange, IEnumerable<MemberInfo>>>> orderedBreakingChangesByAssembly)
         {
             return orderedBreakingChangesByAssembly
                 .SelectMany(o => o.Value)
@@ -72,7 +72,7 @@ namespace Microsoft.Fx.Portability.Reports
                 .ToDictionary(o => o.Key, o => o.Value);
         }
 
-        private IOrderedEnumerable<KeyValuePair<AssemblyInfo, IDictionary<BreakingChange, IEnumerable<MemberInfo>>>> GetGroupedBreakingChanges(IList<BreakingChangeDependency> breakingChanges, IEnumerable<AssemblyInfo> assembliesToInclude)
+        private static IOrderedEnumerable<KeyValuePair<AssemblyInfo, IDictionary<BreakingChange, IEnumerable<MemberInfo>>>> GetGroupedBreakingChanges(IList<BreakingChangeDependency> breakingChanges, IEnumerable<AssemblyInfo> assembliesToInclude)
         {
             Dictionary<AssemblyInfo, IDictionary<BreakingChange, IEnumerable<MemberInfo>>> ret = new Dictionary<AssemblyInfo, IDictionary<BreakingChange, IEnumerable<MemberInfo>>>();
 
@@ -117,7 +117,7 @@ namespace Microsoft.Fx.Portability.Reports
                 .ThenBy(x => x.Key);
         }
 
-        public string RemoveTypeOrMemberPrefix(string assemblyName)
+        public static string RemoveTypeOrMemberPrefix(string assemblyName)
         {
             string[] split = assemblyName.Split(new string[] { ":" }, 2, StringSplitOptions.RemoveEmptyEntries);
             return split.Length == 2 ? split[1] : split[0];

--- a/src/Microsoft.Fx.Portability.Reports.Html/RazorHtmlObject.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/RazorHtmlObject.cs
@@ -117,7 +117,11 @@ namespace Microsoft.Fx.Portability.Reports
                 .ThenBy(x => x.Key);
         }
 
-        public static string RemoveTypeOrMemberPrefix(string assemblyName)
+        // Disabling warning because marking this as static results in Razor
+        // compilation errors when generating the Razor page.
+#pragma warning disable CA1822 // Mark members as static
+        public string RemoveTypeOrMemberPrefix(string assemblyName)
+#pragma warning restore CA1822 // Mark members as static
         {
             string[] split = assemblyName.Split(new string[] { ":" }, 2, StringSplitOptions.RemoveEmptyEntries);
             return split.Length == 2 ? split[1] : split[0];

--- a/src/Microsoft.Fx.Portability/Analysis/AnalysisEngine.cs
+++ b/src/Microsoft.Fx.Portability/Analysis/AnalysisEngine.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Fx.Portability.Analysis
         /// <summary>
         /// Computes a list of strings that describe the status of the api on all the targets (not supported or version when it was introduced)
         /// </summary>
-        private bool IsSupportedAcrossTargets(IApiCatalogLookup catalog, string memberDocId, IEnumerable<FrameworkName> targets, out List<Version> targetStatus)
+        private static bool IsSupportedAcrossTargets(IApiCatalogLookup catalog, string memberDocId, IEnumerable<FrameworkName> targets, out List<Version> targetStatus)
         {
             targetStatus = new List<Version>();
             bool isSupported = true;

--- a/src/Microsoft.Fx.Portability/ApiInformation.cs
+++ b/src/Microsoft.Fx.Portability/ApiInformation.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Fx.Portability
         {
             if (string.IsNullOrWhiteSpace(docId))
             {
-                throw new ArgumentNullException("docId");
+                throw new ArgumentNullException(nameof(docId));
             }
 
             Definition = catalog.GetApiDefinition(docId);

--- a/src/Microsoft.Fx.Portability/CompressedHttpClient.cs
+++ b/src/Microsoft.Fx.Portability/CompressedHttpClient.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Fx.Portability
             }
         }
 
-        private async Task ProcessBadRequestAsync(HttpResponseMessage response)
+        private static async Task ProcessBadRequestAsync(HttpResponseMessage response)
         {
             var content = await response.Content.ReadAsStringAsync();
 
@@ -131,7 +131,7 @@ namespace Microsoft.Fx.Portability
             return new ServiceResponse<TResponse>(result, response.Headers);
         }
 
-        private async Task<byte[]> ReadStreamToEnd(Stream stream)
+        private static async Task<byte[]> ReadStreamToEnd(Stream stream)
         {
             using (var ms = new MemoryStream())
             {

--- a/src/Microsoft.Fx.Portability/Reporting/ObjectModel/MissingInfo.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/ObjectModel/MissingInfo.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Fx.Portability.Reporting.ObjectModel
             return other != null && StringComparer.Ordinal.Equals(other.DocId, DocId);
         }
 
-        protected string GenerateTargetStatusMessage(Version version)
+        protected static string GenerateTargetStatusMessage(Version version)
         {
             if (version == null)
             {

--- a/src/Microsoft.Fx.Portability/Reporting/ObjectModel/MissingTypeInfo.cs
+++ b/src/Microsoft.Fx.Portability/Reporting/ObjectModel/MissingTypeInfo.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Fx.Portability.Reporting.ObjectModel
         {
             int pos = DocId.IndexOf("T:", StringComparison.Ordinal);
             if (pos == -1)
-                throw new ArgumentException(LocalizedStrings.MemberShouldBeDefinedOnTypeException, "docId");
+                throw new ArgumentException(LocalizedStrings.MemberShouldBeDefinedOnTypeException, nameof(docId));
 
             TypeName = DocId.Substring(pos);
             MissingMembers = new HashSet<MissingMemberInfo>();

--- a/src/Microsoft.Fx.Portability/TargetMapper.cs
+++ b/src/Microsoft.Fx.Portability/TargetMapper.cs
@@ -106,8 +106,17 @@ So we suppress this error until the reporting for CA3053 has been updated to acc
 #if FEATURE_XML_SCHEMA
                 // Validate against schema
                 var schemas = new XmlSchemaSet();
-                schemas.Add(null, XmlReader.Create(typeof(TargetMapper).Assembly.GetManifestResourceStream("Microsoft.Fx.Portability.Targets.xsd")));
-                doc.Validate(schemas, (s, e) => { throw new TargetMapperException(e.Message, e.Exception); });
+                using (var xsdStream = typeof(TargetMapper).Assembly.GetManifestResourceStream("Microsoft.Fx.Portability.Targets.xsd"))
+                {
+                    var xmlReaderSettings = new XmlReaderSettings
+                    {
+                        DtdProcessing = DtdProcessing.Prohibit,
+                        XmlResolver = null
+                    };
+
+                    schemas.Add(null, XmlReader.Create(xsdStream, xmlReaderSettings));
+                    doc.Validate(schemas, (s, e) => { throw new TargetMapperException(e.Message, e.Exception); });
+                }
 #endif
 
                 foreach (var item in doc.Descendants("Target"))

--- a/src/Microsoft.Fx.Portability/TargetMapper.cs
+++ b/src/Microsoft.Fx.Portability/TargetMapper.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Fx.Portability
             }
         }
 
-        private bool IsValidPath(string path)
+        private static bool IsValidPath(string path)
         {
             try
             {
@@ -61,7 +61,7 @@ namespace Microsoft.Fx.Portability
             }
         }
 
-        private IEnumerable<string> GetPossibleFileLocations(string path)
+        private static IEnumerable<string> GetPossibleFileLocations(string path)
         {
             yield return path;
 

--- a/src/Microsoft.Fx.Portability/TextWriterProgressReporter.cs
+++ b/src/Microsoft.Fx.Portability/TextWriterProgressReporter.cs
@@ -7,7 +7,7 @@ using System.IO;
 
 namespace Microsoft.Fx.Portability
 {
-    public class TextWriterProgressReporter : IProgressReporter
+    public sealed class TextWriterProgressReporter : IProgressReporter
     {
         private readonly List<string> _issuesReported = new List<string>();
         private readonly TextWriter _textWriter;

--- a/tests/ApiPort.Tests/AnalyzeOptionsTests.cs
+++ b/tests/ApiPort.Tests/AnalyzeOptionsTests.cs
@@ -15,7 +15,7 @@ namespace ApiPort.Tests
         /// in command line for analyzing
         /// </summary>
         [Fact]
-        public void TestAssemblyFlag_Directory()
+        public static void TestAssemblyFlag_Directory()
         {
             var directoryPath = Directory.GetCurrentDirectory();
             var options = GetOptions($"analyze -f {directoryPath}");
@@ -31,7 +31,7 @@ namespace ApiPort.Tests
         }
 
         [Fact]
-        public void NoArgs()
+        public static void NoArgs()
         {
             var options = CommandLineOptions.ParseCommandLineOptions(Array.Empty<string>());
 
@@ -39,7 +39,7 @@ namespace ApiPort.Tests
         }
 
         [Fact]
-        public void AnalyzeNoFile()
+        public static void AnalyzeNoFile()
         {
             var options = GetOptions("analyze -f");
 
@@ -49,7 +49,7 @@ namespace ApiPort.Tests
         [InlineData("dump -f file.dll", "file.dll", CommandLineOptions.DefaultName)]
         [InlineData("dump -f file.dll -o out.json", "file.dll", "out.json")]
         [Theory]
-        public void DumpAnalysis(string args, string file, string output)
+        public static void DumpAnalysis(string args, string file, string output)
         {
             var options = GetOptions(args);
 
@@ -65,7 +65,7 @@ namespace ApiPort.Tests
         [InlineData("analyze -f file.dll -o other", "other")]
         [InlineData("analyze -f file.dll --out other", "other")]
         [Theory]
-        public void OutputFile(string args, string name)
+        public static void OutputFile(string args, string name)
         {
             var options = CommandLineOptions.ParseCommandLineOptions(args.Split(' '));
 
@@ -78,7 +78,7 @@ namespace ApiPort.Tests
         [InlineData("analyze -f file.dll --force", true)]
         [InlineData("analyze -f file.dll -o other --force", true)]
         [Theory]
-        public void OverwriteFile(string args, bool overwrite)
+        public static void OverwriteFile(string args, bool overwrite)
         {
             var options = GetOptions(args);
 
@@ -90,7 +90,7 @@ namespace ApiPort.Tests
         [InlineData("listOutputFormats", AppCommand.ListOutputFormats)]
         [InlineData("docId", AppCommand.DocIdSearch)]
         [Theory]
-        public void SimpleCommandTests(string args, AppCommand command)
+        public static void SimpleCommandTests(string args, AppCommand command)
         {
             var options = GetOptions(args);
 
@@ -98,7 +98,7 @@ namespace ApiPort.Tests
         }
 
         [Fact]
-        public void TestAssemblyFlag_FileName()
+        public static void TestAssemblyFlag_FileName()
         {
             var currentAssemblyPath = typeof(AnalyzeOptionsTests).GetTypeInfo().Assembly.Location;
             var options = GetOptions($"analyze -f {currentAssemblyPath}");
@@ -111,7 +111,7 @@ namespace ApiPort.Tests
         }
 
         [Fact]
-        public void TestAssemblyFlag_DirectoryAndFileName()
+        public static void TestAssemblyFlag_DirectoryAndFileName()
         {
             var directoryPath = Directory.GetCurrentDirectory();
             var currentAssemblyPath = typeof(AnalyzeOptionsTests).GetTypeInfo().Assembly.Location;

--- a/tests/ApiPortVS.Tests/ApiPortVSPackageTests.cs
+++ b/tests/ApiPortVS.Tests/ApiPortVSPackageTests.cs
@@ -14,7 +14,7 @@ namespace ApiPortVS.Tests
     public class ApiPortVSPackageTests
     {
         [Fact]
-        public void FileHasAnalyzableExtension_FileIsExe_ReturnsTrue()
+        public static void FileHasAnalyzableExtension_FileIsExe_ReturnsTrue()
         {
             var filename = "analyzable.exe";
 
@@ -26,7 +26,7 @@ namespace ApiPortVS.Tests
         }
 
         [Fact]
-        public void FileHasAnalyzableExtension_FileIsDll_ReturnsTrue()
+        public static void FileHasAnalyzableExtension_FileIsDll_ReturnsTrue()
         {
             var filename = "analyzable.dll";
 
@@ -38,7 +38,7 @@ namespace ApiPortVS.Tests
         }
 
         [Fact]
-        public void FileHasAnalyzableExtension_FilenameContainsVshost_ReturnsFalse()
+        public static void FileHasAnalyzableExtension_FilenameContainsVshost_ReturnsFalse()
         {
             var filename = "analyzable.vshost.exe";
 
@@ -49,7 +49,7 @@ namespace ApiPortVS.Tests
             Assert.False(result);
         }
 
-        private ProjectAnalyzer GetProjectAnalyzer()
+        private static ProjectAnalyzer GetProjectAnalyzer()
         {
             var threadingService = Substitute.For<IVSThreadingService>();
 

--- a/tests/ApiPortVS.Tests/CciSourceLineMapperTests.cs
+++ b/tests/ApiPortVS.Tests/CciSourceLineMapperTests.cs
@@ -20,7 +20,7 @@ namespace ApiPortVS.Tests
     public class CciSourceLineMapperTests
     {
         [Fact]
-        public void FindMissingTypeReferences_PdbNotFound_ReportedToTextOutput()
+        public static void FindMissingTypeReferences_PdbNotFound_ReportedToTextOutput()
         {
             var assemblyName = "assemblyPath";
             var fileSystem = Substitute.For<IFileSystem>();

--- a/tests/ApiPortVS.Tests/ProjectBuilderTests.cs
+++ b/tests/ApiPortVS.Tests/ProjectBuilderTests.cs
@@ -56,7 +56,7 @@ namespace ApiPortVS.Tests
         private static IVsSolutionBuildManager2 BuildManagerWhichReturns(int returnForUpdate)
         {
             var buildManager = Substitute.For<IVsSolutionBuildManager2>();
-            buildManager.StartUpdateSpecificProjectConfigurations(default(uint), null, null, null, null, null, default(uint), default(int))
+            buildManager.StartUpdateSpecificProjectConfigurations(default, null, null, null, null, null, default, default)
                         .ReturnsForAnyArgs(returnForUpdate);
 
             uint cookie;

--- a/tests/ApiPortVS.Tests/ProjectBuilderTests.cs
+++ b/tests/ApiPortVS.Tests/ProjectBuilderTests.cs
@@ -16,7 +16,7 @@ namespace ApiPortVS.Tests
     public class ProjectBuilderTests
     {
         [Fact]
-        public void Build_VsFailsToStartBuild_TaskResultSetFalse()
+        public static void Build_VsFailsToStartBuild_TaskResultSetFalse()
         {
             var buildManager = BuildManagerWhichReturns(VSConstants.S_FALSE);
             var project = Substitute.For<Project>();
@@ -36,7 +36,7 @@ namespace ApiPortVS.Tests
         }
 
         [Fact]
-        public void Build_BuildCompletedSuccessfully_TaskResultSetTrue()
+        public static void Build_BuildCompletedSuccessfully_TaskResultSetTrue()
         {
             var buildManager = BuildManagerWhichReturns(VSConstants.S_OK);
             var project = Substitute.For<Project>();
@@ -53,7 +53,7 @@ namespace ApiPortVS.Tests
                 .AdviseUpdateSolutionEvents(Arg.Any<IVsUpdateSolutionEvents>(), out pdwCookie);
         }
 
-        private IVsSolutionBuildManager2 BuildManagerWhichReturns(int returnForUpdate)
+        private static IVsSolutionBuildManager2 BuildManagerWhichReturns(int returnForUpdate)
         {
             var buildManager = Substitute.For<IVsSolutionBuildManager2>();
             buildManager.StartUpdateSpecificProjectConfigurations(default(uint), null, null, null, null, null, default(uint), default(int))
@@ -67,7 +67,7 @@ namespace ApiPortVS.Tests
             return buildManager;
         }
 
-        private DefaultProjectBuilder ProjectBuilderAfterBuildHasBegun(IVsSolutionBuildManager2 buildManager)
+        private static DefaultProjectBuilder ProjectBuilderAfterBuildHasBegun(IVsSolutionBuildManager2 buildManager)
         {
             var project = Substitute.For<Project>();
             var projectMapper = Substitute.For<IProjectMapper>();

--- a/tests/ApiPortVS.Tests/ProjectBuilderTests.cs
+++ b/tests/ApiPortVS.Tests/ProjectBuilderTests.cs
@@ -66,17 +66,5 @@ namespace ApiPortVS.Tests
 
             return buildManager;
         }
-
-        private static DefaultProjectBuilder ProjectBuilderAfterBuildHasBegun(IVsSolutionBuildManager2 buildManager)
-        {
-            var project = Substitute.For<Project>();
-            var projectMapper = Substitute.For<IProjectMapper>();
-            var threading = Substitute.For<IVSThreadingService>();
-
-            var projectBuilder = new DefaultProjectBuilder(buildManager, threading, projectMapper);
-            projectBuilder.BuildAsync(new List<Project> { project });
-
-            return projectBuilder;
-        }
     }
 }

--- a/tests/Microsoft.Fx.Portability.Cci.Tests/CciAnalyzerTests.cs
+++ b/tests/Microsoft.Fx.Portability.Cci.Tests/CciAnalyzerTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Fx.Portability.Cci.Tests
     public class CciAnalyzerTests
     {
         [Fact]
-        public void FindDependencies()
+        public static void FindDependencies()
         {
             var cci = new CciDependencyFinder();
             var path = new TestAssemblyFile(TestAssembly.EmptyProject);

--- a/tests/Microsoft.Fx.Portability.Cci.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/Microsoft.Fx.Portability.Cci.Tests/ManagedMetadataReaderTests.cs
@@ -15,19 +15,19 @@ namespace Microsoft.Fx.Portability.Cci.Tests
         private readonly static string s_withGenericsAndReferencePath = TestAssembly.WithGenericsAndReference;
 
         [Fact]
-        public void EmptyProject()
+        public static void EmptyProject()
         {
             CompareFinders(s_emptyProjectPath);
         }
 
         [Fact]
-        public void WithGenericsAndReference()
+        public static void WithGenericsAndReference()
         {
             CompareFinders(s_withGenericsAndReferencePath);
         }
 
         [Fact]
-        public void WithGenericsAndReferenceAndEmptyProject()
+        public static void WithGenericsAndReferenceAndEmptyProject()
         {
             CompareFinders(s_withGenericsAndReferencePath, s_emptyProjectPath);
         }

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         }
 
         [Fact]
-        public void EmptyProject()
+        public static void EmptyProject()
         {
             var assemblyToTest = TestAssembly.Create("EmptyProject.cs");
             var expected = EmptyProjectMemberDocId();
@@ -202,7 +202,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         /// Regression testing for issue https://github.com/Microsoft/dotnet-apiport/issues/42
         /// </summary>
         [Fact]
-        public void MultidimensionalPrimitiveArray()
+        public static void MultidimensionalPrimitiveArray()
         {
             var arrayDocId = "M:System.Int32[0:,0:][0:,0:].#ctor(System.Int32,System.Int32)";
             var objectDocId = "T:System.Object";
@@ -227,7 +227,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         }
 
         [Fact]
-        public void ThrowsSystemObjectNotFoundException()
+        public static void ThrowsSystemObjectNotFoundException()
         {
             var dependencyFilter = Substitute.For<IDependencyFilter>();
             dependencyFilter.IsFrameworkAssembly(Arg.Any<AssemblyReferenceInformation>()).Returns(false);

--- a/tests/Microsoft.Fx.Portability.MetadataReader.Tests/SystemObjectFinderTests.cs
+++ b/tests/Microsoft.Fx.Portability.MetadataReader.Tests/SystemObjectFinderTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
     public class SystemObjectFinderTests
     {
         [Fact]
-        public void MultipleMscorlibReferencesFound()
+        public static void MultipleMscorlibReferencesFound()
         {
             var objectFinder = new SystemObjectFinder(new DotNetFrameworkFilter());
             var file = TestAssembly.Create("multiple-mscorlib.exe");

--- a/tests/Microsoft.Fx.Portability.Reports.Html.Tests/HtmlReportWriterTests.cs
+++ b/tests/Microsoft.Fx.Portability.Reports.Html.Tests/HtmlReportWriterTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Fx.Portability.Reports.Html.Tests
         [InlineData("_CompatibilityResults.cshtml")]
         [InlineData("_CompatibilitySummary.cshtml")]
         [Theory]
-        public void CanFindTemplates(string templateName)
+        public static void CanFindTemplates(string templateName)
         {
             var fullName = FormattableString.Invariant($"{typeof(HtmlReportWriter).Assembly.GetName().Name}.Resources.{templateName}");
 
@@ -36,7 +36,7 @@ namespace Microsoft.Fx.Portability.Reports.Html.Tests
         }
 
         [Fact]
-        public void CreatesHtmlReport()
+        public static void CreatesHtmlReport()
         {
             var mapper = Substitute.For<ITargetMapper>();
             var writer = new HtmlReportWriter(mapper);

--- a/tests/Microsoft.Fx.Portability.Tests/Analysis/AnalysisEngine.NuGetPackageInfo.Tests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/Analysis/AnalysisEngine.NuGetPackageInfo.Tests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Fx.Portability.Tests.Analysis
         /// Tests that given a set of assemblies, the correct nuget package is returned.
         /// </summary>
         [Fact]
-        public void TestGetNugetPackageInfo()
+        public static void TestGetNugetPackageInfo()
         {
             // Arrange
             var nugetPackageAssembly = GetAssemblyInfo("NugetPackageAssembly", "2.0.5.0", isExplicitlySpecified: false);
@@ -75,7 +75,7 @@ namespace Microsoft.Fx.Portability.Tests.Analysis
         /// Tests that if an assembly is not explicitly specified, and packages for this assembly are found, it'll be in the set of assemblies to remove.
         /// </summary>
         [Fact]
-        public void ComputeAssembliesToRemove_PackageFound()
+        public static void ComputeAssembliesToRemove_PackageFound()
         {
             // Arrange
             var userNuGetPackage = GetAssemblyInfo("NugetPackageAssembly", "2.0.5.0", isExplicitlySpecified: false);
@@ -109,7 +109,7 @@ namespace Microsoft.Fx.Portability.Tests.Analysis
         /// the given targets... we shouldn't remove it.
         /// </summary>
         [Fact]
-        public void ComputeAssembliesToRemove_PackageNotFound()
+        public static void ComputeAssembliesToRemove_PackageNotFound()
         {
             // Arrange
             var userNuGetPackage = GetAssemblyInfo("NugetPackageAssembly", "2.0.5.0", isExplicitlySpecified: false);
@@ -150,7 +150,7 @@ namespace Microsoft.Fx.Portability.Tests.Analysis
         /// removed.
         /// </summary>
         [Fact]
-        public void ComputeAssembliesToRemove_AssemblyExplicitlyPassedIn()
+        public static void ComputeAssembliesToRemove_AssemblyExplicitlyPassedIn()
         {
             // Arrange
             var userNuGetPackage = GetAssemblyInfo("NugetPackageAssembly", "2.0.5.0", isExplicitlySpecified: true);
@@ -183,7 +183,7 @@ namespace Microsoft.Fx.Portability.Tests.Analysis
         /// 'isExplicitlySpecified' was added.
         /// </summary>
         [Fact]
-        public void ComputeAssembliesToRemove_AssemblyFlagNotSet()
+        public static void ComputeAssembliesToRemove_AssemblyFlagNotSet()
         {
             // Arrange
             var userNuGetPackage = GetAssemblyInfo("NugetPackageAssembly", "2.0.5.0");

--- a/tests/Microsoft.Fx.Portability.Tests/Analysis/AnalysisEngineTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/Analysis/AnalysisEngineTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
             };
 
         [Fact]
-        public void FindUnreferencedAssemblies_AllNulls()
+        public static void FindUnreferencedAssemblies_AllNulls()
         {
             var engine = new AnalysisEngine(null, null, null);
 
@@ -33,7 +33,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void FindUnreferencedAssemblies_SpecifiedAssembliesNull()
+        public static void FindUnreferencedAssemblies_SpecifiedAssembliesNull()
         {
             var catalog = Substitute.For<IApiCatalogLookup>();
             var recommendations = Substitute.For<IApiRecommendations>();
@@ -45,7 +45,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void FindUnreferencedAssemblies_NoUnreferencedAssemblies()
+        public static void FindUnreferencedAssemblies_NoUnreferencedAssemblies()
         {
             var catalog = Substitute.For<IApiCatalogLookup>();
             var recommendations = Substitute.For<IApiRecommendations>();
@@ -59,7 +59,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void FindUnreferencedAssemblies_UnreferencedAssemblies_1()
+        public static void FindUnreferencedAssemblies_UnreferencedAssemblies_1()
         {
             var catalog = Substitute.For<IApiCatalogLookup>();
             catalog.IsFrameworkAssembly(GetAssemblyIdentityWithoutCultureAndVersion(s_unreferencedAssemblies[0])).Returns(true);
@@ -75,7 +75,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void FindUnreferencedAssemblies_UnreferencedAssemblies_2()
+        public static void FindUnreferencedAssemblies_UnreferencedAssemblies_2()
         {
             var catalog = Substitute.For<IApiCatalogLookup>();
             catalog.IsFrameworkAssembly(GetAssemblyIdentityWithoutCultureAndVersion(s_unreferencedAssemblies[0])).Returns(true);
@@ -90,7 +90,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void FindUnreferencedAssemblies_UnreferencedAssemblies_WithNullInSpecifiedList()
+        public static void FindUnreferencedAssemblies_UnreferencedAssemblies_WithNullInSpecifiedList()
         {
             var catalog = Substitute.For<IApiCatalogLookup>();
             catalog.IsFrameworkAssembly(GetAssemblyIdentityWithoutCultureAndVersion(s_unreferencedAssemblies[0])).Returns(true);
@@ -106,7 +106,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void FindUnreferencedAssemblies_UnreferencedAssemblies_WithNullInUnrefList()
+        public static void FindUnreferencedAssemblies_UnreferencedAssemblies_WithNullInUnrefList()
         {
             var catalog = Substitute.For<IApiCatalogLookup>();
             catalog.IsFrameworkAssembly(GetAssemblyIdentityWithoutCultureAndVersion(s_unreferencedAssemblies[0])).Returns(true);
@@ -125,7 +125,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         #endregion
 
         [Fact]
-        public void FindMembersNotInTargets_AllNull()
+        public static void FindMembersNotInTargets_AllNull()
         {
             var engine = new AnalysisEngine(null, null, null);
 
@@ -133,7 +133,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void FindMembersNotInTargets_1()
+        public static void FindMembersNotInTargets_1()
         {
             var testData = new Dictionary<MemberInfo, ICollection<AssemblyInfo>>();
 
@@ -167,7 +167,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void FindMembersNotInTargetsWithSuppliedAssembly()
+        public static void FindMembersNotInTargetsWithSuppliedAssembly()
         {
             var testData = new Dictionary<MemberInfo, ICollection<AssemblyInfo>>();
 
@@ -201,7 +201,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void FindMembersNotInTargets_2()
+        public static void FindMembersNotInTargets_2()
         {
             // No member information passed through.
             var testData = new Dictionary<MemberInfo, ICollection<AssemblyInfo>>();
@@ -218,7 +218,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void BreakingChangesFullFrameworkAfterBreakBeforeFix()
+        public static void BreakingChangesFullFrameworkAfterBreakBeforeFix()
         {
             TestBreakingChangeWithFixedEntry(Version.Parse("4.5.1"), false);
             TestBreakingChangeWithoutFixedEntry(Version.Parse("4.5.1"), false);
@@ -226,7 +226,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void BreakingChangesFullFrameworkOnBreakingVersion()
+        public static void BreakingChangesFullFrameworkOnBreakingVersion()
         {
             TestBreakingChangeWithFixedEntry(Version.Parse("4.5"), false);
             TestBreakingChangeWithoutFixedEntry(Version.Parse("4.5"), false);
@@ -234,7 +234,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void BreakingChangesFullFrameworkOnFix()
+        public static void BreakingChangesFullFrameworkOnFix()
         {
             TestBreakingChangeWithFixedEntry(Version.Parse("4.5.2"), true);
             TestBreakingChangeWithoutFixedEntry(Version.Parse("4.5.2"), false);
@@ -242,7 +242,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void BreakingChangesFullFrameworkAfterFix()
+        public static void BreakingChangesFullFrameworkAfterFix()
         {
             TestBreakingChangeWithFixedEntry(Version.Parse("4.5.3"), true);
             TestBreakingChangeWithoutFixedEntry(Version.Parse("4.5.3"), false);
@@ -250,7 +250,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void BreakingChangesFullFrameworkBeforeBreak()
+        public static void BreakingChangesFullFrameworkBeforeBreak()
         {
             TestBreakingChangeWithFixedEntry(Version.Parse("4.0"), true);
             TestBreakingChangeWithoutFixedEntry(Version.Parse("4.0"), true);
@@ -258,7 +258,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void BreakingChangesNotFullFramework()
+        public static void BreakingChangesNotFullFramework()
         {
             var catalog = Substitute.For<IApiCatalogLookup>();
             var recommendations = GenerateTestRecommendationsWithFixedEntry();
@@ -273,7 +273,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void BreakingChangesWithAssemblyIgnores()
+        public static void BreakingChangesWithAssemblyIgnores()
         {
             TestBreakingChangeWithIgnoreList(Version.Parse("4.5"), false, Enumerable.Empty<AssemblyInfo>());
             TestBreakingChangeWithIgnoreList(Version.Parse("4.5"), true, new AssemblyInfo[] { new AssemblyInfo() { AssemblyIdentity = "userAsm1, Version=1.0.0.0" } });
@@ -282,7 +282,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void BreakingChangesWithSuppressions()
+        public static void BreakingChangesWithSuppressions()
         {
             TestBreakingChangeWithSuppression(Version.Parse("4.5"), false, Enumerable.Empty<string>());
             TestBreakingChangeWithSuppression(Version.Parse("4.5"), false, new[] { "15" });
@@ -291,7 +291,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void BreakingChangeIgnoreSelection()
+        public static void BreakingChangeIgnoreSelection()
         {
             var catalog = Substitute.For<IApiCatalogLookup>();
             var recommendations = GenerateTestRecommendationsWithFixedEntry();
@@ -336,7 +336,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void ShowRetargettingIssuesFalseShouldReturnOnlyRuntimeIssues()
+        public static void ShowRetargettingIssuesFalseShouldReturnOnlyRuntimeIssues()
         {
             var catalog = Substitute.For<IApiCatalogLookup>();
             var recommendations = GenerateTestRecommendationsForShowRetargetting(2, 3);
@@ -365,7 +365,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void ShowRetargettingIssuesTrueShouldReturnRuntimeAndRetargettingIssues()
+        public static void ShowRetargettingIssuesTrueShouldReturnRuntimeAndRetargettingIssues()
         {
             var catalog = Substitute.For<IApiCatalogLookup>();
             var recommendations = GenerateTestRecommendationsForShowRetargetting(2, 3);
@@ -394,7 +394,7 @@ namespace Microsoft.Fx.Portability.Web.Analyze.Tests
         }
 
         [Fact]
-        public void FilterDependencies()
+        public static void FilterDependencies()
         {
             var testData = new Dictionary<MemberInfo, ICollection<AssemblyInfo>>();
 

--- a/tests/Microsoft.Fx.Portability.Tests/Analysis/TargetNameParserTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/Analysis/TargetNameParserTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Fx.Portability.Tests
     public class TargetNameParserTests
     {
         [Fact]
-        public void NoSpecifiedTargets()
+        public static void NoSpecifiedTargets()
         {
             var parser = new TargetNameParser(new TestCatalog(), "Target 1, version=1.0");
             var targets = parser.MapTargetsToExplicitVersions(null);
@@ -25,7 +25,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void NoSpecifiedTargets_2()
+        public static void NoSpecifiedTargets_2()
         {
             var parser = new TargetNameParser(new TestCatalog(), "Target 1, version=1.0");
             var targets = parser.MapTargetsToExplicitVersions(Enumerable.Empty<string>());
@@ -36,7 +36,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void CaseInsensitive()
+        public static void CaseInsensitive()
         {
             var parser = new TargetNameParser(new TestCatalog(), String.Empty);
             var targets = parser.MapTargetsToExplicitVersions(new String[] { "target 1, version=1.0" });
@@ -47,7 +47,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void NoSpecifiedDefaultTargets()
+        public static void NoSpecifiedDefaultTargets()
         {
             var parser = new TargetNameParser(new TestCatalog(), String.Empty);
             var targets = parser.MapTargetsToExplicitVersions(Enumerable.Empty<string>());
@@ -57,7 +57,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void UnReleasedTarget()
+        public static void UnReleasedTarget()
         {
             var parser = new TargetNameParser(new TestCatalog(), "Target 1, version=1.0");
             var targets = parser.MapTargetsToExplicitVersions(new string[] { "Target 3" });
@@ -68,28 +68,28 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void NonExistentSpecifiedTarget()
+        public static void NonExistentSpecifiedTarget()
         {
             var parser = new TargetNameParser(new TestCatalog(), "Target 1, version=1.0");
             Assert.Throws<UnknownTargetException>(() => parser.MapTargetsToExplicitVersions(new string[] { "Foo" }));
         }
 
         [Fact]
-        public void NonExistentSpecifiedVersionOnKnownTarget()
+        public static void NonExistentSpecifiedVersionOnKnownTarget()
         {
             var parser = new TargetNameParser(new TestCatalog(), "Target 1, version=1.0");
             Assert.Throws<UnknownTargetException>(() => parser.MapTargetsToExplicitVersions(new string[] { "Target 1, version=2.0" }));
         }
 
         [Fact]
-        public void NonExistentSpecifiedVersionOnKnownTargetWithAvailableTarget()
+        public static void NonExistentSpecifiedVersionOnKnownTargetWithAvailableTarget()
         {
             var parser = new TargetNameParser(new TestCatalog(), "Target 1, version=1.0");
             Assert.Throws<UnknownTargetException>(() => parser.MapTargetsToExplicitVersions(new string[] { "Target 1, version=2.0", "Target 1, version=1.0" }));
         }
 
         [Fact]
-        public void NonExistentDefaultTarget()
+        public static void NonExistentDefaultTarget()
         {
             var target1 = "Target 1, version=1.0";
             var target1Framework = new FrameworkName(target1);

--- a/tests/Microsoft.Fx.Portability.Tests/ApiPortClientTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ApiPortClientTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Fx.Portability.Tests
 {
     public class ApiPortClientTests
     {
-        private Task<ServiceResponse<T>> CreateResponse<T>(T result)
+        private static Task<ServiceResponse<T>> CreateResponse<T>(T result)
         {
             var response = new ServiceResponse<T>(result, EndpointStatus.Alive);
 
@@ -100,7 +100,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public async Task AnalyzeAssemblies_ThrowsOnInvalidOptions_TargetCount()
+        public static async Task AnalyzeAssemblies_ThrowsOnInvalidOptions_TargetCount()
         {
             var service = Substitute.For<IApiPortService>();
             var progressReporter = Substitute.For<IProgressReporter>();
@@ -119,7 +119,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public async Task AnalyzeAssemblies_DoesNotThrowsOnInvalidOptions_TargetCount()
+        public static async Task AnalyzeAssemblies_DoesNotThrowsOnInvalidOptions_TargetCount()
         {
             var service = Substitute.For<IApiPortService>();
             var progressReporter = Substitute.For<IProgressReporter>();
@@ -138,7 +138,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public async Task WriteAnalysisReports_ThrowsOnInvalidOptions_TargetCount()
+        public static async Task WriteAnalysisReports_ThrowsOnInvalidOptions_TargetCount()
         {
             var service = Substitute.For<IApiPortService>();
             var progressReporter = Substitute.For<IProgressReporter>();

--- a/tests/Microsoft.Fx.Portability.Tests/ApiPortServiceTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ApiPortServiceTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void VerifyParameterChecks()
+        public static void VerifyParameterChecks()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => new ApiPortService(null, new ProductInformation("")));
             Assert.Throws<ArgumentOutOfRangeException>(() => new ApiPortService(string.Empty, new ProductInformation("")));
@@ -73,7 +73,7 @@ namespace Microsoft.Fx.Portability.Tests
             Assert.Empty(expected.Except(result.Select(r => r.DisplayName)));
         }
 
-        private HttpResponseMessage HttpRequestConverter(HttpRequestMessage request)
+        private static HttpResponseMessage HttpRequestConverter(HttpRequestMessage request)
         {
             string resourceFile = null;
             var query = request.RequestUri.PathAndQuery;

--- a/tests/Microsoft.Fx.Portability.Tests/BreakingChangeParserTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/BreakingChangeParserTests.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Fx.Portability.Tests
         #endregion
 
         #region Helper Methods
-        private void ValidateParse(Stream markdown, params BreakingChange[] expected)
+        private static void ValidateParse(Stream markdown, params BreakingChange[] expected)
         {
             BreakingChange[] actual = BreakingChangeParser.FromMarkdown(markdown).ToArray();
             markdown.Dispose();
@@ -214,7 +214,7 @@ namespace Microsoft.Fx.Portability.Tests
             }
         }
 
-        private void TestEquality(BreakingChange expected, BreakingChange actual)
+        private static void TestEquality(BreakingChange expected, BreakingChange actual)
         {
             if (expected == null)
             {

--- a/tests/Microsoft.Fx.Portability.Tests/BreakingChangeTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/BreakingChangeTests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Fx.Portability.Tests
     public class BreakingChangeTests
     {
         [Fact]
-        public void EqualityTests()
+        public static void EqualityTests()
         {
             var breakingChangeSame1 = new BreakingChange { Id = "id1" };
             var breakingChangeSame2 = new BreakingChange { Id = "id1" };

--- a/tests/Microsoft.Fx.Portability.Tests/ObjectModel/AncestorApiRecommendationsTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ObjectModel/AncestorApiRecommendationsTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         /// Tests that the parent recommended change can be obtained if the docId's does not.
         /// </summary>
         [Fact]
-        public void GetRecommendedChange_Parent()
+        public static void GetRecommendedChange_Parent()
         {
             var docId = "Property:Foo";
             var matchingParentDocId = "Class:Test";
@@ -42,7 +42,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         /// Tests that string.Empty is returned if a recommended change is not found.
         /// </summary>
         [Fact]
-        public void GetRecommendedChange_DoesNotExist()
+        public static void GetRecommendedChange_DoesNotExist()
         {
             var docId = "Property:Foo";
             var ancestors = new[] { "Class:Test", "Namespace:MyTestNamespace" };
@@ -60,7 +60,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         }
 
         [Fact]
-        public void GetRecommendedChange_NoAncestors()
+        public static void GetRecommendedChange_NoAncestors()
         {
             var docId = "Namespace:MyTestNamespace";
             var ancestors = new string[0];
@@ -82,7 +82,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         /// returned if we have multiple matching ones).
         /// </summary>
         [Fact]
-        public void GetRecommendedChange_FirstMatchingRecommendation()
+        public static void GetRecommendedChange_FirstMatchingRecommendation()
         {
             var recommendedChanges = new[]
             {
@@ -113,7 +113,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         /// Tests that the parent Breaking change can be obtained if the docId's does not.
         /// </summary>
         [Fact]
-        public void GetBreakingChange_Parent()
+        public static void GetBreakingChange_Parent()
         {
             var docId = "Property:Foo";
             var matchingParentDocId = "Class:Test";
@@ -140,7 +140,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         /// Tests that string.Empty is returned if a Breaking change is not found.
         /// </summary>
         [Fact]
-        public void GetBreakingChange_DoesNotExist()
+        public static void GetBreakingChange_DoesNotExist()
         {
             var docId = "Property:Foo";
             var ancestors = new[] { "Class:Test", "Namespace:MyTestNamespace" };
@@ -158,7 +158,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         }
 
         [Fact]
-        public void GetBreakingChange_NoAncestors()
+        public static void GetBreakingChange_NoAncestors()
         {
             var docId = "Namespace:MyTestNamespace";
             var ancestors = new string[0];
@@ -180,7 +180,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         /// returned if we have multiple matching ones).
         /// </summary>
         [Fact]
-        public void GetBreakingChange_FirstMatchingRecommendation()
+        public static void GetBreakingChange_FirstMatchingRecommendation()
         {
             var breakingChanges = new Dictionary<string, IEnumerable<BreakingChange>>(StringComparer.Ordinal)
             {

--- a/tests/Microsoft.Fx.Portability.Tests/ObjectModel/AssemblyReferenceInformationTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ObjectModel/AssemblyReferenceInformationTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
     public class AssemblyReferenceInformationTests
     {
         [Fact]
-        public void EqualityTests()
+        public static void EqualityTests()
         {
             var assemblyInfo1 = new AssemblyReferenceInformation("name", Version.Parse("4.0"), "neutral", "1234");
             var assemblyInfo2 = new AssemblyReferenceInformation("Name", Version.Parse("4.0"), "neutral", "1234");

--- a/tests/Microsoft.Fx.Portability.Tests/ObjectModel/CloudApiCatalogLookupTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ObjectModel/CloudApiCatalogLookupTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         [InlineData("M:System.Collections.Concurrent.ConcurrentBag`1.get_Count", "P:System.Collections.Concurrent.ConcurrentBag`1.Count;T:System.Collections.Concurrent.ConcurrentBag`1;N:System.Collections.Concurrent")]
         [InlineData("T:System.Collections.Concurrent.ConcurrentBag`1", "N:System.Collections.Concurrent")]
         [Theory]
-        public void GetAncestorsTest(string docId, string ancestors)
+        public static void GetAncestorsTest(string docId, string ancestors)
         {
             var dotnetCatalog = new TestDotNetCatalog();
             var catalog = new CloudApiCatalogLookup(dotnetCatalog);
@@ -32,7 +32,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         [InlineData("N:System.Collections.Concurrent")]
         [InlineData("N:NonExistentDocId")]
         [Theory]
-        public void GetAncestorsTestEmpty(string docId)
+        public static void GetAncestorsTestEmpty(string docId)
         {
             var dotnetCatalog = new TestDotNetCatalog();
             var catalog = new CloudApiCatalogLookup(dotnetCatalog);

--- a/tests/Microsoft.Fx.Portability.Tests/ObjectModel/DiagnosticAnalyzerInfoTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ObjectModel/DiagnosticAnalyzerInfoTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
     public class DiagnosticAnalyzerInfoTests
     {
         [Fact]
-        public void NullIdReturnsNegativeOne()
+        public static void NullIdReturnsNegativeOne()
         {
             var diagnosticAnalyzerInfo = new DiagnosticAnalyzerInfo
             {
@@ -21,7 +21,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         }
 
         [Fact]
-        public void EmptyIdReturnsNegativeOne()
+        public static void EmptyIdReturnsNegativeOne()
         {
             var diagnosticAnalyzerInfo = new DiagnosticAnalyzerInfo
             {
@@ -33,7 +33,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         }
 
         [Fact]
-        public void ExpectedIdFormatWithTrailingCharacterReturnsIntId()
+        public static void ExpectedIdFormatWithTrailingCharacterReturnsIntId()
         {
             var diagnosticAnalyzerInfo = new DiagnosticAnalyzerInfo
             {
@@ -45,7 +45,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         }
 
         [Fact]
-        public void ExpectedIdFormatWithoutTrailingCharacterReturnsIntId()
+        public static void ExpectedIdFormatWithoutTrailingCharacterReturnsIntId()
         {
             var diagnosticAnalyzerInfo = new DiagnosticAnalyzerInfo
             {
@@ -57,7 +57,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         }
 
         [Fact]
-        public void NoNumberIdReturnsNegativeOne()
+        public static void NoNumberIdReturnsNegativeOne()
         {
             var diagnosticAnalyzerInfo = new DiagnosticAnalyzerInfo
             {

--- a/tests/Microsoft.Fx.Portability.Tests/ObjectModel/NuGetPackageInfoComparerTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ObjectModel/NuGetPackageInfoComparerTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
     public class NuGetPackageInfoComparerTests
     {
         [Fact]
-        public void SortingTest()
+        public static void SortingTest()
         {
             var target1 = NetStandard16;
             var target2 = Net40;

--- a/tests/Microsoft.Fx.Portability.Tests/ObjectModel/NuGetPackageInfoTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ObjectModel/NuGetPackageInfoTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
     public class NuGetPackageInfoTests
     {
         [Fact]
-        public void NuGetPackageInfoCreated()
+        public static void NuGetPackageInfoCreated()
         {
             var assemblyInfo = "MyDll, Version=1.5.3";
             var frameworkName = new FrameworkName("SomeFramework", Version.Parse("5.6.7.2"));
@@ -28,7 +28,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         }
 
         [Fact]
-        public void Equality()
+        public static void Equality()
         {
             // Set up
             var assemblyName = "MyNuGetPackage, Version=1.0.4";
@@ -50,7 +50,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         }
 
         [Fact]
-        public void InvalidConstruction()
+        public static void InvalidConstruction()
         {
             var assemblyInfo = "MyDll, Version=1.5.3";
             var frameworkName = new FrameworkName("SomeFramework", Version.Parse("5.6.7.2"));

--- a/tests/Microsoft.Fx.Portability.Tests/ObjectModel/TargetInformationTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ObjectModel/TargetInformationTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
     public class TargetInformationTests
     {
         [Fact]
-        public void NotNullExpandedTargets()
+        public static void NotNullExpandedTargets()
         {
             var info = new TargetInformation();
 
@@ -24,7 +24,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         }
 
         [Fact]
-        public void ToStringNoExpandedTargets()
+        public static void ToStringNoExpandedTargets()
         {
             const string name = "name";
             var info = new TargetInformation { Name = name };
@@ -33,7 +33,7 @@ namespace Microsoft.Fx.Portability.Tests.ObjectModel
         }
 
         [Fact]
-        public void ToStringWithExpandedTargets()
+        public static void ToStringWithExpandedTargets()
         {
             const string group = "name";
             const string expanded1 = "expanded1";

--- a/tests/Microsoft.Fx.Portability.Tests/ReadWriteApiPortOptionsTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ReadWriteApiPortOptionsTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Fx.Portability.Tests
     public class ReadWriteApiPortOptionsTests
     {
         [Fact]
-        public void AllPropertiesCopied()
+        public static void AllPropertiesCopied()
         {
             var options = new TestOptions();
             var wrappedOptions = new ReadWriteApiPortOptions(options);

--- a/tests/Microsoft.Fx.Portability.Tests/ReportFileWriterTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ReportFileWriterTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Fx.Portability.Reporting;
-using Microsoft.Fx.Portability.Reporting.ObjectModel;
 using NSubstitute;
 using System.Globalization;
 using System.IO;
@@ -15,7 +14,7 @@ namespace Microsoft.Fx.Portability.Tests
     public class ReportFileWriterTests
     {
         [Fact]
-        public async Task FileExists_OverwriteTrue()
+        public static async Task FileExists_OverwriteTrue()
         {
             var dir = "dir";
             var fileName = "file";
@@ -42,7 +41,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public async Task UniquelyNamedFileStream_FileExists_AppendsNumberToName()
+        public static async Task UniquelyNamedFileStream_FileExists_AppendsNumberToName()
         {
             var dir = "dir";
             var fileName = "file";
@@ -69,7 +68,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public async Task UniquelyNamedFileStream_NumberedFileExists_IncrementsNumberInNewName()
+        public static async Task UniquelyNamedFileStream_NumberedFileExists_IncrementsNumberInNewName()
         {
             const int FileExistsCount = 11;
             var dir = "dir";
@@ -104,7 +103,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public async Task VerifyReportHTMLContents()
+        public static async Task VerifyReportHTMLContents()
         {
             var dir = "dir";
             var fileName = "file";
@@ -135,7 +134,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public async Task DoNotUpdateExtensionIfInputExtensionIsEmpty()
+        public static async Task DoNotUpdateExtensionIfInputExtensionIsEmpty()
         {
             var dir = "dir";
             var fileName = "file.test";

--- a/tests/Microsoft.Fx.Portability.Tests/ReportingResultTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/ReportingResultTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Fx.Portability.Tests
 {
     public class ReportingResultTests
     {
-        private MemberInfo MissingMember(string typeDocId, string memberName)
+        private static MemberInfo MissingMember(string typeDocId, string memberName)
         {
             return new MemberInfo
             {
@@ -24,7 +24,7 @@ namespace Microsoft.Fx.Portability.Tests
             };
         }
 
-        private List<FrameworkName> TargetPlatforms(int count)
+        private static List<FrameworkName> TargetPlatforms(int count)
         {
             return Enumerable.Range(1, count)
                 .Select(n => new FrameworkName(string.Format(CultureInfo.CurrentCulture, "Target{0}", n), new Version(1, 0)))
@@ -32,7 +32,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void AddMissingDependency_MissingMemberOfSupportedType_TypeIsNotMarkedMissing()
+        public static void AddMissingDependency_MissingMemberOfSupportedType_TypeIsNotMarkedMissing()
         {
             var targets = TargetPlatforms(2);
             var type = new MemberInfo
@@ -59,7 +59,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void AddMissingDependency_MemberOfUnidentifiedType_TypeAddedToMissingTypes()
+        public static void AddMissingDependency_MemberOfUnidentifiedType_TypeAddedToMissingTypes()
         {
             var targets = TargetPlatforms(2);
             var typeDocId = "T:Spam.Spam";
@@ -78,7 +78,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void AddMissingDependency_MemberOfUnidentifiedType_TypeInheritsMemberTargetStatus()
+        public static void AddMissingDependency_MemberOfUnidentifiedType_TypeInheritsMemberTargetStatus()
         {
             var targets = TargetPlatforms(2);
             var typeDocId = "T:Spam.Spam";

--- a/tests/Microsoft.Fx.Portability.Tests/SerializationTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/SerializationTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Fx.Portability.Tests
     public class SerializationTests
     {
         [Fact]
-        public void SerializeAnalyzeRequest()
+        public static void SerializeAnalyzeRequest()
         {
             var request = new AnalyzeRequest
             {
@@ -31,7 +31,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void SerializeAnalyzeResponse()
+        public static void SerializeAnalyzeResponse()
         {
             var response = new AnalyzeResponse
             {
@@ -47,7 +47,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void SerializeProjectSubmission()
+        public static void SerializeProjectSubmission()
         {
             var submission1 = new ProjectSubmission { Name = "test1", Length = 10, SubmittedDate = new DateTime(10, 1, 4) };
             var submission2 = new ProjectSubmission { Name = "test2", Length = 11, SubmittedDate = new DateTime(10, 2, 4) };
@@ -62,7 +62,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void TestFrameworkNames()
+        public static void TestFrameworkNames()
         {
             VerifySerialization(new FrameworkName("name", new Version("1.2.3.4")));
             VerifySerialization(new FrameworkName("name", new Version("1.2.3.0")));
@@ -73,7 +73,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void TestVersion()
+        public static void TestVersion()
         {
             VerifySerialization(new Version("1.2.3.4"));
             VerifySerialization(new Version("1.2.3.0"));
@@ -84,7 +84,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void TestEmptyValues()
+        public static void TestEmptyValues()
         {
             VerifyEmptySerialized<AnalyzeRequest>();
             VerifyEmptySerialized<FrameworkName>();

--- a/tests/Microsoft.Fx.Portability.Tests/TargetMapTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/TargetMapTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Fx.Portability.Tests
     public class TargetMapTest
     {
         [Fact]
-        public void UnknownTarget()
+        public static void UnknownTarget()
         {
             var map = new TargetMapper();
 
@@ -23,7 +23,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void TwoItems()
+        public static void TwoItems()
         {
             var map = new TargetMapper();
 
@@ -34,7 +34,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void AliasList()
+        public static void AliasList()
         {
             var map = new TargetMapper();
 
@@ -46,7 +46,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void AliasEqualsTarget()
+        public static void AliasEqualsTarget()
         {
             var map = new TargetMapper();
 
@@ -66,7 +66,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void CaseInsensitiveAlias()
+        public static void CaseInsensitiveAlias()
         {
             var map = new TargetMapper();
 
@@ -78,7 +78,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void UndefinedAlias()
+        public static void UndefinedAlias()
         {
             var map = new TargetMapper();
             var alias = "alias";
@@ -87,7 +87,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void CaseInsensitiveTarget()
+        public static void CaseInsensitiveTarget()
         {
             var map = new TargetMapper();
 
@@ -98,7 +98,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void VerifySingleAliasMapping()
+        public static void VerifySingleAliasMapping()
         {
             Assert.Throws<AliasMappedToMultipleNamesException>(() =>
             {
@@ -112,7 +112,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void VerifySingleAliasMappingValid()
+        public static void VerifySingleAliasMappingValid()
         {
             var map = new TargetMapper();
 
@@ -123,7 +123,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void ParseGroupings1Group()
+        public static void ParseGroupings1Group()
         {
             var map = new TargetMapper();
             var groupings = "group1: target1,target2";
@@ -134,7 +134,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void ParseGroupings2Groups()
+        public static void ParseGroupings2Groups()
         {
             var map = new TargetMapper();
             var groupings = "group1: target1,target2; group2: target1, target3";
@@ -146,7 +146,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void ParseGroupingsNull()
+        public static void ParseGroupingsNull()
         {
             var map = new TargetMapper();
 
@@ -154,7 +154,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void ParseInvalidGroups()
+        public static void ParseInvalidGroups()
         {
             var map = new TargetMapper();
             var groupings = "group1 target1,target2; group2: target1, target3";
@@ -166,7 +166,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void ParseInvalidGroupsValidateAtomicOperation()
+        public static void ParseInvalidGroupsValidateAtomicOperation()
         {
             var map = new TargetMapper();
             var groupings = "group1: target1,target2; group2 target1, target3";
@@ -178,7 +178,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void ParseInvalidGroupsValidate()
+        public static void ParseInvalidGroupsValidate()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>
             {
@@ -190,7 +190,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void LoadXmlFromFile()
+        public static void LoadXmlFromFile()
         {
             var map = new TargetMapper();
 
@@ -198,7 +198,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void LoadXmlFromDefault()
+        public static void LoadXmlFromDefault()
         {
             var xml = @"<ApiTool>
         <Targets>
@@ -225,7 +225,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void XmlNoTargets()
+        public static void XmlNoTargets()
         {
             var xml = @"<ApiTool>
         <Targets>
@@ -238,7 +238,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void XmlWithAlias()
+        public static void XmlWithAlias()
         {
             var xml = @"<ApiTool>
         <Targets>
@@ -252,7 +252,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void XmlAliasSameAsName()
+        public static void XmlAliasSameAsName()
         {
             var xml = @"<ApiTool>
         <Targets>
@@ -275,7 +275,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void XmlDuplicateAlias()
+        public static void XmlDuplicateAlias()
         {
             var xml = @"<ApiTool>
         <Targets>
@@ -290,7 +290,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void XmlMalformedXml()
+        public static void XmlMalformedXml()
         {
             var xml = @"<ApiTool>
         <Targets>
@@ -314,7 +314,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void XmlNotInSchema()
+        public static void XmlNotInSchema()
         {
             var xml = @"<ApiTool>
         <Targets>
@@ -341,7 +341,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void XmlGetAlias()
+        public static void XmlGetAlias()
         {
             var xml = @"<ApiTool>
         <Targets>
@@ -356,7 +356,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void XmlGetAliasMultipleAliases()
+        public static void XmlGetAliasMultipleAliases()
         {
             var xml = @"<ApiTool>
         <Targets>
@@ -371,7 +371,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void XmlGetNameMultipleAliases()
+        public static void XmlGetNameMultipleAliases()
         {
             var xml = @"<ApiTool>
         <Targets>
@@ -387,7 +387,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void GetTargetNamesForDistinctTargets()
+        public static void GetTargetNamesForDistinctTargets()
         {
             var mapper = new TargetMapper();
             mapper.AddAlias("Mobile", "Windows Phone");
@@ -408,7 +408,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void GetTargetNamesForMultipleTargetVersions()
+        public static void GetTargetNamesForMultipleTargetVersions()
         {
             var mapper = new TargetMapper();
             mapper.AddAlias("Mobile", "Windows Phone");
@@ -441,7 +441,7 @@ namespace Microsoft.Fx.Portability.Tests
                 targetNamesWithVersions);
         }
 
-        private void AreCollectionsEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual)
+        private static void AreCollectionsEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual)
         {
             var expectedList = expected.OrderBy(k => k).ToList();
             var actualList = actual.OrderBy(k => k).ToList();
@@ -449,7 +449,7 @@ namespace Microsoft.Fx.Portability.Tests
             Assert.Equal<List<T>>(expectedList, actualList);
         }
 
-        private TargetMapper LoadXml(string config)
+        private static TargetMapper LoadXml(string config)
         {
             using (var ms = new MemoryStream())
             using (var writer = new StreamWriter(ms) { AutoFlush = true })

--- a/tests/Microsoft.Fx.Portability.Tests/TestData/TestCatalog.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/TestData/TestCatalog.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Fx.Portability.TestData
             return AllTargets.Values;
         }
 
-        public string GetApiMetadata(string docId, string metadataKey)
+        public static string GetApiMetadata(string docId, string metadataKey)
         {
             return string.Empty;
         }

--- a/tests/Microsoft.Fx.Portability.Tests/UrlBuilderTest.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/UrlBuilderTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Fx.Portability.Tests
     public class UrlBuilderTest
     {
         [Fact]
-        public void NoParameters()
+        public static void NoParameters()
         {
             var url = UrlBuilder.Create("test").Url;
 
@@ -18,7 +18,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void AddQueryParam()
+        public static void AddQueryParam()
         {
             var url = UrlBuilder.Create("test").AddQuery("name", "value").Url;
 
@@ -26,7 +26,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void AddNullableQueryParam()
+        public static void AddNullableQueryParam()
         {
             int? value = 5;
 
@@ -36,7 +36,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void AddNullableQueryParamNull()
+        public static void AddNullableQueryParamNull()
         {
             int? value = null;
 
@@ -46,7 +46,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void AddQueryListNull()
+        public static void AddQueryListNull()
         {
             var url = UrlBuilder.Create("test").AddQuery("name", "value").AddQueryList("test", null).Url;
 
@@ -54,7 +54,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void AddQueryList1Item()
+        public static void AddQueryList1Item()
         {
             var list = new[] { "test1" };
 
@@ -64,7 +64,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void AddQueryListMultiple()
+        public static void AddQueryListMultiple()
         {
             var list = new[] { "test1", "test2", "test3" };
             var url = UrlBuilder.Create("test").AddQuery("name", "value").AddQueryList("test", list).Url;
@@ -73,7 +73,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void AddQueryListMultipleNullItem()
+        public static void AddQueryListMultipleNullItem()
         {
             var list = new[] { "test1", null, "test3" };
             var url = UrlBuilder.Create("test").AddQuery("name", "value").AddQueryList("test", list).Url;
@@ -82,7 +82,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void AddODataParam()
+        public static void AddODataParam()
         {
             var url = UrlBuilder.Create("test").AddODataQuery("top", 10).Url;
 
@@ -90,7 +90,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void HttpEncodeValues()
+        public static void HttpEncodeValues()
         {
             var url = UrlBuilder.Create("test").AddQuery("name with spaces", "value with spaces").Url;
 
@@ -98,7 +98,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void HttpEncodeValuesOData()
+        public static void HttpEncodeValuesOData()
         {
             var url = UrlBuilder.Create("test").AddODataQuery("name with spaces", "value with spaces").Url;
 
@@ -106,7 +106,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void AddPath()
+        public static void AddPath()
         {
             var url = UrlBuilder.Create("test").AddPath("blah ");
 
@@ -114,7 +114,7 @@ namespace Microsoft.Fx.Portability.Tests
         }
 
         [Fact]
-        public void NullObject()
+        public static void NullObject()
         {
             var original = UrlBuilder.Create("test");
             var withNull = original.AddQuery("null", null);


### PR DESCRIPTION
This fixes warnings that an upgrade to Microsoft.CodeAnalysis.FxCopAnalyzers 2.6.0 will discover after we migrate to it.