### PR TITLE
Remove null values and passed in section from ConfigService result

### DIFF
--- a/src/backend/PortabilityService.ConfigurationService/Controllers/ConfigurationController.cs
+++ b/src/backend/PortabilityService.ConfigurationService/Controllers/ConfigurationController.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace PortabilityService.ConfigurationService.Controllers
@@ -45,11 +46,7 @@ namespace PortabilityService.ConfigurationService.Controllers
         }
 
         [HttpGet]
-        public ObjectResult Get()
-        {
-            _logger.LogInformation(LogMessageFormat, nameof(Get), _localizer["ReturningAllConfigSettings"].Value);
-            return Ok(_configuration.GetSection(_baseConfigSectionName).AsEnumerable());
-        }
+        public ObjectResult Get() => GetSectionSettingsList(_baseConfigSectionName);
 
         [HttpGet("section/{sectionName}")]
         public ObjectResult GetSection(string sectionName)
@@ -90,7 +87,10 @@ namespace PortabilityService.ConfigurationService.Controllers
             }
 
             _logger.LogInformation(LogMessageFormat, nameof(GetSectionSettingsList), _localizer["ReturningSectionSettings", sectionName].Value);
-            return Ok(_configuration.GetSection(sectionName).AsEnumerable());
+            return Ok(_configuration.GetSection(sectionName)
+                      .AsEnumerable()
+                      .Where(v => v.Value != null)
+                      .Select(k => new KeyValuePair<string, string>(k.Key.Substring(_baseConfigSectionName.Length + 1), k.Value)));
         }
 
         [HttpGet("setting/{settingName}")]

--- a/src/backend/PortabilityService.ConfigurationService/Resources/Controllers/ConfigurationController.en-US.resx
+++ b/src/backend/PortabilityService.ConfigurationService/Resources/Controllers/ConfigurationController.en-US.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ReturningAllConfigSettings" xml:space="preserve">
-    <value>Returning all the configuration settings.</value>
-  </data>
   <data name="ReturningEnvironment" xml:space="preserve">
     <value>Returning environment setting of {0}.</value>
   </data>


### PR DESCRIPTION
Change the ConfigurationService API calls to remove null configuration values and the SectionName passed in from the result.