### PR TITLE
Accessibility fixes for VSIX

### DIFF
--- a/src/ApiPort/ApiPort.VisualStudio.Common/Resources/LocalizedStrings.Designer.cs
+++ b/src/ApiPort/ApiPort.VisualStudio.Common/Resources/LocalizedStrings.Designer.cs
@@ -106,6 +106,15 @@ namespace ApiPortVS.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Available reports:.
+        /// </summary>
+        public static string AvailableReports {
+            get {
+                return ResourceManager.GetString("AvailableReports", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Back to summary.
         /// </summary>
         public static string BackToSummary {
@@ -341,6 +350,24 @@ namespace ApiPortVS.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Open Directory.
+        /// </summary>
+        public static string OpenDirectory {
+            get {
+                return ResourceManager.GetString("OpenDirectory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open Report.
+        /// </summary>
+        public static string OpenReport {
+            get {
+                return ResourceManager.GetString("OpenReport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Output formats.
         /// </summary>
         public static string OutputFormats {
@@ -436,6 +463,15 @@ namespace ApiPortVS.Resources {
         public static string ReportNotAvailable {
             get {
                 return ResourceManager.GetString("ReportNotAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Save As.
+        /// </summary>
+        public static string SaveAs {
+            get {
+                return ResourceManager.GetString("SaveAs", resourceCulture);
             }
         }
         

--- a/src/ApiPort/ApiPort.VisualStudio.Common/Resources/LocalizedStrings.resx
+++ b/src/ApiPort/ApiPort.VisualStudio.Common/Resources/LocalizedStrings.resx
@@ -322,4 +322,16 @@ There is no public build for https://github.com/Microsoft/cci yet, which support
   <data name="SelectDefaultOutputDirectory" xml:space="preserve">
     <value>Select default output directory</value>
   </data>
+  <data name="AvailableReports" xml:space="preserve">
+    <value>Available reports:</value>
+  </data>
+  <data name="OpenDirectory" xml:space="preserve">
+    <value>Open Directory</value>
+  </data>
+  <data name="OpenReport" xml:space="preserve">
+    <value>Open Report</value>
+  </data>
+  <data name="SaveAs" xml:space="preserve">
+    <value>Save As</value>
+  </data>
 </root>

--- a/src/ApiPort/ApiPort.VisualStudio.Common/ViewModels/OutputViewModel.cs
+++ b/src/ApiPort/ApiPort.VisualStudio.Common/ViewModels/OutputViewModel.cs
@@ -4,6 +4,7 @@
 using ApiPortVS.Resources;
 using Microsoft.Win32;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
@@ -24,8 +25,12 @@ namespace ApiPortVS.ViewModels
         public ICommand OpenDirectory { get; }
 
         public OutputViewModel()
+            : this(Enumerable.Empty<string>())
+        { }
+
+        public OutputViewModel(IEnumerable<string> existingReports)
         {
-            Paths = new ObservableCollection<string>();
+            Paths = new ObservableCollection<string>(existingReports);
             SaveAs = new DelegateCommand<string>(SaveFileAs);
             OpenFile = new DelegateCommand<string>(path =>
             {

--- a/src/ApiPort/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
+++ b/src/ApiPort/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
@@ -143,11 +143,21 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Page Include="Resources\UtilsResourceDictionary.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Views\AnalysisOutputToolWindowControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\OptionsPageControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="Resources\ResourceDictionary.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/ApiPort/ApiPort.VisualStudio/Resources/ResourceDictionary.xaml
+++ b/src/ApiPort/ApiPort.VisualStudio/Resources/ResourceDictionary.xaml
@@ -14,6 +14,23 @@
         <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:EnvironmentColors.DialogTextBrushKey}}" />
     </Style>
 
+    <Style x:Key="HyperlinkFocusVisualStyleKey">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle SnapsToDevicePixels="true"
+                               Margin="0"
+                               Stroke="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"
+                               StrokeDashArray="1 2" StrokeThickness="1" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ToolWindowHyperlinkStyle" TargetType="Hyperlink">
+        <Setter Property="FocusVisualStyle" Value="{StaticResource HyperlinkFocusVisualStyleKey}" />
+    </Style>
+
     <!-- For the tool window because it has a different colour scheme than the options page. -->
     <Style x:Key="ToolWindowTextBlockStyle" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="{DynamicResource VsFont.EnvironmentFontFamily}" />

--- a/src/ApiPort/ApiPort.VisualStudio/Resources/ResourceDictionary.xaml
+++ b/src/ApiPort/ApiPort.VisualStudio/Resources/ResourceDictionary.xaml
@@ -14,6 +14,13 @@
         <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:EnvironmentColors.DialogTextBrushKey}}" />
     </Style>
 
+    <!-- For the tool window because it has a different colour scheme than the options page. -->
+    <Style x:Key="ToolWindowTextBlockStyle" TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="{DynamicResource VsFont.EnvironmentFontFamily}" />
+        <Setter Property="FontSize" Value="{DynamicResource VsFont.EnvironmentFontSize}" />
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}" />
+    </Style>
+    
     <!-- Group Box -->
     <Style x:Key="GroupBoxStyle" TargetType="GroupBox">
         <Setter Property="BorderBrush" Value="{DynamicResource CommonControls.CheckBoxBorder}" />

--- a/src/ApiPort/ApiPort.VisualStudio/Resources/ResourceDictionary.xaml
+++ b/src/ApiPort/ApiPort.VisualStudio/Resources/ResourceDictionary.xaml
@@ -1,0 +1,22 @@
+﻿<ResourceDictionary 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.14.0">
+    <!-- Style Guidance
+        1. Text: https://docs.microsoft.com/en-us/visualstudio/extensibility/ux-guidelines/fonts-and-formatting-for-visual-studio#BKMK_TextStyle
+        2. Brushes: https://docs.microsoft.com/en-us/visualstudio/extensibility/ux-guidelines/shared-colors-for-visual-studio#ui-text
+    -->
+    <Style x:Key="ContentTextBlockStyle" TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="{DynamicResource VsFont.EnvironmentFontFamily}" />
+        <Setter Property="FontSize" Value="{DynamicResource VsFont.EnvironmentFontSize}" />
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:EnvironmentColors.DialogTextBrushKey}}" />
+    </Style>
+
+    <!-- Group Box -->
+    <Style x:Key="GroupBoxStyle" TargetType="GroupBox">
+        <Setter Property="BorderBrush" Value="{DynamicResource CommonControls.CheckBoxBorder}" />
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:EnvironmentColors.DialogTextBrushKey}}" />
+    </Style>
+</ResourceDictionary>

--- a/src/ApiPort/ApiPort.VisualStudio/Resources/ResourceDictionary.xaml
+++ b/src/ApiPort/ApiPort.VisualStudio/Resources/ResourceDictionary.xaml
@@ -28,49 +28,6 @@
     </Style>
 
     <Style x:Key="ToolWindowListBoxItemStyle" TargetType="ListBoxItem">
-        <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="ListBoxItem">
-                    <Border x:Name="Border"
-                            Padding="2"
-                            SnapsToDevicePixels="true">
-                        <Border.BorderBrush>
-                            <SolidColorBrush Color="Transparent" />
-                        </Border.BorderBrush>
-                        <Border.Background>
-                            <SolidColorBrush Color="Transparent" />
-                        </Border.Background>
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="SelectionStates">
-                                <VisualState x:Name="Unselected" /> 
-                                <VisualState x:Name="Selected">
-                                    <Storyboard>
-                                        <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border"
-                                                                      Storyboard.TargetProperty="BorderBrush">
-                                            <EasingColorKeyFrame KeyTime="0" Value="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextColorKey}}" />
-                                        </ColorAnimationUsingKeyFrames>
-                                        <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border"
-                                                                      Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)">
-                                            <EasingColorKeyFrame KeyTime="0" Value="Transparent" />
-                                        </ColorAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="SelectedUnfocused">
-                                    <Storyboard>
-                                        <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border"
-                                                                      Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)">
-                                            <EasingColorKeyFrame KeyTime="0" Value="Transparent" />
-                                            <!--<EasingColorKeyFrame KeyTime="0" Value="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTabMouseOverBorderColorKey}}" />-->
-                                        </ColorAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                            </VisualStateGroup>
-                        </VisualStateManager.VisualStateGroups>
-                        <ContentPresenter />
-                    </Border>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
+        <Setter Property="Focusable" Value="False" />
     </Style>
 </ResourceDictionary>

--- a/src/ApiPort/ApiPort.VisualStudio/Resources/ResourceDictionary.xaml
+++ b/src/ApiPort/ApiPort.VisualStudio/Resources/ResourceDictionary.xaml
@@ -20,10 +20,57 @@
         <Setter Property="FontSize" Value="{DynamicResource VsFont.EnvironmentFontSize}" />
         <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}" />
     </Style>
-    
+
     <!-- Group Box -->
     <Style x:Key="GroupBoxStyle" TargetType="GroupBox">
         <Setter Property="BorderBrush" Value="{DynamicResource CommonControls.CheckBoxBorder}" />
         <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:EnvironmentColors.DialogTextBrushKey}}" />
+    </Style>
+
+    <Style x:Key="ToolWindowListBoxItemStyle" TargetType="ListBoxItem">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ListBoxItem">
+                    <Border x:Name="Border"
+                            Padding="2"
+                            SnapsToDevicePixels="true">
+                        <Border.BorderBrush>
+                            <SolidColorBrush Color="Transparent" />
+                        </Border.BorderBrush>
+                        <Border.Background>
+                            <SolidColorBrush Color="Transparent" />
+                        </Border.Background>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="SelectionStates">
+                                <VisualState x:Name="Unselected" /> 
+                                <VisualState x:Name="Selected">
+                                    <Storyboard>
+                                        <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border"
+                                                                      Storyboard.TargetProperty="BorderBrush">
+                                            <EasingColorKeyFrame KeyTime="0" Value="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextColorKey}}" />
+                                        </ColorAnimationUsingKeyFrames>
+                                        <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border"
+                                                                      Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)">
+                                            <EasingColorKeyFrame KeyTime="0" Value="Transparent" />
+                                        </ColorAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="SelectedUnfocused">
+                                    <Storyboard>
+                                        <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border"
+                                                                      Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)">
+                                            <EasingColorKeyFrame KeyTime="0" Value="Transparent" />
+                                            <!--<EasingColorKeyFrame KeyTime="0" Value="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTabMouseOverBorderColorKey}}" />-->
+                                        </ColorAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <ContentPresenter />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 </ResourceDictionary>

--- a/src/ApiPort/ApiPort.VisualStudio/Resources/UtilsResourceDictionary.xaml
+++ b/src/ApiPort/ApiPort.VisualStudio/Resources/UtilsResourceDictionary.xaml
@@ -1,9 +1,10 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:utils="clr-namespace:ApiPortVS.Utils">
-    
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:utils="clr-namespace:ApiPortVS.Utils">
+
     <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
     <utils:HideWhenTrueBoolConverter x:Key="HideWhenTrue" />
     <utils:TargetInformationStringConverter x:Key="TargetInformationString" />
     <utils:TargetPlatformDisplayNameConverter x:Key="TargetPlatformDisplayName" />
+    <utils:PathToFileNameConverter x:Key="PathToFileNameConverter" />
 </ResourceDictionary>

--- a/src/ApiPort/ApiPort.VisualStudio/Resources/UtilsResourceDictionary.xaml
+++ b/src/ApiPort/ApiPort.VisualStudio/Resources/UtilsResourceDictionary.xaml
@@ -1,0 +1,9 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:utils="clr-namespace:ApiPortVS.Utils">
+    
+    <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+    <utils:HideWhenTrueBoolConverter x:Key="HideWhenTrue" />
+    <utils:TargetInformationStringConverter x:Key="TargetInformationString" />
+    <utils:TargetPlatformDisplayNameConverter x:Key="TargetPlatformDisplayName" />
+</ResourceDictionary>

--- a/src/ApiPort/ApiPort.VisualStudio/ServiceProvider.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/ServiceProvider.cs
@@ -206,16 +206,21 @@ namespace ApiPortVS
 
             if (string.IsNullOrEmpty(viewModel.OutputDirectory))
             {
-                return new OutputViewModel();
             }
 
             var directory = new DirectoryInfo(viewModel.OutputDirectory);
+
+            if (!directory.Exists)
+            {
+                return new OutputViewModel();
+            }
+
             var validExtensions = new HashSet<string>(viewModel.Formats.Select(x => x.FileExtension).Distinct());
             var matchAnything = validExtensions.Count == 0;
 
             var validReports = directory.EnumerateFiles().Where(x => matchAnything || validExtensions.Contains(x.Extension));
 
-            if (!directory.Exists || !validReports.Any())
+            if (!validReports.Any())
             {
                 return new OutputViewModel();
             }

--- a/src/ApiPort/ApiPort.VisualStudio/ServiceProvider.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/ServiceProvider.cs
@@ -199,11 +199,6 @@ namespace ApiPortVS
         private static OutputViewModel GetOutputViewModel(IComponentContext context)
         {
             var viewModel = context.Resolve<OptionsViewModel>();
-
-            if (string.IsNullOrEmpty(viewModel.OutputDirectory))
-            {
-            }
-
             var directory = new DirectoryInfo(viewModel.OutputDirectory);
 
             if (!directory.Exists)
@@ -212,11 +207,12 @@ namespace ApiPortVS
             }
 
             var validExtensions = new HashSet<string>(viewModel.Formats.Select(x => x.FileExtension).Distinct());
-            var matchAnything = validExtensions.Count == 0;
 
-            var validReports = directory.EnumerateFiles().Where(x => matchAnything || validExtensions.Contains(x.Extension));
+            var validReports = directory.EnumerateFiles().Where(x => validExtensions.Contains(x.Extension));
 
-            if (!validReports.Any())
+            // If there are no report file extensions we support,
+            // or if there are no matching reports, return a new view model
+            if (!validExtensions.Any() || !validReports.Any())
             {
                 return new OutputViewModel();
             }

--- a/src/ApiPort/ApiPort.VisualStudio/ServiceProvider.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/ServiceProvider.cs
@@ -99,10 +99,6 @@ namespace ApiPortVS
                 .As<OutputViewModel>()
                 .SingleInstance();
 
-            //builder.RegisterInstance(AnalysisOutputToolWindowControl.Model)
-            //    .As<OutputViewModel>()
-            //    .SingleInstance();
-
             // Register menu handlers
             builder.RegisterType<AnalyzeMenu>()
                 .AsSelf()

--- a/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindow.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindow.cs
@@ -34,10 +34,10 @@ namespace ApiPortVS
             // This is the user control hosted by the tool window; Note that, even if this class implements IDisposable,
             // we are not calling Dispose on this object. This is because ToolWindowPane calls Dispose on
             // the object returned by the Content property.
-            var control = new AnalysisOutputToolWindowControl();
-            control.DataContext = viewModel;
-
-            this.Content = control;
+            this.Content = new AnalysisOutputToolWindowControl
+            {
+                DataContext = viewModel
+            };
         }
     }
 }

