### PR TITLE
Use correct env var for configuration endpoint

### DIFF
--- a/deploy/PortabilityService.ServiceFabricApplication/ApplicationManifest.xml
+++ b/deploy/PortabilityService.ServiceFabricApplication/ApplicationManifest.xml
@@ -23,7 +23,7 @@
     <ServiceManifestImport>
         <ServiceManifestRef ServiceManifestName="portabilityservice.gatewayPkg" ServiceManifestVersion="v1"/>
         <EnvironmentOverrides CodePackageRef="portabilityservice.gateway.Code">
-            <EnvironmentVariable Name="ConfigurationService_Url" Value="http://portabilityservice.configurationservice"/>
+            <EnvironmentVariable Name="PortabilityConfigurationServiceUrl" Value="http://portabilityservice.configurationservice"/>
         </EnvironmentOverrides>
         <Policies>
             <ContainerHostPolicies CodePackageRef="portabilityservice.gateway.Code">

--- a/deploy/PortabilityService.ServiceFabricApplication/ApplicationManifest.xml
+++ b/deploy/PortabilityService.ServiceFabricApplication/ApplicationManifest.xml
@@ -13,7 +13,7 @@
             <ContainerHostPolicies CodePackageRef="portabilityservice.configurationservice.Code">
                 <RepositoryCredentials AccountName="[RepositoryUserName]" Password="[RepositoryPassword]"/>
                 <ImageOverrides>
-                    <Image Name="portabilityservice.azurecr.io/portabilityservice-configurationservice:0.1" />
+                    <Image Name="portabilityservice.azurecr.io/portabilityservice-configurationservice:0.2" />
                 </ImageOverrides>                
                 <PortBinding ContainerPort="80" EndpointRef="portabilityservice.configurationserviceEndpoint"/>
             </ContainerHostPolicies>
@@ -29,7 +29,7 @@
             <ContainerHostPolicies CodePackageRef="portabilityservice.gateway.Code">
                 <RepositoryCredentials AccountName="[RepositoryUserName]" Password="[RepositoryPassword]"/>
                 <ImageOverrides>
-                    <Image Name="portabilityservice.azurecr.io/portabilityservice-gateway:0.1" />
+                    <Image Name="portabilityservice.azurecr.io/portabilityservice-gateway:0.2" />
                 </ImageOverrides>
                 <PortBinding ContainerPort="80" EndpointRef="portabilityservice.gatewayEndpoint"/>
             </ContainerHostPolicies>

--- a/deploy/PortabilityService.ServiceFabricApplication/portabilityservice.configurationservicePkg/ServiceManifest.xml
+++ b/deploy/PortabilityService.ServiceFabricApplication/portabilityservice.configurationservicePkg/ServiceManifest.xml
@@ -9,7 +9,7 @@
   <CodePackage Name="portabilityservice.configurationservice.Code" Version="0.1">
     <EntryPoint>
       <ContainerHost>
-        <ImageName>portabilityservice.azurecr.io/portabilityservice-configurationservice:0.1</ImageName>
+        <ImageName>portabilityservice.azurecr.io/portabilityservice-configurationservice:0.2</ImageName>
       </ContainerHost>
     </EntryPoint>
     <EnvironmentVariables/>

--- a/deploy/PortabilityService.ServiceFabricApplication/portabilityservice.gatewayPkg/ServiceManifest.xml
+++ b/deploy/PortabilityService.ServiceFabricApplication/portabilityservice.gatewayPkg/ServiceManifest.xml
@@ -9,7 +9,7 @@
     <CodePackage Name="portabilityservice.gateway.Code" Version="0.1">
         <EntryPoint>
             <ContainerHost>
-                <ImageName>portabilityservice.azurecr.io/portabilityservice-gateway:0.1</ImageName>
+                <ImageName>portabilityservice.azurecr.io/portabilityservice-gateway:0.2</ImageName>
             </ContainerHost>
         </EntryPoint>
         <EnvironmentVariables>

--- a/deploy/PortabilityService.ServiceFabricApplication/portabilityservice.gatewayPkg/ServiceManifest.xml
+++ b/deploy/PortabilityService.ServiceFabricApplication/portabilityservice.gatewayPkg/ServiceManifest.xml
@@ -13,7 +13,7 @@
             </ContainerHost>
         </EntryPoint>
         <EnvironmentVariables>
-            <EnvironmentVariable Name="ConfigurationService_Url" Value="http://portabilityservice.configurationservice"/>
+            <EnvironmentVariable Name="PortabilityConfigurationServiceUrl" Value="http://portabilityservice.configurationservice"/>
         </EnvironmentVariables>
     </CodePackage>
     <Resources>

