### PR TITLE
Remove Microsoft.AspNetCore.App version

### DIFF
--- a/src/backend/PortabilityService.AnalysisService/PortabilityService.AnalysisService.csproj
+++ b/src/backend/PortabilityService.AnalysisService/PortabilityService.AnalysisService.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.5.1" />

--- a/src/backend/PortabilityService.ConfigurationService/PortabilityService.ConfigurationService.csproj
+++ b/src/backend/PortabilityService.ConfigurationService/PortabilityService.ConfigurationService.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.5.1" />

--- a/src/backend/PortabilityService.Gateway/PortabilityService.Gateway.csproj
+++ b/src/backend/PortabilityService.Gateway/PortabilityService.Gateway.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="ocelot" Version="3.1.9" />
     <PackageReference Include="Polly" Version="5.3.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />

--- a/tests/backend/PortabilityService.AnalysisService.Tests/PortabilityService.AnalysisService.Tests.csproj
+++ b/tests/backend/PortabilityService.AnalysisService.Tests/PortabilityService.AnalysisService.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/tests/backend/PortabilityService.ConfigurationService.Tests/PortabilityService.ConfigurationService.Tests.csproj
+++ b/tests/backend/PortabilityService.ConfigurationService.Tests/PortabilityService.ConfigurationService.Tests.csproj
@@ -1,9 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/tests/backend/PortabilityService.Gateway.Tests/PortabilityService.Gateway.Tests.csproj
+++ b/tests/backend/PortabilityService.Gateway.Tests/PortabilityService.Gateway.Tests.csproj
@@ -1,12 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <SignAssembly>false</SignAssembly>
+    <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
The version is inferred based on the SDK installed. The ASP.NET Core 2.1 project
templates doesn't include version for it either.