--- a/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindow.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindow.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using ApiPortVS.Resources;
+using ApiPortVS.ViewModels;
 using Microsoft.VisualStudio.Shell;
 using System;
 using System.Runtime.InteropServices;
@@ -27,12 +28,16 @@ namespace ApiPortVS
         /// </summary>
         public AnalysisOutputToolWindow() : base(null)
         {
+            var viewModel = ApiPortVSPackage.LocalServiceProvider.GetService(typeof(OutputViewModel)) as OutputViewModel;
             this.Caption = LocalizedStrings.PortabilityAnalysisResults;
 
             // This is the user control hosted by the tool window; Note that, even if this class implements IDisposable,
             // we are not calling Dispose on this object. This is because ToolWindowPane calls Dispose on
             // the object returned by the Content property.
-            this.Content = new AnalysisOutputToolWindowControl();
+            var control = new AnalysisOutputToolWindowControl();
+            control.DataContext = viewModel;
+
+            this.Content = control;
         }
     }
 }

--- a/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindowControl.xaml
+++ b/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindowControl.xaml
@@ -2,59 +2,78 @@
 Copyright (c) Microsoft. All rights reserved.
 Licensed under the MIT license. See LICENSE file in the project root for full license information.
 -->
-
 <UserControl x:Class="ApiPortVS.AnalysisOutputToolWindowControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:utils="clr-namespace:ApiPortVS.Utils"
