### PR TITLE
Fix minor typos in Linux/Mac instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Download and build for yourself:
 4. Run ApiPort by executing: `dotnet ApiPort.dll`
   * Example: `dotnet ApiPort.dll listTargets`
   * Example: `dotnet ApiPort.dll analyze -f Foo.dll -r HTML`
-5. For convenience, create an alias command adding the following to your ~/.bash_profile. Replace `{dotnent-apiport-folder}` with the path where you cloned the repo.
+5. For convenience, create an alias command adding the following to your ~/.bash_profile. Replace `{dotnet-apiport-folder}` with the path where you cloned the repo.
 ```
-alias apiport='dotnet {dotnet-apiport-folder}/bin/Debug/ApiPort/netcoreapp2.0/ApiPort.dll"
+alias apiport="dotnet {dotnet-apiport-folder}/bin/Debug/ApiPort/netcoreapp2.0/ApiPort.dll"
 ```
-This will alow you to use apiport globally from the command line: `airport analyze -f Foo.dll -r HTML`
+This will alow you to use apiport globally from the command line: `apiport analyze -f Foo.dll -r HTML`
 
 ## Documentation
 


### PR DESCRIPTION
Address some small typos in the README file.