### PR TITLE
Adding regex for git version branches

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,9 +2,11 @@ assembly-versioning-scheme: MajorMinorPatchTag
 mode: ContinuousDeployment
 branches:
   master:
+    regex: master
     tag: alpha
     prevent-increment-of-merged-branch-version: true
   dev:
+    regex: dev(elop)?(ment)?$
     tag: unstable
 next-version: 2.4
 ignore:

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -8,6 +8,11 @@ branches:
   dev:
     regex: dev(elop)?(ment)?$
     tag: unstable
+  pull-request:
+    regex: (pull|pull\-requests|pr)[/-]
+    mode: ContinuousDelivery
+    tag: pr
+    prevent-increment-of-merged-branch-version: false
 next-version: 2.4
 ignore:
   sha: []

--- a/build.ps1
+++ b/build.ps1
@@ -87,18 +87,18 @@ function Set-DevEnvironment {
     }
 
     $output = cmd /c "`"$devEnv`" & set"
-    
+
     foreach ($line in $output)
     {
         if ($line -match "(?<key>.*?)=(?<value>.*)") {
             $key = $matches["key"]
             $value = $matches["value"]
-                
+
             Write-Verbose("$key=$value")
             Set-Item "ENV:\$key" -Value "$value" -Force
         }
     }
-    
+
     if (Get-Command $msbuild -ErrorAction SilentlyContinue)
     {
         Write-Host "Added $msbuild to path"
@@ -128,7 +128,7 @@ if ($Platform -eq "AnyCPU") {
 
 Push-Location $root
 
-& msbuild PortabilityTools.sln "/t:restore;build;pack" /p:Configuration=$Configuration /p:Platform="$PlatformToUse" /nologo /m /v:m /nr:false "/bl:$binFolder\msbuild.binlog"
+& msbuild PortabilityTools.sln "/t:restore;build;pack" /p:Configuration=$Configuration /p:Platform="$PlatformToUse" /nologo /m:1 /v:m /nr:false "/bl:$binFolder\msbuild.binlog"
 
 Pop-Location
 


### PR DESCRIPTION
* Builds failing because of missing regex for gitversion.yml.

```
WARN [01/30/18 16:02:32:20] Could not determine assembly version: GitVersion.GitVersionConfigurationException: Branch configuration 'dev' is missing required configuration 'regex' 
at GitVersion.ConfigurationProvider.ApplyDefaultsTo(Config config) 
at GitVersion.ConfigurationProvider.Provide(String workingDirectory, IFileSystem fileSystem, Boolean applyDefaults, Config overrideConfig) 
at GitVersion.ConfigurationProvider.Provide(GitPreparer gitPreparer, IFileSystem fileSystem, Boolean applyDefaults, Config overrideConfig) 
at GitVersion.ExecuteCore.ExecuteInternal(String targetBranch, String commitId, GitPreparer gitPreparer, IBuildServer buildServer, Config overrideConfig) 
at GitVersion.ExecuteCore.ExecuteGitVersion(String targetUrl, String dynamicRepositoryLocation, Authentication authentication, String targetBranch, Boolean noFetch, String workingDirectory, String commitId, Config overrideConfig, Boolean noCache) 
at GitVersion.ExecuteCore.TryGetVersion(String directory, VersionVariables& versionVariables, Boolean noFetch, Authentication authentication)
```