-             Background="{DynamicResource VsBrush.Window}"
-             Foreground="{DynamicResource VsBrush.WindowText}"
+             xmlns:const="clr-namespace:ApiPortVS.Resources;assembly=ApiPort.VisualStudio.Common"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="300"
              Name="PortabilityResultsToolbar">
-
     <UserControl.Resources>
-        <utils:PathToFileNameConverter x:Key="PathToFileName" />
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Resources/ResourceDictionary.xaml" />
+                <ResourceDictionary Source="../Resources/UtilsResourceDictionary.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </UserControl.Resources>
-
     <Grid>
-        <ScrollViewer>
-            <StackPanel>
-                <TextBlock FontWeight="Bold" Text="Available reports:" />
-                <ItemsControl Margin="20,10,0,0" ItemsSource="{Binding Path=Paths}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                    <ItemsControl.ItemTemplate>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+        <TextBlock Text="{x:Static const:LocalizedStrings.AvailableReports}"
+                   Margin="5"
+                   FontWeight="Bold"
+                   Grid.Row="0"/>
+        <Grid Grid.Row="1">
+            <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+                <ListView ItemsSource="{Binding Paths}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
+                    <ListView.ItemTemplate>
                         <DataTemplate>
-                            <Grid HorizontalAlignment="Stretch" Margin="0,5,0,0">
+                            <Grid Margin="0,5">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
-
-                                <TextBlock Grid.Column="0" Text="{Binding Path=., Converter={StaticResource PathToFileName}}" Margin="5,0,5,0" />
-                                <TextBlock Grid.Column="1" Margin="5,0,5,0">
-                                <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=DataContext.OpenFile}" CommandParameter="{Binding}">
-                                    <TextBlock Text="Open Report" />
-                                </Hyperlink>
-                            </TextBlock>
-                                <TextBlock Grid.Column="3" Margin="5,0,5,0">
-                                <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=DataContext.OpenDirectory}" CommandParameter="{Binding}">
-                                    <TextBlock Text="Open directory" />
-                                </Hyperlink>
-                            </TextBlock>
-                                <TextBlock Grid.Column="2" Margin="5,0,5,0">
-                                <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=DataContext.SaveAs}" CommandParameter="{Binding}">
-                                    <TextBlock Text="Save As" />
-                                </Hyperlink>
-                            </TextBlock>
+                                <TextBlock Text="{Binding Path=., Converter={StaticResource PathToFileNameConverter}}"
+                                           AutomationProperties.Name="{Binding Path=., Converter={StaticResource PathToFileNameConverter}}"
+                                           Style="{DynamicResource ContentTextBlockStyle}"
+                                           Margin="5,0"
+                                           Grid.Column="0"/>
+                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Left"
+                                            Grid.Column="2">
+                                    <TextBlock Margin="5,0">
+                                        <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ListView}, Path=DataContext.OpenFile}"
+                                                   CommandParameter="{Binding}">
+                                            <TextBlock Text="{x:Static const:LocalizedStrings.OpenReport}"
+                                                       AutomationProperties.Name="{x:Static const:LocalizedStrings.OpenReport}"
+                                                       Style="{DynamicResource ContentTextBlockStyle}" />
+                                        </Hyperlink>
+                                    </TextBlock>
+                                    <TextBlock Margin="5,0">
+                                        <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=DataContext.OpenDirectory}" CommandParameter="{Binding}">
+                                            <TextBlock Text="{x:Static const:LocalizedStrings.OpenDirectory}"
+                                                       AutomationProperties.Name="{x:Static const:LocalizedStrings.OpenDirectory}"
+                                                       Style="{DynamicResource ContentTextBlockStyle}" />
+                                        </Hyperlink>
+                                    </TextBlock>
+                                    <TextBlock Margin="5,0">
+                                        <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=DataContext.SaveAs}" CommandParameter="{Binding}">
+                                            <TextBlock Text="{x:Static const:LocalizedStrings.SaveAs}"
+                                                       AutomationProperties.Name="{x:Static const:LocalizedStrings.SaveAs}"
+                                                       Style="{DynamicResource ContentTextBlockStyle}" />
+                                        </Hyperlink>
+                                    </TextBlock>
+                                </StackPanel>
                             </Grid>
                         </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-        </ScrollViewer>
