### PR TITLE
Only use GitVersion when .git folder exists

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -59,7 +59,7 @@
 
     <!-- GitVersionTask is not compiled against .NET Core, so importing the targets will
          result in a failure because it will try to resolve Microsoft.Build.Utilities v4.0 -->
-    <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" Condition=" '$(MSBuildRuntimeType)' != 'Core' ">
+    <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" Condition=" '$(MSBuildRuntimeType)' != 'Core' AND Exists('$(MSBuildThisFileDirectory)\.git') ">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
Fixes #633 