### PR TITLE
Correct misleading message when no files are found to analyze

### DIFF
--- a/src/lib/Microsoft.Fx.Portability/ApiPortClient.cs
+++ b/src/lib/Microsoft.Fx.Portability/ApiPortClient.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Fx.Portability
             }
             else
             {
-                _progressReport.ReportIssue(LocalizedStrings.NoFilesAvailableToUpload);
+                _progressReport.ReportIssue(LocalizedStrings.NoFilesToAnalyze);
 
                 return null;
             }
@@ -268,7 +268,7 @@ namespace Microsoft.Fx.Portability
             }
             else
             {
-                _progressReport.ReportIssue(LocalizedStrings.NoFilesAvailableToUpload);
+                _progressReport.ReportIssue(LocalizedStrings.NoFilesToAnalyze);
 
                 return new MultipleFormatAnalysis
                 {

--- a/src/lib/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
+++ b/src/lib/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
@@ -281,9 +281,9 @@ namespace Microsoft.Fx.Portability.Resources {
         /// <summary>
         ///   Looks up a localized string similar to No files were found to upload..
         /// </summary>
-        public static string NoFilesAvailableToUpload {
+        public static string NoFilesToAnalyze {
             get {
-                return ResourceManager.GetString("NoFilesAvailableToUpload", resourceCulture);
+                return ResourceManager.GetString("NoFilesToAnalyze", resourceCulture);
             }
         }
         

--- a/src/lib/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
+++ b/src/lib/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
@@ -201,8 +201,8 @@
   <data name="InvalidFileName" xml:space="preserve">
     <value>Invalid file name: '{0}'</value>
   </data>
-  <data name="NoFilesAvailableToUpload" xml:space="preserve">
-    <value>No files were found to upload.</value>
+  <data name="NoFilesToAnalyze" xml:space="preserve">
+    <value>No files were found to analyze.</value>
   </data>
   <data name="NotFoundException" xml:space="preserve">
     <value>Resource was not found for {0} {1}</value>


### PR DESCRIPTION
This rewords the error message apiport prints when no file is found to analyze. The current message implies the client uploads binaries for analysis, when in fact it sends only metadata.