+                    </ListView.ItemTemplate>
+                </ListView>
+            </ScrollViewer>
+        </Grid>
     </Grid>
 </UserControl>

--- a/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindowControl.xaml
+++ b/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindowControl.xaml
@@ -62,7 +62,8 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                                             Grid.Column="2">
                                     <TextBlock Margin="5,0">
                                         <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ListView}, Path=DataContext.OpenFile}"
-                                                   CommandParameter="{Binding}">
+                                                   CommandParameter="{Binding}"
+                                                   Style="{DynamicResource ToolWindowHyperlinkStyle}">
                                             <TextBlock Text="{x:Static const:LocalizedStrings.OpenReport}"
                                                        AutomationProperties.Name="{x:Static const:LocalizedStrings.OpenReport}"
                                                        KeyboardNavigation.IsTabStop="true"
@@ -70,7 +71,9 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                                         </Hyperlink>
                                     </TextBlock>
                                     <TextBlock Margin="5,0">
-                                        <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=DataContext.OpenDirectory}" CommandParameter="{Binding}">
+                                        <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=DataContext.OpenDirectory}"
+                                                   CommandParameter="{Binding}"
+                                                   Style="{DynamicResource ToolWindowHyperlinkStyle}">
                                             <TextBlock Text="{x:Static const:LocalizedStrings.OpenDirectory}"
                                                        AutomationProperties.Name="{x:Static const:LocalizedStrings.OpenDirectory}"
                                                        KeyboardNavigation.IsTabStop="true"
