### PR TITLE
Add breaking changes & recommended changes to AnalysisService

### DIFF
--- a/src/backend/PortabilityService.AnalysisService/AnalysisServiceSettings.cs
+++ b/src/backend/PortabilityService.AnalysisService/AnalysisServiceSettings.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.WindowsAzure.Storage;
+using System;
 
 namespace PortabilityService.AnalysisService
 {
@@ -39,8 +39,6 @@ namespace PortabilityService.AnalysisService
 
         public string DefaultVersions => _configuration[nameof(DefaultVersions)];
 
-        public string DotNetStatusEndpoint => _configuration[nameof(DotNetStatusEndpoint)];
-
         public CloudStorageAccount StorageAccount
         {
             get
@@ -53,16 +51,11 @@ namespace PortabilityService.AnalysisService
 
         public string TargetGroups => _configuration[nameof(TargetGroups)];
 
-        public bool UnionAspNetWithNetCore
-        {
-            get
-            {
-                bool settingValue;
-                if (bool.TryParse(_configuration[nameof(UnionAspNetWithNetCore)], out settingValue))
-                    return settingValue;
-                else
-                    return false;
-            }
-        }
+        public bool UnionAspNetWithNetCore =>
+            bool.TryParse(_configuration[nameof(UnionAspNetWithNetCore)], out var settingValue) ? settingValue : false;
+
+        public string BreakingChangesPath => _configuration[nameof(BreakingChangesPath)];
+
+        public string RecommendedChangesPath => _configuration[nameof(RecommendedChangesPath)];
     }
 }

--- a/src/backend/PortabilityService.AnalysisService/ApiPortData.cs
+++ b/src/backend/PortabilityService.AnalysisService/ApiPortData.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Fx.Portability;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PortabilityService.AnalysisService
+{
+    public class ApiPortData
+    {
+        /// <summary>
+        /// Coresponding ApiCatalog data types fetched from the Git repository.
+        /// </summary>
+        public static readonly string[] CatalogDataTypes = new[] {
+            nameof(BreakingChange),
+            nameof(RecommendedChange)
+        };
+
+        public IDictionary<string, string> Components { get; set; } = new Dictionary<string, string>();
+
+        public IEnumerable<BreakingChange> BreakingChanges { get; set; } = Enumerable.Empty<BreakingChange>();
+
+        public IDictionary<string, ICollection<BreakingChange>> BreakingChangesDictionary { get; set; } = new Dictionary<string, ICollection<BreakingChange>>();
+
+        public IDictionary<string, string> RecommendedChanges { get; set; } = new Dictionary<string, string>();
+
+        public static bool IsDataValidType(string dataType) => CatalogDataTypes.Any(x => x.Equals(dataType, StringComparison.Ordinal));
+    }
+}

--- a/src/backend/PortabilityService.AnalysisService/Controllers/ReadyController.cs
+++ b/src/backend/PortabilityService.AnalysisService/Controllers/ReadyController.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Fx.Portability;
+using Microsoft.Fx.Portability.Cache;
+using System;
+using System.Linq;
+
+namespace PortabilityService.AnalysisService.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ReadyController : ControllerBase
+    {
+        private readonly ApiPortData _apiPortData;
+        private readonly IObjectCache<CatalogIndex> _catalog;
+
+        public ReadyController(ApiPortData apiPortData, IObjectCache<CatalogIndex> catalog)
+        {
+            _apiPortData = apiPortData;
+            _catalog = catalog;
+        }
+
+        [HttpGet]
+        public IActionResult Ready() =>
+            CatalogReady() && GitHubDataReady() ? Ok() : new StatusCodeResult(StatusCodes.Status503ServiceUnavailable);
+
+        private bool CatalogReady() =>
+            _catalog?.LastUpdated != default(DateTimeOffset) && _catalog.Value?.Catalog?.DocIds?.Count() > 0;
+
+        private bool GitHubDataReady() =>
+            _apiPortData?.BreakingChangesDictionary?.Keys.Count() > 0 && _apiPortData?.RecommendedChanges?.Count() > 0;
+    }
+}

