### PR TITLE
Handle resources DLLs

### DIFF
--- a/src/lib/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
+++ b/src/lib/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
@@ -49,17 +49,7 @@ namespace Microsoft.Fx.Portability.Analyzer
             // reference to System.Object that is considered a possible
             // framework assembly and use that for any primitives that don't
             // have an assembly
-            AssemblyReferenceInformation systemObjectAssembly;
-
-            if (!_reader.AssemblyReferences.Any() && !_reader.MemberReferences.Any())
-            {
-                // this is probably a resources DLL and doesn't need inspection
-                systemObjectAssembly = null;
-            }
-            else
-            {
-                systemObjectAssembly = _objectFinder.GetSystemRuntimeAssemblyInformation(_reader);
-            }
+            var systemObjectAssembly = _objectFinder.GetSystemRuntimeAssemblyInformation(_reader);
 
             var provider = new MemberMetadataInfoTypeProvider(_reader);
 

--- a/src/lib/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
+++ b/src/lib/Microsoft.Fx.Portability.MetadataReader/DependencyFinderEngineHelper.cs
@@ -4,6 +4,7 @@
 using Microsoft.Fx.Portability.ObjectModel;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection.Metadata;
 
 namespace Microsoft.Fx.Portability.Analyzer
@@ -48,7 +49,17 @@ namespace Microsoft.Fx.Portability.Analyzer
             // reference to System.Object that is considered a possible
             // framework assembly and use that for any primitives that don't
             // have an assembly
-            var systemObjectAssembly = _objectFinder.GetSystemRuntimeAssemblyInformation(_reader);
+            AssemblyReferenceInformation systemObjectAssembly;
+
+            if (!_reader.AssemblyReferences.Any() && !_reader.MemberReferences.Any())
+            {
+                // this is probably a resources DLL and doesn't need inspection
+                systemObjectAssembly = null;
+            }
+            else
+            {
+                systemObjectAssembly = _objectFinder.GetSystemRuntimeAssemblyInformation(_reader);
+            }
 
             var provider = new MemberMetadataInfoTypeProvider(_reader);
 

--- a/src/lib/Microsoft.Fx.Portability.MetadataReader/SystemObjectFinder.cs
+++ b/src/lib/Microsoft.Fx.Portability.MetadataReader/SystemObjectFinder.cs
@@ -32,6 +32,10 @@ namespace Microsoft.Fx.Portability.Analyzer
         /// </summary>
         public AssemblyReferenceInformation GetSystemRuntimeAssemblyInformation(MetadataReader reader)
         {
+            // this is probably a resources DLL and doesn't need inspection
+            if (!reader.AssemblyReferences.Any() && !reader.MemberReferences.Any())
+                return null;
+
             var microsoftAssemblies = reader.AssemblyReferences
                 .Select(handle =>
                 {

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
@@ -29,6 +29,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Tests\ResourceAssembliesGetSkipped_NoReferences.il" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
@@ -29,10 +29,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="Tests\ResourceAssembliesGetSkipped_NoReferences.il" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Tests/ResourceAssembliesGetSkipped_NoReferences.il
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Tests/ResourceAssembliesGetSkipped_NoReferences.il
@@ -1,0 +1,4 @@
+﻿.assembly NoReferences
+{
+  .ver 1:0:0:0
+}


### PR DESCRIPTION
Resources DLLs don't have any AssemblyReferences and therefore won't resolve System.Object.

fixes #697