### PR TITLE
Minor fixes to Excel Report

### DIFF
--- a/src/Microsoft.Fx.Portability.Reports.Excel/ExcelOpenXmlOutputWriter.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Excel/ExcelOpenXmlOutputWriter.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Fx.Portability.Reports
 
         private void GenerateSummaryPage(Worksheet summaryPage, ReportingResult analysisResult)
         {
-            var targetNames = _mapper.GetTargetNames(analysisResult.Targets);
+            var targetNames = _mapper.GetTargetNames(analysisResult.Targets, alwaysIncludeVersion: true);
 
             // This is the submission id
             summaryPage.AddRow(LocalizedStrings.SubmissionId, AddSubmissionLink(analysisResult.SubmissionId));
@@ -225,7 +225,7 @@ namespace Microsoft.Fx.Portability.Reports
                 detailsPageHeader.Add(LocalizedStrings.AssemblyHeader);
             }
 
-            detailsPageHeader.AddRange(_mapper.GetTargetNames(analysisResult.Targets));
+            detailsPageHeader.AddRange(_mapper.GetTargetNames(analysisResult.Targets, alwaysIncludeVersion: true));
             detailsPageHeader.Add(LocalizedStrings.RecommendedChanges);
 
             int detailsRows = 0;

--- a/src/Microsoft.Fx.Portability.Reports.Excel/Resources/LocalizedStrings.Designer.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Excel/Resources/LocalizedStrings.Designer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Fx.Portability.Reports.Excel.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Header for assembly name entries.
+        ///   Looks up a localized string similar to Assembly Name.
         /// </summary>
         internal static string AssemblyHeader {
             get {

--- a/src/Microsoft.Fx.Portability.Reports.Excel/Resources/LocalizedStrings.resx
+++ b/src/Microsoft.Fx.Portability.Reports.Excel/Resources/LocalizedStrings.resx
@@ -118,7 +118,8 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AssemblyHeader" xml:space="preserve">
-    <value>Header for assembly name entries</value>
+    <value>Assembly Name</value>
+    <comment>Header for assembly name entries</comment>
   </data>
   <data name="BreakingChanges" xml:space="preserve">
     <value>Breaking Changes</value>


### PR DESCRIPTION
* Changed the Assembly header from "Header for assembly name entries" to "Assembly Name"
* Always include .NET platform targets in Excel summary output