### PR TITLE
Disable VSIX deployment during CI build

### DIFF
--- a/.vsts.ci.yaml
+++ b/.vsts.ci.yaml
@@ -54,7 +54,7 @@ steps:
   inputs:
     solution: PortabilityTools.sln
     vsVersion: 15.0
-    msbuildArgs: '/t:restore;build /m /p:DeployExtension=false /bl:$(Build.SourcesDirectory)\bin\$(BuildConfiguration)\msbuild.binlog'
+    msbuildArgs: '/t:restore;build /p:DeployExtension=false /bl:$(Build.SourcesDirectory)\bin\$(BuildConfiguration)\msbuild.binlog'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
 


### PR DESCRIPTION
This can potentially add quite a while to the build process and we don't need it to actually be deployed