### PR TITLE
Merge development into master

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,6 +22,14 @@
     <BaseIntermediateOutputPath>$(OutputFullPath)obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
   </PropertyGroup>
 
+  <!-- TODO: Remove this when our CI machine supports 15.5.
+  See: https://github.com/dotnet/dotnet-ci/issues/905
+  Our CI builds have VS2017 15.3 installed and our release builds have VS2017 15.5
+  installed. This results in a conflict when we change Microsoft.CodeAnalysis.FxCopAnalyzers from 2.3.0-beta1 to 2.6.0 in Directory.Build.targets. -->
+  <PropertyGroup>
+    <IncludeCodeAnalysisPackages Condition="'$(IncludeCodeAnalysisPackages)' == ''">true</IncludeCodeAnalysisPackages>
+  </PropertyGroup>
+
   <!-- Assembly signing not supported on Linux, yet.
     `CS7027: Error signing output with public key from file` -->
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -37,17 +37,19 @@
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)\stylecop.json" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core" Version="0.2.0" Condition="!$(IsTest)">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
 
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1" Condition=" '$(IsPackage)' != 'true' ">
+    <!-- TODO: Remove IncludeCodeAnalysisPackages when our CI machine supports
+    VS2017 15.5. See Directory.Build.props for more info. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1" Condition=" '$(IsPackage)' != 'true' and '$(IncludeCodeAnalysisPackages)' == 'true' ">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
 


### PR DESCRIPTION
* Add IncludeCodeAnalysisPackages variable to conditionally not include Microsoft.CodeAnalysis.FxCopAnalyzers. (#549)
* Fixes our master build