### PR TITLE
Revert IncludeCodeAnalysisPackages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,14 +22,6 @@
     <BaseIntermediateOutputPath>$(OutputFullPath)obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
   </PropertyGroup>
 
-  <!-- TODO: Remove this when our CI machine supports 15.5.
-  See: https://github.com/dotnet/dotnet-ci/issues/905
-  Our CI builds have VS2017 15.3 installed and our release builds have VS2017 15.5
-  installed. This results in a conflict when we change Microsoft.CodeAnalysis.FxCopAnalyzers from 2.3.0-beta1 to 2.6.0 in Directory.Build.targets. -->
-  <PropertyGroup>
-    <IncludeCodeAnalysisPackages Condition="'$(IncludeCodeAnalysisPackages)' == ''">true</IncludeCodeAnalysisPackages>
-  </PropertyGroup>
-
   <!-- Assembly signing not supported on Linux, yet.
     `CS7027: Error signing output with public key from file` -->
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -37,17 +37,17 @@
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)\stylecop.json" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core" Version="0.2.0" Condition="!$(IsTest)">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    
+
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
 
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1" Condition=" '$(IsPackage)' != 'true' ">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" Condition=" '$(IsPackage)' != 'true' ">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -37,19 +37,17 @@
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)\stylecop.json" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core" Version="0.2.0" Condition="!$(IsTest)">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-
+    
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
 
-    <!-- TODO: Remove IncludeCodeAnalysisPackages when our CI machine supports
-    VS2017 15.5. See Directory.Build.props for more info. -->
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1" Condition=" '$(IsPackage)' != 'true' and '$(IncludeCodeAnalysisPackages)' == 'true' ">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1" Condition=" '$(IsPackage)' != 'true' ">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -47,6 +47,12 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
 
+    <!-- Enforcing the same compiler toolset to be used on desktop builds.
+      https://github.com/dotnet/roslyn-analyzers/issues/1533#issuecomment-358733030 -->
+    <PackageReference Include="Microsoft.Net.Compilers" Version="2.6.1" Condition="'$(OS)' == 'Windows_NT'">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" Condition=" '$(IsPackage)' != 'true' ">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ installSDK() {
         mkdir -p $DotNetToolsPath
     fi
 
-    curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 2.0 --install-dir $DotNetSDKPath
+    curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel Current --install-dir $DotNetSDKPath
     curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 1.0 --shared-runtime --install-dir $DotNetSDKPath
 }
 

--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ build() {
 runTest() {
     ls $1/*.csproj | while read file
     do
-        if awk -F: '/<TargetFramework>netcoreapp1\.[0-9]<\/TargetFramework>/ { found = 1 } END { if (found == 1) { exit 0 } else { exit 1 } }' $file; then
+        if awk -F: '/<TargetFramework>netcoreapp[1-9]\.[0-9]<\/TargetFramework>/ { found = 1 } END { if (found == 1) { exit 0 } else { exit 1 } }' $file; then
             echo "Testing "$file
             $DotNetExe test $file -c $Configuration --logger trx
         else

--- a/netci.groovy
+++ b/netci.groovy
@@ -21,7 +21,7 @@ def outerloopPlatforms = ['Windows_NT', 'Ubuntu14.04', 'Ubuntu16.04', 'OSX10.12'
                     }
                 }
 
-                Utilities.setMachineAffinity(newJob, os, 'latest-dev15-3')
+                Utilities.setMachineAffinity(newJob, os, 'latest-dev15-5')
             } else {
                 newJob.with {
                     steps {


### PR DESCRIPTION
* Reverts addition of IncludeCodeAnalysisPackages
* Updates CI build to use 15.5
* Updates Microsoft.CodeAnalysis.FxCopAnalyzers to 2.6.0

Related to: https://github.com/dotnet/dotnet-ci/issues/905