### PR TITLE
Fix configuration key constant

### DIFF
--- a/src/backend/PortabilityService.AnalysisService/AnalysisServiceSettings.cs
+++ b/src/backend/PortabilityService.AnalysisService/AnalysisServiceSettings.cs
@@ -9,7 +9,7 @@ namespace PortabilityService.AnalysisService
 {
     internal class AnalysisServiceSettings : IServiceSettings
     {
-        private const string CatalogStorageConnectionKeyName = "CatalogStorageConnectionString";
+        private const string CatalogStorageConnectionKeyName = "CatalogStorageConnection";
         private readonly IConfiguration _configuration;
 
         public AnalysisServiceSettings(IConfiguration configuration)


### PR DESCRIPTION
This constant doesn't match the key in `appsettings.Development.json`.