### PR TITLE
Move GitVersion to a CI step instead of MSBuild task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ project.lock.json
 src/Microsoft.Fx.Portability.Offline/data/
 /nupkg
 .tools/
-.data
+.build/
 *.nuget.props
 *.nuget.targets
 .vscode

--- a/.vsts.ci.yaml
+++ b/.vsts.ci.yaml
@@ -54,7 +54,7 @@ steps:
   inputs:
     solution: PortabilityTools.sln
     vsVersion: 15.0
-    msbuildArgs: '/t:restore;build /p:DeployExtension=false /bl:$(Build.SourcesDirectory)\bin\$(BuildConfiguration)\msbuild.binlog'
+    msbuildArgs: '/t:restore;build /m /p:DeployExtension=false /bl:$(Build.SourcesDirectory)\bin\$(BuildConfiguration)\msbuild.binlog'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <AssemblyInfoFile>$(MSBuildThisFileDirectory)\.build\GlobalAssemblyInfo.cs</AssemblyInfoFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <LicenseDocumentDirectory>$(MSBuildThisFileDirectory)\docs\LicenseTerms</LicenseDocumentDirectory>
     <FullLicenseFile>$(MSBuildThisFileDirectory)\LICENSE</FullLicenseFile>
     <OutputFullPath>$(MSBuildThisFileDirectory)</OutputFullPath>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,10 +13,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyInfoFile>$(MSBuildThisFileDirectory)\.build\GlobalAssemblyInfo.cs</AssemblyInfoFile>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <LicenseDocumentDirectory>$(MSBuildThisFileDirectory)\docs\LicenseTerms</LicenseDocumentDirectory>
     <FullLicenseFile>$(MSBuildThisFileDirectory)\LICENSE</FullLicenseFile>
     <OutputFullPath>$(MSBuildThisFileDirectory)</OutputFullPath>
@@ -30,10 +26,12 @@
     <IsTest>false</IsTest>
     <IsTest Condition="$(MSBuildProjectName.ToLowerInvariant().Contains('test'))">true</IsTest>
   </PropertyGroup>
+
   <PropertyGroup>
     <IsFunctionsProject>false</IsFunctionsProject>
     <IsFunctionsProject Condition="$(MSBuildProjectName.StartsWith('PortabilityService.Functions'))">true</IsFunctionsProject>
   </PropertyGroup>
+
   <PropertyGroup>
     <IsOnWindows>false</IsOnWindows>
     <IsOnWindows Condition="'$(OS)' == 'Windows_NT'">true</IsOnWindows>
@@ -71,6 +69,10 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>.NET portability apiport</PackageTags>
     <Copyright>Copyright 2017</Copyright>
+    <VersionFile>$(MSBuildThisFileDirectory)\.build\version.txt</VersionFile>
+    <InfoVersionFile>$(MSBuildThisFileDirectory)\.build\infoversion.txt</InfoVersionFile>
+    <Version Condition="Exists($(VersionFile))">$([System.IO.File]::ReadAllText($(VersionFile)).Trim())</Version>
+    <InformationalVersion Condition="Exists($(VersionFile))">$([System.IO.File]::ReadAllText($(InfoVersionFile)).Trim())</InformationalVersion>
   </PropertyGroup>
 
   <!-- Some of the project types do not have a pack target. This creates a default empty pack target that will be overridden in supported project types -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -38,10 +38,6 @@
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)\stylecop.json" />
   </ItemGroup>
 
-  <ItemGroup Condition="Exists($(AssemblyInfoFile))">
-    <Compile Include="$(AssemblyInfoFile)" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core" Version="0.2.0" Condition="$(ShouldSignAssembly)">
       <PrivateAssets>All</PrivateAssets>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -38,6 +38,10 @@
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)\stylecop.json" />
   </ItemGroup>
 
+  <ItemGroup Condition="Exists($(AssemblyInfoFile))">
+    <Compile Include="$(AssemblyInfoFile)" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core" Version="0.2.0" Condition="$(ShouldSignAssembly)">
       <PrivateAssets>All</PrivateAssets>
@@ -54,12 +58,6 @@
     </PackageReference>
 
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" Condition=" '$(IsPackage)' != 'true' ">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-
-    <!-- GitVersionTask is not compiled against .NET Core, so importing the targets will
-         result in a failure because it will try to resolve Microsoft.Build.Utilities v4.0 -->
-    <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" Condition=" '$(MSBuildRuntimeType)' != 'Core' AND Exists('$(MSBuildThisFileDirectory)\.git') ">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/init.ps1
+++ b/init.ps1
@@ -39,7 +39,12 @@ function GetGitVersion($path) {
 
     $gitversion = "$path\GitVersion.CommandLine\tools\GitVersion.exe"
 
-    & $gitversion /updateAssemblyInfo "$path\GlobalAssemblyInfo.cs" /ensureassemblyinfo /output buildserver
+    & $gitversion /output buildserver
+    
+    $data = & $gitversion | ConvertFrom-Json
+
+    $data.AssemblySemVer > (Join-Path $path "version.txt")
+    $data.InformationalVersion > (Join-Path $path "infoversion.txt")
 }
 
 $root = Join-Path $PSScriptRoot ".build"