@@ -78,7 +81,9 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                                         </Hyperlink>
                                     </TextBlock>
                                     <TextBlock Margin="5,0">
-                                        <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=DataContext.SaveAs}" CommandParameter="{Binding}">
+                                        <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=DataContext.SaveAs}"
+                                                   CommandParameter="{Binding}"
+                                                   Style="{DynamicResource ToolWindowHyperlinkStyle}">
                                             <TextBlock Text="{x:Static const:LocalizedStrings.SaveAs}"
                                                        AutomationProperties.Name="{x:Static const:LocalizedStrings.SaveAs}"
                                                        KeyboardNavigation.IsTabStop="true"

--- a/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindowControl.xaml
+++ b/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindowControl.xaml
@@ -29,11 +29,19 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                    FontWeight="Bold"
                    Grid.Row="0"/>
         <Grid Grid.Row="1">
-            <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
-                <ListView ItemsSource="{Binding Paths}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Auto"
+                          IsTabStop="False">
+                <ListView ItemsSource="{Binding Paths}"
+                          HorizontalAlignment="Stretch"
+                          HorizontalContentAlignment="Stretch"
+                          KeyboardNavigation.TabNavigation="Continue"
+                          IsTabStop="False">
                     <ListView.ItemTemplate>
                         <DataTemplate>
-                            <Grid Margin="0,5">
+                            <Grid Margin="0,5"
+                                  KeyboardNavigation.TabNavigation="Continue"
+                                  KeyboardNavigation.IsTabStop="false">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="*" />
@@ -45,12 +53,14 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                                            Margin="5,0"
                                            Grid.Column="0"/>
                                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Left"
+                                            KeyboardNavigation.TabNavigation="Continue"
                                             Grid.Column="2">
                                     <TextBlock Margin="5,0">
                                         <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ListView}, Path=DataContext.OpenFile}"
                                                    CommandParameter="{Binding}">
                                             <TextBlock Text="{x:Static const:LocalizedStrings.OpenReport}"
                                                        AutomationProperties.Name="{x:Static const:LocalizedStrings.OpenReport}"
+                                                       KeyboardNavigation.IsTabStop="true"
                                                        Style="{DynamicResource ContentTextBlockStyle}" />
                                         </Hyperlink>
                                     </TextBlock>
@@ -58,6 +68,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                                         <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=DataContext.OpenDirectory}" CommandParameter="{Binding}">
                                             <TextBlock Text="{x:Static const:LocalizedStrings.OpenDirectory}"
                                                        AutomationProperties.Name="{x:Static const:LocalizedStrings.OpenDirectory}"
+                                                       KeyboardNavigation.IsTabStop="true"
                                                        Style="{DynamicResource ContentTextBlockStyle}" />
                                         </Hyperlink>
                                     </TextBlock>
@@ -65,6 +76,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                                         <Hyperlink Command="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=DataContext.SaveAs}" CommandParameter="{Binding}">
                                             <TextBlock Text="{x:Static const:LocalizedStrings.SaveAs}"
                                                        AutomationProperties.Name="{x:Static const:LocalizedStrings.SaveAs}"
+                                                       KeyboardNavigation.IsTabStop="true"
                                                        Style="{DynamicResource ContentTextBlockStyle}" />
                                         </Hyperlink>
                                     </TextBlock>

--- a/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindowControl.xaml
+++ b/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindowControl.xaml
@@ -35,6 +35,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                           Background="Transparent"
                           IsTabStop="False">
                 <ListView ItemsSource="{Binding Paths}"
+                          ItemContainerStyle="{DynamicResource ToolWindowListBoxItemStyle}"
                           HorizontalAlignment="Stretch"
                           HorizontalContentAlignment="Stretch"
                           KeyboardNavigation.TabNavigation="Continue"

--- a/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindowControl.xaml
+++ b/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindowControl.xaml
@@ -25,17 +25,20 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
             <RowDefinition />
         </Grid.RowDefinitions>
         <TextBlock Text="{x:Static const:LocalizedStrings.AvailableReports}"
+                   Style="{DynamicResource ToolWindowTextBlockStyle}"
                    Margin="5"
                    FontWeight="Bold"
                    Grid.Row="0"/>
         <Grid Grid.Row="1">
             <ScrollViewer VerticalScrollBarVisibility="Auto"
                           HorizontalScrollBarVisibility="Auto"
+                          Background="Transparent"
                           IsTabStop="False">
                 <ListView ItemsSource="{Binding Paths}"
                           HorizontalAlignment="Stretch"
                           HorizontalContentAlignment="Stretch"
                           KeyboardNavigation.TabNavigation="Continue"
+                          Background="Transparent"
                           IsTabStop="False">
                     <ListView.ItemTemplate>
                         <DataTemplate>
@@ -49,7 +52,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Text="{Binding Path=., Converter={StaticResource PathToFileNameConverter}}"
                                            AutomationProperties.Name="{Binding Path=., Converter={StaticResource PathToFileNameConverter}}"
-                                           Style="{DynamicResource ContentTextBlockStyle}"
+                                           Style="{DynamicResource ToolWindowTextBlockStyle}"
                                            Margin="5,0"
                                            Grid.Column="0"/>
                                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Left"
@@ -61,7 +64,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                                             <TextBlock Text="{x:Static const:LocalizedStrings.OpenReport}"
                                                        AutomationProperties.Name="{x:Static const:LocalizedStrings.OpenReport}"
                                                        KeyboardNavigation.IsTabStop="true"
