### PR TITLE
Support .NET Core 2.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -45,15 +45,14 @@ installSDK() {
     fi
 
     curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel Current --install-dir $DotNetSDKPath
-    curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 1.0 --shared-runtime --install-dir $DotNetSDKPath
 }
 
 build() {
     echo "Building ApiPort... Configuration: ["$Configuration"]"
 
     pushd src/ApiPort > /dev/null
-    $DotNetExe build ApiPort.csproj -f netcoreapp1.0 -c $Configuration
-    $DotNetExe build ApiPort.Offline.csproj -f netcoreapp1.0 -c $Configuration
+    $DotNetExe build ApiPort.csproj -f netcoreapp2.0 -c $Configuration
+    $DotNetExe build ApiPort.Offline.csproj -f netcoreapp2.0 -c $Configuration
     popd > /dev/null
 }
 

--- a/src/ApiPort/ApiPort.props
+++ b/src/ApiPort/ApiPort.props
@@ -7,8 +7,8 @@
       netcoreapp target must be first to avoid a ResXFileCodeGenerator issue
       (tracked at https://github.com/dotnet/project-system/issues/1519)
     -->
-    <TargetFrameworks>netcoreapp1.0;net461</TargetFrameworks>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;ubuntu.14.04-x64</RuntimeIdentifiers>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;ubuntu.14.04-x64;ubuntu.17.04-x64</RuntimeIdentifiers>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <IsPackable>false</IsPackable>

--- a/src/ApiPort/DocIdSearchRepl.cs
+++ b/src/ApiPort/DocIdSearchRepl.cs
@@ -67,7 +67,13 @@ namespace ApiPort
 
                 if (query.StartsWith(LocalizedStrings.ReplOptionCount, StringComparison.OrdinalIgnoreCase))
                 {
-                    var trimmed = query.Replace(LocalizedStrings.ReplOptionCount, "").Trim();
+                    var trimmed = query
+#if NETCOREAPP2_0
+                        .Replace(LocalizedStrings.ReplOptionCount, string.Empty, StringComparison.OrdinalIgnoreCase)
+#else
+                        .Replace(LocalizedStrings.ReplOptionCount, string.Empty)
+#endif
+                        .Trim();
                     int updatedCount;
 
                     if (Int32.TryParse(trimmed, out updatedCount))

--- a/src/ApiPort/Proxy/WebProxy.cs
+++ b/src/ApiPort/Proxy/WebProxy.cs
@@ -30,12 +30,7 @@ namespace ApiPort.Proxy
 
         public WebProxy(Uri proxyAddress)
         {
-            if (proxyAddress == null)
-            {
-                throw new ArgumentNullException(nameof(proxyAddress));
-            }
-
-            ProxyAddress = proxyAddress;
+            ProxyAddress = proxyAddress ?? throw new ArgumentNullException(nameof(proxyAddress));
         }
 
         public Uri ProxyAddress { get; }
@@ -83,9 +78,19 @@ namespace ApiPort.Proxy
 
         private static string WildcardToRegex(string pattern)
         {
-            return Regex.Escape(pattern)
-                .Replace(@"\*", ".*?")
-                .Replace(@"\?", ".");
+            string Replace(string content, string oldValue, string newValue)
+            {
+#if NETCOREAPP2_0
+                return content.Replace(oldValue, newValue, StringComparison.Ordinal);
+#else
+                return content.Replace(oldValue, newValue);
+#endif
+            };
+
+            return Replace(
+                    Replace(Regex.Escape(pattern), @"\*", ".*?"),
+                    @"\?",
+                    ".");
         }
 
         private static Uri CreateProxyUri(string address)

--- a/tests/ApiPort.Tests/ApiPort.Tests.csproj
+++ b/tests/ApiPort.Tests/ApiPort.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/Microsoft.Fx.Portability.Offline.Tests/Microsoft.Fx.Portability.Offline.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Offline.Tests/Microsoft.Fx.Portability.Offline.Tests.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <NonShipping>true</NonShipping>
   </PropertyGroup>
 
   <!-- FxCop does not understand this target platform and will output the
     following errors:
-    MSBUILD : error : CA0055 : Could not identify platform for 'bin\Debug\ApiPort\netcoreapp1.0\ApiPort.dll'
+    MSBUILD : error : CA0055 : Could not identify platform for 'bin\Debug\ApiPort\netcoreapp2.0\ApiPort.dll'
     MSBUILD : error : CA0052 : No targets were selected.
     -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
 

--- a/tests/Microsoft.Fx.Portability.Offline.Tests/OffLineApiPortServiceTests.cs
+++ b/tests/Microsoft.Fx.Portability.Offline.Tests/OffLineApiPortServiceTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Fx.Portability.Reporting;
 using NSubstitute;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -145,8 +146,8 @@ namespace Microsoft.Fx.Portability.Offline.Tests
         {
             var expectedDocIds = new List<string>
             {
-                $"T:{ValidDocId.ToUpper()}0" ,
-                $"M:{ValidDocId.ToUpper()}1",
+                $"T:{ValidDocId.ToUpper(CultureInfo.InvariantCulture)}0" ,
+                $"M:{ValidDocId.ToUpper(CultureInfo.InvariantCulture)}1",
                 $"P:{ValidDocId}0"
             };
 

--- a/tests/Microsoft.Fx.Portability.Tests/BreakingChangeParserTests.cs
+++ b/tests/Microsoft.Fx.Portability.Tests/BreakingChangeParserTests.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Fx.Portability.Tests
 ...
 </runtime>
 </configuration>
-```".Replace(Environment.NewLine, "\n")
+```".Replace(Environment.NewLine, "\n", StringComparison.InvariantCulture)
             };
 
             ValidateParse(GetBreakingChangeMarkdown("CommentsInRecommendedChanges.md"), expected);

--- a/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
+++ b/tests/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <NonShipping>true</NonShipping>
   </PropertyGroup>
 
   <!-- FxCop does not understand this target platform and will output the
     following errors:
-    MSBUILD : error : CA0055 : Could not identify platform for 'bin\Debug\ApiPort\netcoreapp1.0\ApiPort.dll'
+    MSBUILD : error : CA0055 : Could not identify platform for 'bin\Debug\ApiPort\netcoreapp2.0\ApiPort.dll'
     MSBUILD : error : CA0052 : No targets were selected.
     -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
 


### PR DESCRIPTION
Updates our tests to .NET Core App 2.0. This is because this target is available on more distributions.