--- a/deploy/PortabilityService.ServiceFabricMeshApplication/PortabilityService-1709.json
+++ b/deploy/PortabilityService.ServiceFabricMeshApplication/PortabilityService-1709.json
@@ -62,7 +62,7 @@
               "osType": "windows",
               "codePackages": [{
                 "name": "Gateway.Code",
-                "image": "portabilityservice-gateway:0.1-windows",
+                "image": "portabilityservice-gateway:0.2-windows",
                 "imageRegistryCredential": {
                   "server": "[parameters('registry-server')]",
                   "username": "[parameters('registry-username')]",
@@ -73,7 +73,7 @@
                   "port": 80
                 }],
                 "environmentVariables": [{
-                    "name": "ConfigurationService_Url",
+                    "name": "PortabilityConfigurationServiceUrl",
                     "value": "http://ConfigurationService"
                   },
                   {
@@ -101,7 +101,7 @@
               "osType": "windows",
               "codePackages": [{
                 "name": "ConfigurationService.Code",
-                "image": "portabilityservice-configurationservice:0.1-windows",
+                "image": "portabilityservice-configurationservice:0.2-windows",
                 "imageRegistryCredential": {
                   "server": "[parameters('registry-server')]",
                   "username": "[parameters('registry-username')]",

--- a/deploy/PortabilityService.ServiceFabricMeshApplication/PortabilityService-Linux.json
+++ b/deploy/PortabilityService.ServiceFabricMeshApplication/PortabilityService-Linux.json
@@ -62,7 +62,7 @@
               "osType": "linux",
               "codePackages": [{
                 "name": "Gateway.Code",
-                "image": "portabilityservice-gateway:0.1",
+                "image": "portabilityservice-gateway:0.2",
                 "imageRegistryCredential": {
                   "server": "[parameters('registry-server')]",
                   "username": "[parameters('registry-username')]",
@@ -73,7 +73,7 @@
                   "port": 80
                 }],
                 "environmentVariables": [{
-                    "name": "ConfigurationService_Url",
+                    "name": "PortabilityConfigurationServiceUrl",
                     "value": "http://ConfigurationService"
                   },
                   {
@@ -101,7 +101,7 @@
               "osType": "linux",
               "codePackages": [{
                 "name": "ConfigurationService.Code",
-                "image": "portabilityservice-configurationservice:0.1",
+                "image": "portabilityservice-configurationservice:0.2",
                 "imageRegistryCredential": {
                   "server": "[parameters('registry-server')]",
                   "username": "[parameters('registry-username')]",
@@ -111,6 +111,11 @@
                   "name": "ConfigurationServiceEndpoint",
                   "port": 80
                 }],
+                "environmentVariables": [{
+                  "name": "ASPNETCORE_ENVIRONMENT",
+                  "value": "Development"
+                }
+              ],                
                 "resources": {
                   "requests": {
                     "cpu": 0.5,

--- a/deploy/PortabilityService.ServiceFabricMeshApplication/PortabilityService-MixedOS.json
+++ b/deploy/PortabilityService.ServiceFabricMeshApplication/PortabilityService-MixedOS.json
@@ -62,7 +62,7 @@
               "osType": "linux",
               "codePackages": [{
                 "name": "Gateway.Code",
-                "image": "portabilityservice-gateway:0.1",
+                "image": "portabilityservice-gateway:0.2",
                 "imageRegistryCredential": {
                   "server": "[parameters('registry-server')]",
                   "username": "[parameters('registry-username')]",
@@ -73,7 +73,7 @@
                   "port": 80
                 }],
                 "environmentVariables": [{
-                    "name": "ConfigurationService_Url",
+                    "name": "PortabilityConfigurationServiceUrl",
                     "value": "http://ConfigurationService"
                   },
                   {
@@ -101,7 +101,7 @@
               "osType": "windows",
               "codePackages": [{
                 "name": "ConfigurationService.Code",
-                "image": "portabilityservice-configurationservice:0.1-windows",
+                "image": "portabilityservice-configurationservice:0.2-windows",
                 "imageRegistryCredential": {
                   "server": "[parameters('registry-server')]",
                   "username": "[parameters('registry-username')]",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     depends_on:
       - portabilityservice.configurationservice
     environment:
-      "ConfigurationService_Url": "http://portabilityservice.configurationservice"
+      "PortabilityConfigurationServiceUrl": "http://portabilityservice.configurationservice"
 
   portabilityservice.configurationservice:
     image: ${DOCKER_REGISTRY}portabilityservice-configurationservice:${PORTABILITYSERVICE_VERSION:-latest}


### PR DESCRIPTION
This small update makes two fixes:

* Uses the correct environment variable for specifying the configuration provider endpoint
* Updates SF and SF Mesh templates to use version 0.2 of our Docker images (which include the latest changes to the services)