-                                                       Style="{DynamicResource ContentTextBlockStyle}" />
+                                                       Style="{DynamicResource ToolWindowTextBlockStyle}" />
                                         </Hyperlink>
                                     </TextBlock>
                                     <TextBlock Margin="5,0">
@@ -69,7 +72,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                                             <TextBlock Text="{x:Static const:LocalizedStrings.OpenDirectory}"
                                                        AutomationProperties.Name="{x:Static const:LocalizedStrings.OpenDirectory}"
                                                        KeyboardNavigation.IsTabStop="true"
-                                                       Style="{DynamicResource ContentTextBlockStyle}" />
+                                                       Style="{DynamicResource ToolWindowTextBlockStyle}" />
                                         </Hyperlink>
                                     </TextBlock>
                                     <TextBlock Margin="5,0">
@@ -77,7 +80,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
                                             <TextBlock Text="{x:Static const:LocalizedStrings.SaveAs}"
                                                        AutomationProperties.Name="{x:Static const:LocalizedStrings.SaveAs}"
                                                        KeyboardNavigation.IsTabStop="true"
-                                                       Style="{DynamicResource ContentTextBlockStyle}" />
+                                                       Style="{DynamicResource ToolWindowTextBlockStyle}" />
                                         </Hyperlink>
                                     </TextBlock>
                                 </StackPanel>

--- a/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindowControl.xaml
+++ b/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindowControl.xaml
@@ -25,6 +25,7 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
             <RowDefinition />
         </Grid.RowDefinitions>
         <TextBlock Text="{x:Static const:LocalizedStrings.AvailableReports}"
+                   AutomationProperties.Name="{x:Static const:LocalizedStrings.AvailableReports}"
                    Style="{DynamicResource ToolWindowTextBlockStyle}"
                    Margin="5"
                    FontWeight="Bold"

--- a/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindowControl.xaml.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/Views/AnalysisOutputToolWindowControl.xaml.cs
@@ -8,16 +8,12 @@ namespace ApiPortVS
 {
     public partial class AnalysisOutputToolWindowControl : UserControl
     {
-        public static OutputViewModel Model { get; } = new OutputViewModel();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AnalysisOutputToolWindowControl"/> class.
         /// </summary>
         public AnalysisOutputToolWindowControl()
         {
             this.InitializeComponent();
-
-            DataContext = Model;
         }
     }
 }

--- a/src/ApiPort/ApiPort.VisualStudio/Views/OptionsPageControl.xaml
+++ b/src/ApiPort/ApiPort.VisualStudio/Views/OptionsPageControl.xaml
@@ -190,7 +190,8 @@
                </Hyperlink>
             </TextBlock>
 
-            <TextBlock Grid.Column="2" FontSize="11" HorizontalAlignment="Right">
+            <TextBlock Grid.Column="2"
+                       HorizontalAlignment="Right">
                 <Hyperlink RequestNavigate="NavigateToMoreInformation"
                            AutomationProperties.Name="{x:Static const:LocalizedStrings.AboutTool}">
                     <TextBlock Text="{x:Static const:LocalizedStrings.AboutTool}"

--- a/src/ApiPort/ApiPort.VisualStudio/Views/OptionsPageControl.xaml
+++ b/src/ApiPort/ApiPort.VisualStudio/Views/OptionsPageControl.xaml
@@ -4,15 +4,15 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:const="clr-namespace:ApiPortVS.Resources;assembly=ApiPort.VisualStudio.Common"
-             xmlns:utils="clr-namespace:ApiPortVS.Utils"
              mc:Ignorable="d"
-             d:DesignHeight="283.5" d:DesignWidth="640" >
-
+             d:DesignHeight="283.5" d:DesignWidth="640">
     <UserControl.Resources>
-        <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
-        <utils:HideWhenTrueBoolConverter x:Key="HideWhenTrue" />
-        <utils:TargetInformationStringConverter x:Key="TargetInformationString" />
-        <utils:TargetPlatformDisplayNameConverter x:Key="TargetPlatformDisplayName" />
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Resources/ResourceDictionary.xaml" />
+                <ResourceDictionary Source="../Resources/UtilsResourceDictionary.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </UserControl.Resources>
 
     <Grid>
@@ -24,52 +24,65 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <TextBlock FontSize="12" FontWeight="DemiBold" Foreground="Red"
+        <TextBlock FontWeight="DemiBold"
                    Text="{Binding ErrorMessage, Mode=OneWay}"
                    Visibility="{Binding HasError, Converter={StaticResource BoolToVisibility}}"
                    Grid.Row="0" />
 
         <GroupBox Header="{x:Static const:LocalizedStrings.GeneralSettings}"
-                  BorderBrush="LightGray" IsTabStop="False"
+                  Style="{DynamicResource GroupBoxStyle}"
+                  IsTabStop="False"
                   Grid.Row="1">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="10" />
-                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="*" />
+                    <RowDefinition />
                     <RowDefinition Height="10" />
-                    <RowDefinition Height="*" />
+                    <RowDefinition />
                 </Grid.RowDefinitions>
 
