### PR TITLE
Remove authorization from Function HTTP triggers

### DIFF
--- a/src/backend/PortabilityService.Functions/Analyze.cs
+++ b/src/backend/PortabilityService.Functions/Analyze.cs
@@ -19,7 +19,7 @@ namespace PortabilityService.Functions
     {
         [FunctionName("analyze")]
         public static async Task<HttpResponseMessage> Run(
-            [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestMessage req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] HttpRequestMessage req,
             [Queue("%WorkflowQueueName%")]ICollector<WorkflowQueueMessage> workflowMessageQueue,
             [Inject]IStorage storage,
             ILogger log)

--- a/src/backend/PortabilityService.Functions/Report.cs
+++ b/src/backend/PortabilityService.Functions/Report.cs
@@ -17,7 +17,7 @@ namespace PortabilityService.Functions
     {
         [FunctionName("report")]
         public static HttpResponseMessage Run(
-            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "report/{submissionId}")] HttpRequestMessage req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "report/{submissionId}")] HttpRequestMessage req,
             string submissionId,
             TraceWriter log)
         {

--- a/src/backend/PortabilityService.Functions/ReportFormat.cs
+++ b/src/backend/PortabilityService.Functions/ReportFormat.cs
@@ -15,7 +15,7 @@ namespace PortabilityService.Functions
     {
         [FunctionName("ReportFormat")]
         public static HttpResponseMessage Run(
-            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "reportformat/{arg:alpha?}")] HttpRequestMessage req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "reportformat/{arg:alpha?}")] HttpRequestMessage req,
             string arg,
             TraceWriter log)
         {


### PR DESCRIPTION
This makes our HTTP Functions accessible without API keys, so we don't have to keep clients up to date with those keys.