### PR TITLE
Add $(IncludeCodeAnalysisPackages) property to conditionally exclude Microsoft.CodeAnalysis.FxCopAnalyzers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,6 +22,14 @@
     <BaseIntermediateOutputPath>$(OutputFullPath)obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
   </PropertyGroup>
 
+  <!-- TODO: Remove this when our CI machine supports 15.5.
+  See: https://github.com/dotnet/dotnet-ci/issues/905
+  Our CI builds have VS2017 15.3 installed and our release builds have VS2017 15.5
+  installed. This results in a conflict when we change Microsoft.CodeAnalysis.FxCopAnalyzers from 2.3.0-beta1 to 2.6.0 in Directory.Build.targets. -->
+  <PropertyGroup>
+    <IncludeCodeAnalysisPackages Condition="'$(IncludeCodeAnalysisPackages)' == ''">true</IncludeCodeAnalysisPackages>
+  </PropertyGroup>
+
   <!-- Assembly signing not supported on Linux, yet.
     `CS7027: Error signing output with public key from file` -->
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -37,17 +37,19 @@
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)\stylecop.json" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core" Version="0.2.0" Condition="!$(IsTest)">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
 
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1" Condition=" '$(IsPackage)' != 'true' ">
+    <!-- TODO: Remove IncludeCodeAnalysisPackages when our CI machine supports
+    VS2017 15.5. See Directory.Build.props for more info. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1" Condition=" '$(IsPackage)' != 'true' and '$(IncludeCodeAnalysisPackages)' == 'true' ">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
 


### PR DESCRIPTION
This property allows for conditionally excluding them from our build.  The gated CI builds happen more often than our release builds (dev -> master), so these warnings are more meaningful if they are in our CI PRs.  It is opted-in by default.

Our dev -> master release build is throwing:
```
CSC:CSC(0,0): Error   CS8032: An instance of analyzer   Microsoft.NetCore.Analyzers.Runtime.TestForNaNCorrectlyAnalyzer cannot be   created from C:\Users\dlab\.nuget\packages\microsoft.netcore.analyzers\2.3.0-beta1\analyzers\dotnet\cs\Microsoft.NetCore.Analyzers.dll   : Exception has been thrown by the target of an invocation..
Process   'msbuild.exe' exited with code '1'.
```