-                <TextBlock Grid.Column="0" Grid.Row="0" Text="{x:Static const:LocalizedStrings.DefaultOutputDirectory}" />
-                <TextBlock Grid.Column="2" Grid.Row="0" AutomationProperties.HelpText="{Binding OutputDirectory}"
-                           Text="{Binding OutputDirectory}" />
-                <Button Grid.Column="4" Grid.Row="0" Content="..." Click="UpdateDirectoryClick"
+                <TextBlock Text="{x:Static const:LocalizedStrings.DefaultOutputDirectory}"
+                           Style="{DynamicResource ContentTextBlockStyle}"
+                           AutomationProperties.Name="{x:Static const:LocalizedStrings.DefaultOutputDirectory}"
+                           Grid.Column="0" Grid.Row="0" />
+                <TextBlock Text="{Binding OutputDirectory}"
+                           Style="{DynamicResource ContentTextBlockStyle}"
+                           AutomationProperties.HelpText="{Binding OutputDirectory}"
+                           Grid.Column="2" Grid.Row="0" />
+                <Button Content="..."
+                        Click="UpdateDirectoryClick"
                         AutomationProperties.Name="{x:Static const:LocalizedStrings.SelectDefaultOutputDirectory}"
-                        KeyboardNavigation.TabIndex="0" />
-                <TextBlock Grid.Column="0" Grid.Row="2" Text="{x:Static const:LocalizedStrings.DefaultFileName}" />
-                <TextBox Grid.Column="2" Grid.ColumnSpan="2" Grid.Row="2" Text="{Binding DefaultOutputName, Mode=TwoWay}"
+                        KeyboardNavigation.TabIndex="0"
+                        Grid.Column="4" Grid.Row="0" />
+                <TextBlock Text="{x:Static const:LocalizedStrings.DefaultFileName}"
+                           Style="{DynamicResource ContentTextBlockStyle}"
+                           Grid.Column="0" Grid.Row="2" />
+                <TextBox Text="{Binding DefaultOutputName, Mode=TwoWay}"
                          AutomationProperties.Name="{x:Static const:LocalizedStrings.DefaultReportFilename}"
-                         KeyboardNavigation.TabIndex="1" />
+                         KeyboardNavigation.TabIndex="1"
+                         Grid.Column="2" Grid.Row="2" Grid.ColumnSpan="2" />
             </Grid>
         </GroupBox>
 
         <GroupBox Header="{x:Static const:LocalizedStrings.OutputFormats}"
-                  BorderBrush="LightGray" IsTabStop="False"
+                  Style="{DynamicResource GroupBoxStyle}"
+                  IsTabStop="False"
                   Grid.Row="2">
             <DockPanel>
                 <TextBlock Visibility="{Binding UpdatingPlatforms, Converter={StaticResource BoolToVisibility}}"
-                       Text="{x:Static const:LocalizedStrings.RefreshingOutputFormats}"
-                       KeyboardNavigation.IsTabStop="false" KeyboardNavigation.TabIndex="0" Margin="0,5,0,5"/>
-
+                           Text="{x:Static const:LocalizedStrings.RefreshingOutputFormats}"
+                           Style="{DynamicResource ContentTextBlockStyle}"
+                           AutomationProperties.Name="{x:Static const:LocalizedStrings.RefreshingOutputFormats}"
+                           KeyboardNavigation.IsTabStop="false" 
+                           KeyboardNavigation.TabIndex="0" Margin="0,5"/>
                 <ItemsControl ItemsSource="{Binding Path=Formats, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                  Background="Transparent" BorderBrush="Transparent"
-                                  Visibility="{Binding Path=UpdatingPlatforms, Mode=OneWay, Converter={StaticResource HideWhenTrue}}"
-                                  KeyboardNavigation.IsTabStop="False">
+                              Visibility="{Binding Path=UpdatingPlatforms, Mode=OneWay, Converter={StaticResource HideWhenTrue}}"
+                              KeyboardNavigation.IsTabStop="False">
 
                     <ItemsControl.ItemContainerStyle>
                         <Style>
@@ -82,13 +95,14 @@
                             <WrapPanel Orientation="Horizontal" HorizontalAlignment="Stretch" />
                         </ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
-
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}" Content="{Binding DisplayName}"
-                                     KeyboardNavigation.IsTabStop="True" KeyboardNavigation.TabIndex="1"
-                                     Padding="3,0,10,3"
-                                     AutomationProperties.Name="{Binding DisplayName}" />
+                            <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                      Content="{Binding DisplayName}"
+                                      KeyboardNavigation.IsTabStop="True"
+                                      KeyboardNavigation.TabIndex="1"
+                                      AutomationProperties.Name="{Binding DisplayName}"
+                                      Padding="3,0,10,3" />
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
@@ -96,19 +110,23 @@
         </GroupBox>
 
         <GroupBox Header="{x:Static const:LocalizedStrings.TargetPlatforms}"
-                  BorderBrush="LightGray" IsTabStop="False"
+                  Style="{DynamicResource GroupBoxStyle}"
+                  IsTabStop="False"
                   Grid.Row="3">
             <DockPanel>
                 <TextBlock Visibility="{Binding UpdatingPlatforms, Converter={StaticResource BoolToVisibility}}"
-                       Text="{x:Static const:LocalizedStrings.RefreshingPlatforms}"
-                       KeyboardNavigation.IsTabStop="false" KeyboardNavigation.TabIndex="0" Margin="0,5,0,5"/>
+                           Text="{x:Static const:LocalizedStrings.RefreshingPlatforms}"
+                           KeyboardNavigation.IsTabStop="false"
+                           KeyboardNavigation.TabIndex="0"
+                           Margin="0,5,0,5"/>
 
-                <ScrollViewer VerticalScrollBarVisibility="Auto" KeyboardNavigation.IsTabStop="False" IsTabStop="False">
+                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                              KeyboardNavigation.IsTabStop="False"
+                              IsTabStop="False">
                     <ItemsControl ItemsSource="{Binding Path=Targets, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                  Background="Transparent" BorderBrush="Transparent" Name="platformList"
                                   Visibility="{Binding Path=UpdatingPlatforms, Mode=OneWay, Converter={StaticResource HideWhenTrue}}"
