### PR TITLE
Set all variables for CI build in yaml

### DIFF
--- a/vsts.ci.yaml
+++ b/vsts.ci.yaml
@@ -10,6 +10,8 @@ queue:
   - vstest
 
 variables:
+  BuildConfiguration: 'Release'
+  BuildPlatform: 'any cpu'
   SigningType: 'Test'
   TeamName: 'dotnet-apiport'
 

--- a/vsts.ci.yaml
+++ b/vsts.ci.yaml
@@ -11,6 +11,7 @@ queue:
 
 variables:
   SigningType: 'Test'
+  TeamName: 'dotnet-apiport'
 
 steps:
 - task: PowerShell@1


### PR DESCRIPTION
A convenient way to ensure every required value will be set and documented in yaml. One side effect is that these values then can't be overridden. But given the build's purpose, it seems unlikely we'd want to do so.