### PR TITLE
Fixing more FxCop issues

### DIFF
--- a/src/ApiPort.VisualStudio.2015/ProjectBuilder2015.cs
+++ b/src/ApiPort.VisualStudio.2015/ProjectBuilder2015.cs
@@ -5,17 +5,16 @@ using ApiPortVS.Common;
 using ApiPortVS.Contracts;
 using EnvDTE;
 using Microsoft.VisualStudio.ProjectSystem;
-using Microsoft.VisualStudio.ProjectSystem.Build;
 using Microsoft.VisualStudio.ProjectSystem.Designers;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using static Microsoft.Fx.Portability.Utils.FormattableStringHelper;
 
 namespace ApiPortVS.VS2015
 {
@@ -57,7 +56,7 @@ namespace ApiPortVS.VS2015
         /// project is not a CPS project.</returns>
         private async Task<IEnumerable<string>> GetBuildOutputFilesFromCPSAsync(
             Project project,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             if (project == null)
             {
@@ -68,7 +67,7 @@ namespace ApiPortVS.VS2015
 
             if (hierarchy == null)
             {
-                Trace.TraceWarning($"Unable to locate {nameof(IVsHierarchy)} for {project.Name}");
+                Trace.TraceWarning(ToCurrentCulture($"Unable to locate {nameof(IVsHierarchy)} for {project.Name}"));
                 return null;
             }
 

--- a/src/ApiPort.VisualStudio.Common/ComProjectMapper.cs
+++ b/src/ApiPort.VisualStudio.Common/ComProjectMapper.cs
@@ -9,6 +9,7 @@ using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using VisualStudio = Microsoft.VisualStudio.Shell;
+using static Microsoft.Fx.Portability.Utils.FormattableStringHelper;
 
 namespace ApiPortVS
 {
@@ -67,18 +68,18 @@ namespace ApiPortVS
 
             if (getConfigurationProvider == null)
             {
-                Trace.TraceError($"Could not retrieve {nameof(IVsGetCfgProvider)} from project: {project.Name}");
+                Trace.TraceError(ToCurrentCulture($"Could not retrieve {nameof(IVsGetCfgProvider)} from project: {project.Name}"));
                 return null;
             }
 
             if (ErrorHandler.Failed(getConfigurationProvider.GetCfgProvider(out IVsCfgProvider provider)))
             {
-                Trace.TraceError($"Could not retrieve {nameof(IVsCfgProvider)} from project: {project.Name}");
+                Trace.TraceError(ToCurrentCulture($"Could not retrieve {nameof(IVsCfgProvider)} from project: {project.Name}"));
                 return null;
             }
             if (!(provider is IVsCfgProvider2))
             {
-                Trace.TraceError($"IVsCfgProvider returned {provider.GetType()} is not of the right type. Expected: {nameof(IVsCfgProvider2)}");
+                Trace.TraceError(ToCurrentCulture($"IVsCfgProvider returned {provider.GetType()} is not of the right type. Expected: {nameof(IVsCfgProvider2)}"));
                 return null;
             }
 
@@ -87,7 +88,7 @@ namespace ApiPortVS
 
             if (ErrorHandler.Failed(provider2.GetCfgOfName(activeConfiguration.ConfigurationName, activeConfiguration.PlatformName, out IVsCfg configuration)))
             {
-                Trace.TraceError($"Could not retrieve {nameof(IVsCfg)} from project: {project.Name}");
+                Trace.TraceError(ToCurrentCulture($"Could not retrieve {nameof(IVsCfg)} from project: {project.Name}"));
                 return null;
             }
 

--- a/src/ApiPort.VisualStudio.Common/DefaultProjectBuilder.cs
+++ b/src/ApiPort.VisualStudio.Common/DefaultProjectBuilder.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using static Microsoft.VisualStudio.VSConstants;
+using static Microsoft.Fx.Portability.Utils.FormattableStringHelper;
 using System;
 using System.Threading;
 using Microsoft.VisualStudio;
@@ -99,7 +100,7 @@ namespace ApiPortVS
 
             if (!(configuration is IVsProjectCfg2 configuration2))
             {
-                Trace.TraceError($"IVsCfg returned {configuration.GetType()} is not of the right type. Expected: {nameof(IVsProjectCfg2)}");
+                Trace.TraceError(ToCurrentCulture($"IVsCfg returned {configuration.GetType()} is not of the right type. Expected: {nameof(IVsProjectCfg2)}"));
                 return null;
             }
 
@@ -107,19 +108,19 @@ namespace ApiPortVS
 
             if (ErrorHandler.Failed(configuration2.OpenOutputGroup(Common.Constants.OutputGroups.BuiltProject, out IVsOutputGroup outputGroup)))
             {
-                Trace.TraceError($"Could not retrieve {nameof(IVsOutputGroup)} from project: {project.Name}");
+                Trace.TraceError(ToCurrentCulture($"Could not retrieve {nameof(IVsOutputGroup)} from project: {project.Name}"));
                 return null;
             }
 
             if (!(outputGroup is IVsOutputGroup2 outputGroup2))
             {
-                Trace.TraceError($"Could not retrieve {nameof(IVsOutputGroup2)} from project: {project.Name}");
+                Trace.TraceError(ToCurrentCulture($"Could not retrieve {nameof(IVsOutputGroup2)} from project: {project.Name}"));
                 return null;
             }
 
             if (ErrorHandler.Failed(outputGroup2.get_KeyOutputObject(out IVsOutput2 keyGroup)))
             {
-                Trace.TraceError($"Could not retrieve {nameof(IVsOutput2)} from project: {project.Name}");
+                Trace.TraceError(ToCurrentCulture($"Could not retrieve {nameof(IVsOutput2)} from project: {project.Name}"));
                 return null;
             }
 

--- a/src/ApiPort/DocIdSearchRepl.cs
+++ b/src/ApiPort/DocIdSearchRepl.cs
@@ -7,6 +7,7 @@ using System;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using static Microsoft.Fx.Portability.Utils.FormattableStringHelper;
 
 namespace ApiPort
 {
@@ -20,15 +21,15 @@ namespace ApiPort
 
         public async Task DocIdSearchAsync()
         {
-            var countOption = $"{LocalizedStrings.ReplOptionCount}[{LocalizedStrings.Number}]";
+            var countOption = ToCurrentCulture($"{LocalizedStrings.ReplOptionCount}[{LocalizedStrings.Number}]");
             var optionColumnWidth = Math.Max(countOption.Length, LocalizedStrings.ReplOptionExit.Length);
 
             Console.WriteLine();
             Console.WriteLine(LocalizedStrings.ReplEnterQuery);
             Console.WriteLine();
             Console.WriteLine(LocalizedStrings.ReplOptionsHeader);
-            Console.WriteLine($"  {LocalizedStrings.ReplOptionExit.PadRight(optionColumnWidth)}\t{LocalizedStrings.ReplOptionExit_Text}");
-            Console.WriteLine($"  {countOption.PadRight(optionColumnWidth)}\t{LocalizedStrings.ReplOptionCount_Text}");
+            Console.WriteLine(ToCurrentCulture($"  {LocalizedStrings.ReplOptionExit.PadRight(optionColumnWidth)}\t{LocalizedStrings.ReplOptionExit_Text}"));
+            Console.WriteLine(ToCurrentCulture($"  {countOption.PadRight(optionColumnWidth)}\t{LocalizedStrings.ReplOptionCount_Text}"));
             Console.WriteLine();
 
             Console.CancelKeyPress += ConsoleCancelKeyPress;
@@ -95,7 +96,7 @@ namespace ApiPort
                 {
                     foreach (var result in results)
                     {
-                        WriteColorLine($"\"{result}\",", ConsoleColor.Cyan);
+                        WriteColorLine(ToCurrentCulture($"\"{result}\","), ConsoleColor.Cyan);
                     }
                 }
                 else

--- a/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
+++ b/src/Microsoft.Fx.Portability.Reports.Html/HtmlReportWriter.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System;
 using Microsoft.Fx.Portability.Reports.Html;
 using Microsoft.Fx.Portability.Reports.Html.Resources;
+using static System.FormattableString;
 
 namespace Microsoft.Fx.Portability.Reports
 {
@@ -115,7 +116,7 @@ namespace Microsoft.Fx.Portability.Reports
                 var className = supported ? "IconSuccessEncoded" : "IconErrorEncoded";
                 var title = supported ? LocalizedStrings.Supported : LocalizedStrings.NotSupported;
 
-                return Raw($"<td class=\"{className}\" title=\"{title}\"></td>");
+                return Raw(Invariant($"<td class=\"{className}\" title=\"{title}\"></td>"));
             }
 
             public IEncodedString BreakingChangeCountCell(int breaks, int warningThreshold, int errorThreshold)
@@ -130,7 +131,7 @@ namespace Microsoft.Fx.Portability.Reports
                     className = breaks <= errorThreshold ? "FewBreakingChanges" : "ManyBreakingChanges";
                 }
 
-                return Raw($"<td class=\"textCentered {className}\">{breaks}</td>");
+                return Raw(Invariant($"<td class=\"textCentered {className}\">{breaks}</td>"));
             }
 #pragma warning restore CA1822 // Mark members as static
         }

--- a/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
+++ b/src/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
@@ -7,6 +7,8 @@
     -->
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <Description>The core data structures and network calls for .NET Portability Analyzer</Description>
+    <!-- Adding this to properly suppress CA3053. -->
+    <DefineConstants>$(DefineConstants);CODE_ANALYSIS</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'== 'net46'">

--- a/src/Microsoft.Fx.Portability/TargetMapper.cs
+++ b/src/Microsoft.Fx.Portability/TargetMapper.cs
@@ -84,6 +84,8 @@ namespace Microsoft.Fx.Portability
             Load(stream, null);
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security.Xml", "CA3053:UseXmlSecureResolver",
+            Justification = @"We have set this in line 99 and 115. This is a false positive. https://msdn.microsoft.com/en-us/library/mt661872.aspx")]
         private void Load(Stream stream, string path)
         {
             var readerSettings = new XmlReaderSettings
@@ -113,7 +115,9 @@ namespace Microsoft.Fx.Portability
                         XmlResolver = null
                     };
 
-                    schemas.Add(null, XmlReader.Create(xsdStream, xmlReaderSettings));
+                    var reader = XmlReader.Create(xsdStream, xmlReaderSettings);
+
+                    schemas.Add(null, reader);
                     doc.Validate(schemas, (s, e) => { throw new TargetMapperException(e.Message, e.Exception); });
                 }
 #endif

--- a/src/Microsoft.Fx.Portability/Utils/FormattableStringHelper.cs
+++ b/src/Microsoft.Fx.Portability/Utils/FormattableStringHelper.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.Fx.Portability.Utils
+{
+    public static class FormattableStringHelper
+    {
+        public static string ToCurrentCulture(FormattableString formattableString) => formattableString.ToString(CultureInfo.CurrentCulture);
+    }
+}


### PR DESCRIPTION
* Suppresses CA3053 again. The issue is a false negative
* Fixes globalisation issues with interpolated strings
* Add FormattableStringHelper to ease the need to cast an interpolated string to `(FormattableString)` and then perform a `.ToString(CultureInfo.CurrentCulture)`