### PR TITLE
[WIP] Add Application Insights Profiler

### DIFF
--- a/src/backend/PortabilityService.AnalysisService/PortabilityService.AnalysisService.csproj
+++ b/src/backend/PortabilityService.AnalysisService/PortabilityService.AnalysisService.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.2" />
     <PackageReference Include="CommonMark.NET" Version="0.15.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Profiler.AspNetCore" Version="1.1.3-beta1" />
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />

--- a/src/backend/PortabilityService.ConfigurationService/PortabilityService.ConfigurationService.csproj
+++ b/src/backend/PortabilityService.ConfigurationService/PortabilityService.ConfigurationService.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.Profiler.AspNetCore" Version="1.1.3-beta1" />
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />

--- a/src/backend/PortabilityService.Gateway/PortabilityService.Gateway.csproj
+++ b/src/backend/PortabilityService.Gateway/PortabilityService.Gateway.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Profiler.AspNetCore" Version="1.1.3-beta1" />
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
     <PackageReference Include="ocelot" Version="3.1.9" />
     <PackageReference Include="Polly" Version="5.3.1" />


### PR DESCRIPTION
The feature can be lighted up by setting the following environment variable

ASPNETCORE_HOSTINGSTARTUPASSEMBLIES: Microsoft.ApplicationInsights.Profiler.AspNetCore