### PR TITLE
Prevent parsing breaking change comments as categories

### DIFF
--- a/src/Microsoft.Fx.Portability/BreakingChangeParser.cs
+++ b/src/Microsoft.Fx.Portability/BreakingChangeParser.cs
@@ -309,7 +309,7 @@ namespace Microsoft.Fx.Portability
                     }
                     break;
                 case ParseState.Categories:
-                    if (string.IsNullOrWhiteSpace(currentLine) || currentLine.StartsWith("<!--"))
+                    if (string.IsNullOrWhiteSpace(currentLine) || currentLine.StartsWith("<!--", StringComparison.Ordinal))
                     {
                         break;
                     }

--- a/tests/Microsoft.Fx.Portability.Tests/TestAssets/long-path-support.md
+++ b/tests/Microsoft.Fx.Portability.Tests/TestAssets/long-path-support.md
@@ -1,0 +1,67 @@
+## Long path support
+
+### Scope
+Minor
+
+### Version Introduced
+4.6.2
+
+### Source Analyzer Status
+Investigating
+
+### Change Description
+
+Starting with apps that target the .NET Framework 4.6.2, long paths (of up to
+32K characters) are supported, and the 260-character (or `MAX_PATH`) limitation
+on path lengths has been removed.
+
+For apps that are recompiled to target the .NET Framework 4.6.2, code paths that
+previously threw a <xref:System.IO.PathTooLongException?displayProperty=name>
+because a path exceeded 260 characters will now throw a
+<xref:System.IO.PathTooLongException?displayProperty=name> only under the
+following conditions:
+
+- The length of the path is greater than <xref:System.Int16.MaxValue> (32,767) characters.
+- The operating system returns `COR_E_PATHTOOLONG` or its equivalent.
+
+For apps that target the .NET Framework 4.6.1 and earlier versions, the runtime
+automatically throws a
+<xref:System.IO.PathTooLongException?displayProperty=name> whenever a path
+exceeds 260 characters.
+
+- [X] Quirked
+- [ ] Build-time break
+
+### Recommended Action
+
+For apps that target the .NET Framework 4.6.2, you can opt out of long path
+support if it is not desirable by adding the following to the `<runtime>`
+section of your `app.config` file:
+
+   ```xml
+   <runtime>
+      <AppContextSwitchOverrides value="Switch.System.IO.BlockLongPaths=true" />
+   </runtime>
+   ```
+
+For apps that target earlier versions of the .NET Framework but run on the .NET
+Framework 4.6.2 or later, you can opt in to long path support by adding the
+following to the `<runtime>` section of your `app.config` file:
+
+   ```xml
+   <runtime>
+      <AppContextSwitchOverrides value="Switch.System.IO.BlockLongPaths=false" />
+   </runtime>
+   ```
+### Affected APIs
+* Not detectable via API analysis
+
+### Category
+Core
+
+<!--
+    ### Original Bug
+    195340
+-->
+
+<!-- breaking change id: 162 -->

--- a/tests/Microsoft.Fx.Portability.Tests/TestAssets/opt-in-break-to-revert-from-different-4_5-sql-generation-to-simpler-4_0-sql-generation.md
+++ b/tests/Microsoft.Fx.Portability.Tests/TestAssets/opt-in-break-to-revert-from-different-4_5-sql-generation-to-simpler-4_0-sql-generation.md
@@ -1,0 +1,34 @@
+﻿## Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation
+
+### Scope
+Transparent
+
+### Version Introduced
+4.5.2
+
+### Source Analyzer Status
+Not planned
+
+### Change Description
+Queries that produce JOIN statements and contain a call to a limiting operation without first using OrderBy now produce simpler SQL. After upgrading to .NET Framework 4.5, these queries produced more complicated SQL than previous versions.
+
+- [ ] Quirked
+- [x] Optional
+- [ ] Build-time break
+
+### Recommended Action
+This feature is disabled by default. If Entity Framework generates extra JOIN statements that cause performance degradation, you can enable this feature by adding the following entry to the `<appSettings>` section of the application configuration (app.config) file:
+
+```xml
+<add key="EntityFramework_SimplifyLimitOperations" value="true" />
+```
+
+### Affected APIs
+* Not detectable via API analysis
+
+### Category
+Entity Framework
+
+<!-- MSDN lists this as a 'minor'-scope break, but it is 'transparent' here because it is an opt-in break -->
+
+<!-- breaking change id: 50 -->


### PR DESCRIPTION
When parsing categories, `BreakingChangeParser` can consider comments categories. This change prevents that and adds tests of category parsing.