### PR TITLE
Add YAML for VSTS CI

### DIFF
--- a/vsts.ci.yaml
+++ b/vsts.ci.yaml
@@ -58,7 +58,7 @@ steps:
   inputs:
     solution: PortabilityTools.sln
     vsVersion: 15.0
-    msbuildArgs: '/t:build /bl'
+    msbuildArgs: '/t:build /bl:$(Build.SourcesDirectory)\bin\$(BuildConfiguration)\msbuild.binlog'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
 

--- a/vsts.ci.yaml
+++ b/vsts.ci.yaml
@@ -1,0 +1,132 @@
+resources:
+- repo: self
+  clean: true
+queue:
+  name: VSEng-MicroBuildVS2017
+  demands:
+  - DotNetFramework
+  - msbuild
+  - visualstudio
+  - vstest
+
+variables:
+  SigningType: 'Test'
+
+steps:
+- task: PowerShell@1
+  inputs:
+    scriptType: inlineScript
+    inlineScript: |
+     Write-Host "Set variable: variable=NuGetPackagesDirectory to $env:Build_SourcesDirectory\packages"
+     Write-Host "##vso[task.setvariable variable=NuGetPackagesDirectory;]$env:Build_SourcesDirectory\packages"
+     $outputFolder = "$($env:Build_SourcesDirectory)\bin\$($env:BuildConfiguration)"
+     Write-Host "This is the output folder: $outputFolder"
+     if (!$(Test-Path $outputFolder)) {
+         New-Item $outputFolder -ItemType Directory
+     }
+
+- task: PowerShell@1
+  inputs:
+    scriptName: init.ps1
+
+- task: MicroBuildSigningPlugin@1
+  inputs:
+    signType: '$(SigningType)'
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+  inputs:
+    optionsFC: 0
+    optionsXS: 0
+    optionsHMENABLE: 0
+  continueOnError: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+  inputs:
+    debugMode: false
+  continueOnError: true
+
+- task: VSBuild@1
+  inputs:
+    solution: PortabilityTools.sln
+    vsVersion: 15.0
+    msbuildArgs: '/t:restore'
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
+    clean: true
+
+- task: VSBuild@1
+  inputs:
+    solution: PortabilityTools.sln
+    vsVersion: 15.0
+    msbuildArgs: '/t:build /bl'
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
+
+- task: VSTest@2
+  inputs:
+    testAssemblyVer2: |
+     **\*test*.dll
+     !**\obj\**
+     !**\PortabilityServiceIntegrationTests.dll
+    runOnlyImpactedTests: false
+    vsTestVersion: 15.0
+    runInParallel: false
+    runTestsInIsolation: false
+    codeCoverageEnabled: false
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
+
+- task: CopyFiles@2
+  inputs:
+    SourceFolder: 'bin\$(BuildConfiguration)'
+    TargetFolder: '$(Build.StagingDirectory)\$(Build.BuildNumber)'
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: '$(Build.StagingDirectory)'
+    ArtifactName: '$(Build.BuildNumber)'
+    ArtifactType: Container
+
+- task: CopyFiles@2
+  inputs:
+    SourceFolder: 'bin\$(BuildConfiguration)'
+    Contents: '**\*.pdb'
+    TargetFolder: '$(Build.StagingDirectory)\symbols'
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: '$(Build.StagingDirectory)\symbols'
+    ArtifactName: symbols
+    ArtifactType: Container
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-fxcop.FxCop@2
+  inputs:
+    inputType: Basic
+    targets: '$(Build.StagingDirectory)\$(Build.BuildNumber)\ApiPort\net461\win7-x64\ApiPort.exe;$(Build.StagingDirectory)\$(Build.BuildNumber)\ApiPort.VisualStudio\ApiPort.VisualStudio.2015.dll;$(Build.StagingDirectory)\$(Build.BuildNumber)\ApiPort.VisualStudio\ApiPort.VisualStudio.2017.dll;$(Build.StagingDirectory)\$(Build.BuildNumber)\Microsoft.Fx.Portability\net46\Microsoft.Fx.Portability.dll;$(Build.StagingDirectory)\$(Build.BuildNumber)\ApiPort.VisualStudio\ApiPort.VisualStudio.Common.dll;$(Build.StagingDirectory)\$(Build.BuildNumber)\Microsoft.Fx.Portability.Reports.Html\net46\Microsoft.Fx.Portability.Reports.Html.dll'
+    recursive: false
+    verbose: true
+    toolVersion: 14.0.23107.0
+  continueOnError: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
+  inputs:
+    InputType: Basic
+    AnalyzeTarget: '$(Build.StagingDirectory)\$(Build.BuildNumber)\Microsoft.Fx.*.dll;$(Build.StagingDirectory)\$(Build.BuildNumber)\ApiPor*.dll;$(Build.StagingDirectory)\$(Build.BuildNumber)\ApiPor*.exe'
+    AnalyzeSymPath: '$(Build.StagingDirectory)\symbols'
+  continueOnError: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-apiscan.APIScan@1
+  inputs:
+    softwareFolder: '$(Build.StagingDirectory)\$(Build.BuildNumber)'
+    softwareName: 'C#'
+    softwareVersionNum: 4.XX
+    symbolsFolder: '$(Build.StagingDirectory)\symbols'
+    isLargeApp: false
+    verbosityLevel: none
+  continueOnError: true
+  enabled: false
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+  condition: succeededOrFailed()
+
+- task: MicroBuildCleanup@1


### PR DESCRIPTION
This adds a YAML file specifying our CI build. Basically the `dev` CI process minus packing nupkgs and running APIScan (note there's a task for APIScan; I've disabled it because it's slow).