--- a/init.ps1
+++ b/init.ps1
@@ -1,31 +1,53 @@
 $ErrorActionPreference = "Stop"
 
 function DownloadFile($url, $outputPath) {
-	Write-Host "Attempt to download to $outputPath"
+    Write-Host "Attempt to download to $outputPath"
 
-	# If the file has been downloaded don't download again. An empty file implies a failed download
-	if(Test-Path $outputPath) {
-		$file = Get-ChildItem $outputPath
+    # If the file has been downloaded don't download again. An empty file implies a failed download
+    if (Test-Path $outputPath) {
+        $file = Get-ChildItem $outputPath
 
-		if($file.Length -gt 0) {
-			Write-Host "$outputPath is already downloaded"
-			return;
-		}
-	}
+        if ($file.Length -gt 0) {
+            Write-Host "$outputPath is already downloaded"
+            return;
+        }
+    }
 
-	try {
-		# Create placeholder so directory exists
-		New-Item -Type File $OutputPath -Force | Out-Null
+    try {
+        # Attempt to download.  If fails, placeholder remains so msbuild won't complain
+        Invoke-WebRequest $url -OutFile $OutputPath | Out-Null
 
-		# Attempt to download.  If fails, placeholder remains so msbuild won't complain
-		Invoke-WebRequest $url -OutFile $OutputPath | Out-Null
-
-		Write-Host "Downloaded $OutputPath"
-	} catch {
-		Write-Error "Failed to download '$url'. $($Error[0])"
-	}
+        Write-Host "Downloaded $OutputPath"
+    }
+    catch {
+        Write-Error "Failed to download '$url'. $($Error[0])"
+    }
 }
+
+function GetGitVersion($path) {
+    $nuget = Join-Path $path "nuget.exe"
+
+    if (!(Test-Path $nuget)) {
+        Invoke-WebRequest "https://dist.nuget.org/win-x86-commandline/v4.7.0/nuget.exe" -OutFile $nuget | Out-Null
+    }
+
+    $gitversion = "$path\GitVersion.CommandLine\tools\GitVersion.exe"
+
+    if (!(Test-Path $gitversion)) {
+        & $nuget install -ExcludeVersion GitVersion.CommandLine -Source https://api.nuget.org/v3/index.json -Version 4.0.0-beta0012 -OutputDirectory $path
+    }
+
+    $gitversion = "$path\GitVersion.CommandLine\tools\GitVersion.exe"
+
+    & $gitversion /updateAssemblyInfo "$path\GlobalAssemblyInfo.cs" /ensureassemblyinfo /output buildserver
+}
+
+$root = Join-Path $PSScriptRoot ".build"
+
+# Create placeholder so directory exists
+New-Item -Type Directory $root -ErrorAction Ignore | Out-Null
 
 $address = "https://portability.blob.core.windows.net/catalog/catalog.bin"
 
-DownloadFile "$address" "$PSScriptRoot\.data\catalog.bin"
+DownloadFile "$address" (Join-Path $root "catalog.bin")
+GetGitVersion $root

--- a/src/ApiPort/ApiPort.Vsix/UpdateVsixVersion.targets
+++ b/src/ApiPort/ApiPort.Vsix/UpdateVsixVersion.targets
@@ -2,8 +2,8 @@
 <Project>
 
   <Target Name="UpdateVsixVersion" BeforeTargets="CreateVsixContainer">
-    <UpdateVersion VsixVersion="$(AssemblyVersion)" VsixFile="$(IntermediateVsixManifest)" />
-    <Message Text="Updated $(IntermediateVsixManifest) to $(AssemblyVersion)" />
+    <UpdateVersion VsixVersion="$(Version)" VsixFile="$(IntermediateVsixManifest)" />
+    <Message Text="Updated $(IntermediateVsixManifest) to $(Version)" />
   </Target>
 
   <UsingTask TaskName="UpdateVersion" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">

--- a/src/lib/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
+++ b/src/lib/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <DataPath>$(OutputFullPath)\.data\</DataPath>
+    <DataPath>$(OutputFullPath)\.build\</DataPath>
     <BreakingChangePath>$(OutputFullPath)\docs\BreakingChanges\</BreakingChangePath>
     <CatalogDataFile>$(DataPath)catalog.bin</CatalogDataFile>
   </PropertyGroup>


### PR DESCRIPTION
GitVersion does not work well in multithreaded builds (ie, using the `/m` switch). This moves it to the init phase, which also helps it not have to recalculate stuff so often.