### PR TITLE
Upgrade Microsoft.NET.Sdk.Functions to 1.0.10

### DIFF
--- a/src/backend/Functions/Functions.csproj
+++ b/src/backend/Functions/Functions.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="2.1.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.6" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\lib\Microsoft.Fx.Portability\Microsoft.Fx.Portability.csproj" />


### PR DESCRIPTION
This fixes a NuGet warning about Microsoft.NET.Sdk.Functions 1.0.6 requires
Microsoft.Azure.WebJobs 2.1.0-beta4 but 2.1.0 was resolved.