+                                  Background="Transparent" BorderBrush="Transparent"
                                   KeyboardNavigation.IsTabStop="False">
-
                         <ItemsControl.ItemContainerStyle>
                             <Style>
                                 <Setter Property="Control.Margin" Value="5,5,0,0" />
@@ -118,9 +136,13 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <DockPanel LastChildFill="True">
-                                    <TextBlock Text="{Binding Converter={StaticResource TargetPlatformDisplayName}}" DockPanel.Dock="Top" />
-                                    <ItemsControl ItemsSource="{Binding Path=Versions}" Margin="10,5,0,0"
-                                                  KeyboardNavigation.DirectionalNavigation="Local" KeyboardNavigation.IsTabStop="False">
+                                    <TextBlock Text="{Binding Converter={StaticResource TargetPlatformDisplayName}}"
+                                               Style="{DynamicResource ContentTextBlockStyle}"
+                                               DockPanel.Dock="Top" />
+                                    <ItemsControl ItemsSource="{Binding Path=Versions}"
+                                                  Margin="10,5,0,0"
+                                                  KeyboardNavigation.DirectionalNavigation="Local"
+                                                  KeyboardNavigation.IsTabStop="False">
                                         <ItemsControl.ItemsPanel>
                                             <ItemsPanelTemplate>
                                                 <WrapPanel Orientation="Horizontal" HorizontalAlignment="Stretch" />
@@ -128,10 +150,12 @@
                                         </ItemsControl.ItemsPanel>
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>
-                                                <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}" Content="{Binding Version}"
-                                                          KeyboardNavigation.IsTabStop="True" KeyboardNavigation.TabIndex="1"
-                                                          Padding="3,0,10,3"
-                                                          AutomationProperties.Name="{Binding Converter={StaticResource TargetInformationString}}" />
+                                                <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                                          Content="{Binding Version}"
+                                                          KeyboardNavigation.IsTabStop="True"
+                                                          KeyboardNavigation.TabIndex="1"
+                                                          AutomationProperties.Name="{Binding Converter={StaticResource TargetInformationString}}"
+                                                          Padding="3,0,10,3" />
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>
@@ -149,34 +173,39 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="10" />
-                <ColumnDefinition Width="*" />
+                <ColumnDefinition />
                 <ColumnDefinition Width="10" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <TextBlock Grid.Column="0" FontSize="11" HorizontalAlignment="Left"
-                Visibility="{Binding UpdatingPlatforms, Converter={StaticResource HideWhenTrue}}">
+            <TextBlock HorizontalAlignment="Left"
+                       Visibility="{Binding UpdatingPlatforms, Converter={StaticResource HideWhenTrue}}"
+                       Grid.Column="0">
                <Hyperlink Click="RefreshRequested"
                           AutomationProperties.Name="{x:Static const:LocalizedStrings.Refresh}">
                   <TextBlock Text="{x:Static const:LocalizedStrings.Refresh}"
-                    ToolTip="{x:Static const:LocalizedStrings.Refresh}"
-                    KeyboardNavigation.IsTabStop="True" KeyboardNavigation.TabIndex="1" />
+                             ToolTip="{x:Static const:LocalizedStrings.Refresh}"
+                             KeyboardNavigation.IsTabStop="True"
+                             KeyboardNavigation.TabIndex="1" />
                </Hyperlink>
             </TextBlock>
 
             <TextBlock Grid.Column="2" FontSize="11" HorizontalAlignment="Right">
-                <Hyperlink Name="GuidanceLink" RequestNavigate="NavigateToMoreInformation"
+                <Hyperlink RequestNavigate="NavigateToMoreInformation"
                            AutomationProperties.Name="{x:Static const:LocalizedStrings.AboutTool}">
                     <TextBlock Text="{x:Static const:LocalizedStrings.AboutTool}"
-                               KeyboardNavigation.IsTabStop="True" KeyboardNavigation.TabIndex="0"/>
+                               KeyboardNavigation.IsTabStop="True"
+                               KeyboardNavigation.TabIndex="0"/>
                 </Hyperlink>
             </TextBlock>
 
-            <TextBlock Grid.Column="4" FontSize="11" HorizontalAlignment="Right">
-                <Hyperlink Name="PrivacyLink" RequestNavigate="NavigateToPrivacyModel"
+            <TextBlock Grid.Column="4"
+                       HorizontalAlignment="Right">
+                <Hyperlink RequestNavigate="NavigateToPrivacyModel"
                            AutomationProperties.Name="{x:Static const:LocalizedStrings.AboutPrivacy}">
                     <TextBlock Text="{x:Static const:LocalizedStrings.AboutPrivacy}"
-                               KeyboardNavigation.IsTabStop="True" KeyboardNavigation.TabIndex="0"/>
+                               KeyboardNavigation.IsTabStop="True"
+                               KeyboardNavigation.TabIndex="0"/>
                 </Hyperlink>
             </TextBlock>
         </Grid>


### PR DESCRIPTION
* Fixes the high-contrast issues in VSIX for Options pane and settings page
* Cleaned up XAML
* Added AutomationProperties.Name to text

@chlowell I removed some extraneous x:Name... I'm not sure if that affects that Windows UI tool that shows you the visual hierarchy. I also haven't tested the narrator tool. :( I've been living in High Contrast mode.

The high contrast issues assigned to me should be fixed.