--- a/src/backend/PortabilityService.AnalysisService/DependencyInjection/ApiPortDataModule.cs
+++ b/src/backend/PortabilityService.AnalysisService/DependencyInjection/ApiPortDataModule.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Autofac;
+using Microsoft.Fx.Portability;
+using Microsoft.Fx.Portability.ObjectModel;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace PortabilityService.AnalysisService
+{
+    public class ApiPortDataModule : Module
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+            builder.Register(LoadApiPortData).SingleInstance();
+            builder.RegisterType<GitCatalogRecommendations>().As<IApiRecommendations>().SingleInstance();
+        }
+
+        private ApiPortData LoadApiPortData(IComponentContext context)
+        {
+            var settings = context.Resolve<IServiceSettings>();
+
+            var breakingChanges = Directory.EnumerateFiles(settings.BreakingChangesPath, "*.md")
+                .Where(path =>
+                {
+                    var filename = Path.GetFileNameWithoutExtension(path);
+                    return !(filename.StartsWith('!') || filename.Equals("README", StringComparison.Ordinal));
+                })
+                .Select(File.ReadAllBytes)
+                .SelectMany(bytes =>
+                {
+                    using (var stream = new MemoryStream(bytes))
+                    {
+                        return BreakingChangeParser.FromMarkdown(stream);
+                    }
+                });
+
+            var recommendedChanges = Directory.EnumerateFiles(settings.RecommendedChangesPath, "*.md", SearchOption.AllDirectories)
+                .Select(File.ReadAllText)
+                .Select(RecommendedChange.ParseFromMarkdown)
+                .Where(change => change != null);
+
+            return new ApiPortData
+            {
+                BreakingChangesDictionary = ToDictionary(breakingChanges, change => change.ApplicableApis),
+                RecommendedChanges = ToDictionary(recommendedChanges, change => change.AffectedApis, change => change.RecommendedAction)
+            };
+        }
+
+        private IDictionary<string, Value> ToDictionary<Type, Value>(IEnumerable<Type> items, Func<Type, IEnumerable<string>> valueToKeysFactory, Func<Type, Value> dictionaryValueFactory)
+        {
+            var dictionary = new Dictionary<string, Value>();
+
+            foreach (var item in items)
+            {
+                foreach (var key in valueToKeysFactory(item))
+                {
+                    var value = dictionaryValueFactory(item);
+
+                    if (!dictionary.ContainsKey(key))
+                    {
+                        dictionary.Add(key, value);
+                    }
+                }
+            }
+
+            return dictionary;
+        }
+
+        private IDictionary<string, ICollection<T>> ToDictionary<T>(IEnumerable<T> items, Func<T, IEnumerable<string>> valueToKeysFactory)
+        {
+            var dictionary = new Dictionary<string, ICollection<T>>();
+
+            foreach (var item in items)
+            {
+                var keys = valueToKeysFactory(item) ?? Enumerable.Empty<string>();
+
+                foreach (var key in keys)
+                {
+                    if (dictionary.ContainsKey(key))
+                    {
+                        dictionary[key].Add(item);
+                    }
+                    else
+                    {
+                        dictionary.Add(key, new List<T> { item });
+                    }
+                }
+            }
+
+            return dictionary;
+        }
+    }
+}

--- a/src/backend/PortabilityService.AnalysisService/DependencyInjection/DependencyModule.cs
+++ b/src/backend/PortabilityService.AnalysisService/DependencyInjection/DependencyModule.cs
@@ -59,8 +59,7 @@ namespace PortabilityService.AnalysisService
             builder.RegisterType<ReportGenerator>().As<IReportGenerator>().SingleInstance();
             builder.RegisterType<CloudPackageFinder>().As<IPackageFinder>().SingleInstance();
 
-            //TODO (yumeng): replace DummyRecommendations with a real implementation
-            builder.RegisterType<DummyRecommendations>().As<IApiRecommendations>().InstancePerLifetimeScope();
+            builder.RegisterModule<ApiPortDataModule>();
 
             builder.Register(CreateStorage).As<IStorage>().SingleInstance();
         }

--- a/src/backend/PortabilityService.AnalysisService/Dockerfile
+++ b/src/backend/PortabilityService.AnalysisService/Dockerfile
@@ -1,21 +1,26 @@
-### Build Stage
-FROM microsoft/dotnet:2.1-sdk-alpine AS build
+# We cache these documents here because they seldom change.
+# Updating the service when the documents change will require rebuilding the image.
+FROM microsoft/dotnet:2.1-sdk-alpine AS github
+WORKDIR /github
+RUN wget https://github.com/Microsoft/dotnet/archive/master.zip -O dotnet.zip && \
+    unzip dotnet.zip "dotnet-master/Documentation/compatibility/*.md" -q
+RUN wget https://github.com/Microsoft/dotnet-apiport/archive/master.zip -O apiport.zip && \
+    unzip apiport.zip "dotnet-apiport-master/docs/RecommendedChanges/*" -q
 
