### PR TITLE
Add netstandard as a possible home for System.Object

### DIFF
--- a/src/Microsoft.Fx.Portability.MetadataReader/SystemObjectFinder.cs
+++ b/src/Microsoft.Fx.Portability.MetadataReader/SystemObjectFinder.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Fx.Portability.Analyzer
         private static readonly HashSet<string> s_systemObjectAssemblies = new HashSet<string>(StringComparer.Ordinal)
         {
             "mscorlib",
+            "netstandard",
             "System.Runtime",
             "System.Private.CoreLib"
         };

--- a/src/Microsoft.Fx.Portability/Analyzer/DotNetFrameworkFilter.cs
+++ b/src/Microsoft.Fx.Portability/Analyzer/DotNetFrameworkFilter.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Fx.Portability.Analyzer
             "0738eb9f132ed756", // Mono
             "ddd0da4d3e678217", // Component model
             "84e04ff9cfb79065", // Mono Android
-            "842cf8be1de50553"  // Xamarin.iOS
+            "842cf8be1de50553", // Xamarin.iOS
+            "cc7b13ffcd2ddd51"  // NetStandard
         }, StringComparer.OrdinalIgnoreCase);
 
         private static readonly IEnumerable<string> s_frameworkAssemblyNamePrefixes = new[]


### PR DESCRIPTION
This is needed in case of .NET Standard NetFx facade assemblies
which won't have references to mscorlib or System.Runtime.

Prior to this change, ApiPort was failing when analyzing .NET Framework facade assemblies since they didn't have references to the usual 'base' assemblies (system.runtime, mscorlib, etc.).