### PR TITLE
Copy the whole solution folder when building docker images

### DIFF
--- a/src/backend/PortabilityService.AnalysisService/Dockerfile
+++ b/src/backend/PortabilityService.AnalysisService/Dockerfile
@@ -1,20 +1,17 @@
 ### Build Stage
 FROM microsoft/dotnet:2.1-sdk-alpine AS build
-WORKDIR /src
 
-# Restore packages in one build layer
-COPY NuGet.config .
-COPY src/backend/PortabilityService.AnalysisService/PortabilityService.AnalysisService.csproj backend/PortabilityService.AnalysisService/
-RUN dotnet restore backend/PortabilityService.AnalysisService/PortabilityService.AnalysisService.csproj
+COPY . .
 
-# Build the application in the next
-COPY ./src .
-WORKDIR /src/backend/PortabilityService.AnalysisService
-RUN dotnet build PortabilityService.AnalysisService.csproj -c Release -o /app
+# Restore packages
+RUN dotnet restore src/backend/PortabilityService.AnalysisService/PortabilityService.AnalysisService.csproj
+
+# Build
+RUN dotnet build src/backend/PortabilityService.AnalysisService/PortabilityService.AnalysisService.csproj -c Release -o /app
 
 ### Publish Stage
 FROM build AS publish
-RUN dotnet publish PortabilityService.AnalysisService.csproj -c Release -o /app
+RUN dotnet publish src/backend/PortabilityService.AnalysisService/PortabilityService.AnalysisService.csproj -c Release -o /app
 
 ### Run Stage
 FROM microsoft/dotnet:2.1-aspnetcore-runtime-alpine AS final

--- a/src/backend/PortabilityService.ConfigurationService/Dockerfile
+++ b/src/backend/PortabilityService.ConfigurationService/Dockerfile
@@ -1,22 +1,17 @@
 ### Build Stage
 FROM microsoft/dotnet:2.1-sdk-alpine AS build
-WORKDIR /src
 
-# Restore packages in one build layer
-COPY NuGet.config .
-COPY src/backend/PortabilityService.ConfigurationService/PortabilityService.ConfigurationService.csproj backend/PortabilityService.ConfigurationService/
-RUN dotnet restore backend/PortabilityService.ConfigurationService/PortabilityService.ConfigurationService.csproj
+COPY . .
 
-# Build the application in the next
-COPY ./src .
-WORKDIR /src/backend/PortabilityService.ConfigurationService
-RUN dotnet build PortabilityService.ConfigurationService.csproj -c Release -o /app
+# Restore packages
+RUN dotnet restore src/backend/PortabilityService.ConfigurationService/PortabilityService.ConfigurationService.csproj
 
+# Build
+RUN dotnet build src/backend/PortabilityService.ConfigurationService/PortabilityService.ConfigurationService.csproj -c Release -o /app
 
 ### Publish Stage
 FROM build AS publish
-RUN dotnet publish PortabilityService.ConfigurationService.csproj -c Release -o /app
-
+RUN dotnet publish src/backend/PortabilityService.ConfigurationService/PortabilityService.ConfigurationService.csproj -c Release -o /app
 
 ### Run Stage
 FROM microsoft/dotnet:2.1-aspnetcore-runtime-alpine AS final

--- a/src/backend/PortabilityService.Gateway/Dockerfile
+++ b/src/backend/PortabilityService.Gateway/Dockerfile
@@ -1,22 +1,17 @@
 ### Build Stage
 FROM microsoft/dotnet:2.1-sdk-alpine AS build
-WORKDIR /src
 
-# Restore packages in one build layer
-COPY NuGet.config .
-COPY src/backend/PortabilityService.Gateway/PortabilityService.Gateway.csproj backend/PortabilityService.Gateway/
-RUN dotnet restore backend/PortabilityService.Gateway/PortabilityService.Gateway.csproj
+COPY . .
 
-# Build the application in the next
-COPY ./src .
-WORKDIR /src/backend/PortabilityService.Gateway
-RUN dotnet build PortabilityService.Gateway.csproj -c Release -o /app
+# Restore packages
+RUN dotnet restore src/backend/PortabilityService.Gateway/PortabilityService.Gateway.csproj
 
+# Build
+RUN dotnet build src/backend/PortabilityService.Gateway/PortabilityService.Gateway.csproj -c Release -o /app
 
-### Publish Stage
+### Publish
 FROM build AS publish
-RUN dotnet publish PortabilityService.Gateway.csproj -c Release -o /app
-
+RUN dotnet publish src/backend/PortabilityService.Gateway/PortabilityService.Gateway.csproj -c Release -o /app
 
 ### Run Stage
 FROM microsoft/dotnet:2.1-aspnetcore-runtime-alpine AS final


### PR DESCRIPTION
There are several files that are used by dotnet restore/build. Besides
`NuGet.config` we also need `Directory.build.{props|targets}`.

This change copies the whole solution root folder so that builds in docker should
be closer to normal builds outside docker.