+FROM github AS build
 COPY . .
-
-# Restore packages
 RUN dotnet restore src/backend/PortabilityService.AnalysisService/PortabilityService.AnalysisService.csproj
-
-# Build
 RUN dotnet build src/backend/PortabilityService.AnalysisService/PortabilityService.AnalysisService.csproj -c Release -o /app
 
-### Publish Stage
 FROM build AS publish
 RUN dotnet publish src/backend/PortabilityService.AnalysisService/PortabilityService.AnalysisService.csproj -c Release -o /app
 
-### Run Stage
-FROM microsoft/dotnet:2.1-aspnetcore-runtime-alpine AS final
+FROM microsoft/dotnet:2.1-aspnetcore-runtime-alpine
 WORKDIR /app
+COPY --from=github /github/dotnet-master/Documentation/compatibility/ ./breaking-changes
+COPY --from=github /github/dotnet-apiport-master/docs/RecommendedChanges/ ./recommended-changes
 COPY --from=publish /app .
+ENV BreakingChangesPath=breaking-changes \
+    RecommendedChangesPath=recommended-changes
 EXPOSE 80
 ENTRYPOINT ["dotnet", "PortabilityService.AnalysisService.dll"]

--- a/src/backend/PortabilityService.AnalysisService/GitCatalogRecommendations.cs
+++ b/src/backend/PortabilityService.AnalysisService/GitCatalogRecommendations.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Fx.Portability;
+using Microsoft.Fx.Portability.ObjectModel;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PortabilityService.AnalysisService
+{
+    public class GitCatalogRecommendations : AncestorApiRecommendations
+    {
+        private readonly ApiPortData _gitApiPortData;
+
+        public GitCatalogRecommendations(IApiCatalogLookup catalog, ApiPortData gitData)
+            : base(catalog)
+        {
+            _gitApiPortData = gitData;
+        }
+
+        protected override IEnumerable<BreakingChange> GetBreakingChanges(string docId)
+        {
+            return GetValueFromDictionary(_gitApiPortData.BreakingChangesDictionary, docId);
+        }
+
+        protected override string GetComponent(string docId)
+        {
+            return GetValueFromDictionary(_gitApiPortData.Components, docId);
+        }
+
+        /// <summary>
+        /// Gets the recommended change for a docId.
+        /// If a recommended change does not exist for a particular docId,
+        /// but exists for its parent, then it'll return that recommended change.
+        /// Otherwise, will return null;
+        /// </summary>
+        protected override string GetRecommendedChanges(string docId)
+        {
+            return GetValueFromDictionary(_gitApiPortData.RecommendedChanges, docId);
+        }
+
+        private IEnumerable<T> GetValueFromDictionary<T>(IDictionary<string, ICollection<T>> dictionary, string key)
+        {
+            ICollection<T> value;
+
+            if (dictionary.TryGetValue(key, out value))
+            {
+                return value;
+            }
+
+            return Enumerable.Empty<T>();
+        }
+
+        private string GetValueFromDictionary(IDictionary<string, string> dictionary, string key)
+        {
+            string value;
+
+            if (dictionary.TryGetValue(key, out value))
+            {
+                return value;
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/src/backend/PortabilityService.AnalysisService/IServiceSettings.cs
+++ b/src/backend/PortabilityService.AnalysisService/IServiceSettings.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-//TODO (yumeng): uncommend next line
-//using Microsoft.Fx.Portability.Github;
 using Microsoft.WindowsAzure.Storage;
 using System;
 
@@ -38,13 +36,6 @@ namespace PortabilityService.AnalysisService
         string DefaultVersions { get; }
 
         /// <summary>
-        /// URL to http://dotnetstatus.azurewebsites.net site
-        /// 
-        /// TODO: Remove this because site is replaced with apisof.net
-        /// </summary>
-        string DotNetStatusEndpoint { get; }
-
-        /// <summary>
         /// Storage account for catalog.bin
         /// </summary>
         CloudStorageAccount StorageAccount { get; }
@@ -54,28 +45,17 @@ namespace PortabilityService.AnalysisService
         /// </summary>
         string TargetGroups { get; }
 
-        /* TODO (yumeng): add back the following after portability is done
         /// <summary>
-        /// Git repository used to fetch <see cref="Microsoft.Fx.Portability.ObjectModel.ApiPortData"/>
+        /// Absolute path to a directory containing breaking change docs as .md files
+        /// (i.e. the contents of https://github.com/Microsoft/dotnet/tree/master/Documentation/compatibility)
         /// </summary>
-        IGitSettings ApiPortGitData { get; }
+        string BreakingChangesPath { get; }
 
         /// <summary>
-        /// Git repository to fetch <see cref="BreakingChange"/>
+        /// Absolute path to a directory tree containing recommended changes as .md files
+        /// (i.e. the contents of https://github.com/Microsoft/dotnet-apiport/tree/master/docs/RecommendedChanges)
         /// </summary>
-        IGitSettings BreakingChangeData { get; }
-
-        /// <summary>
-        /// Settings used to download Compatibility Diagnostic information
-        /// </summary>
-        IDiagnosticDownloaderSettings DiagnosticDownloader { get; }
-
-        /// <summary>
-        /// OAuth information used to communicate with GitHub.
-        /// </summary>
-        /// <remarks>Used for the WebHooks for dotnet-apiport PR validation</remarks>
-        IGitHubSettings GitHub { get; }
-        end TODO */
+        string RecommendedChangesPath { get; }
 
         /// <summary>
         /// True to unify APIs from ASP.NET Core and .NET Core into the same

--- a/src/backend/PortabilityService.AnalysisService/PortabilityService.AnalysisService.csproj
+++ b/src/backend/PortabilityService.AnalysisService/PortabilityService.AnalysisService.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />

--- a/src/backend/PortabilityService.AnalysisService/PortabilityService.AnalysisService.csproj
+++ b/src/backend/PortabilityService.AnalysisService/PortabilityService.AnalysisService.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.2" />
+    <PackageReference Include="CommonMark.NET" Version="0.15.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />

--- a/src/backend/PortabilityService.AnalysisService/Properties/launchSettings.json
+++ b/src/backend/PortabilityService.AnalysisService/Properties/launchSettings.json
@@ -1,24 +1,8 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:13612/",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "PortabilityConfigurationServiceUrl": "http://localhost:1443",
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "PortabilityService.AnalysisService": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "environmentVariables": {
         "PortabilityConfigurationServiceUrl": "http://localhost:1443",
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/backend/PortabilityService.AnalysisService/RecommendedChange.cs
+++ b/src/backend/PortabilityService.AnalysisService/RecommendedChange.cs
@@ -1,0 +1,152 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using CommonMark;
+using CommonMark.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.Fx.Portability
+{
+    public sealed class RecommendedChange
+    {
+        public string RecommendedAction { get; set; }
+
+        public ICollection<string> AffectedApis { get; set; }
+
+        public static RecommendedChange ParseFromMarkdown(string contents)
+        {
+            return MarkdownParser.Parse(contents);
+        }
+
+        private static class MarkdownParser
+        {
+            private static List<string> s_empty = new List<string>();
+            private const string RecommendedAction = "Recommended Action";
+
+            private const string AffectedApis = "Affected APIs";
+
+            /// <summary>
+            /// Parses markdown formatted as: https://github.com/Microsoft/dotnet-apiport/blob/master/docs/RecommendedChanges/!%20Template.md
+            /// </summary>
+            /// <returns>The corresponding RecommendedChange; returns null if unable to parse the markdown contents</returns>
+            public static RecommendedChange Parse(string contents)
+            {
+                var root = CommonMarkConverter.Parse(contents);
+                var currentBlock = root.FirstChild;
+
+                string recommendedAction = null;
+                IEnumerable<string> affectedApis = null;
+
+                while (currentBlock != null)
+                {
+                    string header = null;
+
+                    if (TryParseAtxHeading(currentBlock, out header))
+                    {
+                        if (header.Equals(RecommendedAction, StringComparison.Ordinal))
+                        {
+                            currentBlock = currentBlock.NextSibling;
+
+                            if (!TryParseParagraph(currentBlock, out recommendedAction))
+                            {
+                                Trace.TraceError($"Could not parse recommended action.");
+                                return null;
+                            }
+                        }
+                        else if (header.Equals(AffectedApis, StringComparison.Ordinal))
+                        {
+                            if (!TryParseList(currentBlock.NextSibling, out affectedApis))
+                            {
+                                Trace.TraceError($"Could not parse the affected apis");
+                                return null;
+                            }
+                        }
+                        else
+                        {
+                            Trace.TraceError($"Could not parse the ATX header");
+                            return null;
+                        }
+                    }
+
+                    currentBlock = currentBlock.NextSibling;
+                }
+
+                return new RecommendedChange
+                {
+                    RecommendedAction = recommendedAction ?? string.Empty,
+                    AffectedApis = affectedApis?.ToList() ?? s_empty
+                };
+            }
+
+            private static bool TryParseParagraph(Block block, out string contents)
+            {
+                contents = null;
+
+                if (block.Tag != BlockTag.Paragraph)
+                    return false;
+
+                contents = block.InlineContent.LiteralContent;
+
+                return true;
+            }
+
+            private static bool TryParseAtxHeading(Block block, out string header)
+            {
+                header = null;
+
+                if (block.Tag != BlockTag.AtxHeading)
+                    return false;
+
+                header = block.InlineContent?.LiteralContent;
+
+                return !string.IsNullOrEmpty(header);
+            }
+
+            private static bool TryParseList(Block block, out IEnumerable<string> listContents)
+            {
+                listContents = null;
+
+                if (block.Tag != BlockTag.List)
+                    return false;
+
+                List<string> apis = new List<string>();
+
+                var listItem = block.FirstChild;
+
+                while (listItem != null)
+                {
+                    string api = null;
+
+                    if (TryParseListItem(listItem, out api))
+                    {
+                        apis.Add(api);
+                    }
+                    else
+                    {
+                        // log something about not being able to parse the list item and continue;
+                    }
+
+                    listItem = listItem.NextSibling;
+                }
+
+                listContents = apis;
+
+                return true;
+            }
+
+            private static bool TryParseListItem(Block block, out string listItem)
+            {
+                listItem = null;
+                var contents = block.FirstChild;
+
+                if (block.Tag != BlockTag.ListItem || contents == null)
+                    return false;
+
+                return TryParseParagraph(contents, out listItem);
+            }
+        }
+    }
+}

--- a/src/backend/PortabilityService.AnalysisService/appsettings.Development.json
+++ b/src/backend/PortabilityService.AnalysisService/appsettings.Development.json
@@ -8,5 +8,6 @@
   "DefaultVersions": ".NET Core,Version=2.0;.NET Standard,Version=2.0",
   "TargetGroups": "Mobile: .NET Standard, Xamarin.Android, Xamarin.iOS",
   "UnionAspNetWithNetCore": true,
-  "DotNetStatusEndpoint": "http://dotnetstatus.azurewebsites.com"
+  "BreakingChangesPath": "path to Microsoft/dotnet/Documentation/compatibility",
+  "RecommendedChangesPath": "path to dotnet-apiport/docs/RecommendedChanges"
 }

--- a/src/backend/PortabilityService.ConfigurationService/Properties/launchSettings.json
+++ b/src/backend/PortabilityService.ConfigurationService/Properties/launchSettings.json
@@ -1,25 +1,8 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:1443/",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "launchUrl": "api/configuration",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "PortabilityConfigurationService": {
       "commandName": "Project",
-      "launchBrowser": true,
-      "launchUrl": "api/configuration",
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/src/backend/PortabilityService.Gateway/Properties/launchSettings.json
+++ b/src/backend/PortabilityService.Gateway/Properties/launchSettings.json
@@ -1,21 +1,5 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:2747",
-      "sslPort": 0
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": false,
-      "environmentVariables": {
-        "PortabilityConfigurationServiceUrl": "http://localhost:1443",
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "PortabilityServiceGateway": {
       "commandName": "Project",
       "launchBrowser": false,

--- a/tests/backend/PortabilityService.AnalysisService.Tests/ReadyControllerTests.cs
+++ b/tests/backend/PortabilityService.AnalysisService.Tests/ReadyControllerTests.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Fx.Portability;
+using Microsoft.Fx.Portability.Cache;
+using Microsoft.Fx.Portability.ObjectModel;
+using NSubstitute;
+using PortabilityService.AnalysisService.Controllers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace PortabilityService.AnalysisService.Tests
+{
+    public class ReadyControllerTests
+    {
+        [Fact]
+        public void ReadyWhenCatalogAndGitHubDataReady()
+        {
+            var apiPortData = new ApiPortData
+            {
+                BreakingChangesDictionary = new Dictionary<string, ICollection<BreakingChange>>
+                {
+                    ["foo"] = new List<BreakingChange>(new[] { new BreakingChange() })
+                },
+                RecommendedChanges = new Dictionary<string, string> { ["a"] = "b" }
+            };
+
+            var catalogCache = TestCatalogCache();
+            var controller = new ReadyController(apiPortData, catalogCache);
+
+            var response = controller.Ready();
+
+            Assert.IsType<OkResult>(response);
+        }
+
+        [Fact]
+        public void NotReadyWhenCatalogNotReady()
+        {
+            var apiPortData = new ApiPortData
+            {
+                BreakingChangesDictionary = new Dictionary<string, ICollection<BreakingChange>>
+                {
+                    ["foo"] = new List<BreakingChange>(new[] { new BreakingChange() })
+                },
+                RecommendedChanges = new Dictionary<string, string> { ["a"] = "b" }
+            };
+            var catalogCache = TestCatalogCache(true);
+            var controller = new ReadyController(apiPortData, catalogCache);
+
+            var response = controller.Ready();
+
+            Assert.IsType<StatusCodeResult>(response);
+            Assert.Equal(StatusCodes.Status503ServiceUnavailable, (response as StatusCodeResult).StatusCode);
+        }
+
+        [Fact]
+        public void NotReadyWhenNoBreakingChanges()
+        {
+            var apiPortData = new ApiPortData
+            {
+                BreakingChangesDictionary = new Dictionary<string, ICollection<BreakingChange>>(),
+                RecommendedChanges = new Dictionary<string, string> { ["a"] = "b" }
+            };
+
+            var catalogCache = TestCatalogCache();
+            var controller = new ReadyController(apiPortData, catalogCache);
+
+            var response = controller.Ready();
+
+            Assert.IsType<StatusCodeResult>(response);
+            Assert.Equal(StatusCodes.Status503ServiceUnavailable, (response as StatusCodeResult).StatusCode);
+        }
+
+        [Fact]
+        public void NotReadyWhenNoRecommendedChanges()
+        {
+            var apiPortData = new ApiPortData
+            {
+                BreakingChangesDictionary = new Dictionary<string, ICollection<BreakingChange>>
+                {
+                    ["foo"] = new List<BreakingChange>(new[] { new BreakingChange() })
+                },
+                RecommendedChanges = new Dictionary<string, string>()
+            };
+
+            var catalogCache = TestCatalogCache();
+            var controller = new ReadyController(apiPortData, catalogCache);
+
+            var response = controller.Ready();
+
+            Assert.IsType<StatusCodeResult>(response);
+            Assert.Equal(StatusCodes.Status503ServiceUnavailable, (response as StatusCodeResult).StatusCode);
+        }
+
+        private static IObjectCache<CatalogIndex> TestCatalogCache(bool empty = false)
+        {
+            var catalog = Substitute.For<IApiCatalogLookup>();
+            var docIds = empty ? Enumerable.Empty<string>() : new[] { "T:a.doc.id", "T:a.nother.doc.id" };
+            catalog.DocIds.Returns(docIds);
+            var catalogIndex = new CatalogIndex(catalog, Substitute.For<ISearcher<string>>());
+            var catalogCache = Substitute.For<IObjectCache<CatalogIndex>>();
+            catalogCache.Value.Returns(catalogIndex);
+            catalogCache.LastUpdated.Returns(DateTimeOffset.Now);
+
+            return catalogCache;
+        }
+    }
+}


### PR DESCRIPTION
This adds breaking and recommended change data to the AnalysisService. The data is parsed from markdown on the local filesystem at configurable paths. I updated the Dockerfile to acquire the markdown at build so runtime images will launch with the data in place. I also added a readiness check with Kubernetes semantics so we have a mechanism to prevent requests flowing to the service before the data is deserialized.