### PR TITLE
Updated VSIX for Dev16 compatibility and to use AsyncPackage

### DIFF
--- a/PortabilityTools.sln
+++ b/PortabilityTools.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2036
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28210.120
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C991F5FC-04B5-420C-98A0-80974AA946F7}"
 	ProjectSection(SolutionItems) = preProject
@@ -82,7 +82,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ApiPort", "ApiPort", "{C2CF
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "lib", "lib", "{CB5759DE-9D7B-4B21-89BC-E81920D611BB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Fx.Portability.Reports.DGML", "src\lib\Microsoft.Fx.Portability.Reports.DGML\Microsoft.Fx.Portability.Reports.DGML.csproj", "{1B6E53A7-9180-4D79-9556-E5CE59483EA1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Fx.Portability.Reports.DGML", "src\lib\Microsoft.Fx.Portability.Reports.DGML\Microsoft.Fx.Portability.Reports.DGML.csproj", "{1B6E53A7-9180-4D79-9556-E5CE59483EA1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/ApiPort/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
+++ b/src/ApiPort/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{D15030D8-CFC5-4F05-8987-784326856E90}</ProjectGuid>
     <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/src/ApiPort/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
+++ b/src/ApiPort/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{D15030D8-CFC5-4F05-8987-784326856E90}</ProjectGuid>
     <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -21,6 +21,11 @@
     <DeployExtension>false</DeployExtension>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <UseCodebase>true</UseCodebase>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>15.0</OldToolsVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Most projects will just inherit this from Directory.Build.props, but since this contains WPF, a temp project is created which causes issues with MSBuildProjectName -->

--- a/src/ApiPort/ApiPort.VisualStudio/ApiPortVSPackage.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/ApiPortVSPackage.cs
@@ -11,22 +11,27 @@ using System;
 using System.ComponentModel.Design;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ApiPortVS
 {
     [Guid(Guids.ApiPortVSPkgString)]
     [InstalledProductRegistration("#110", "#112", "1.1.10808.0", IconResourceID = 400)] // Help->About info
-    [PackageRegistration(UseManagedResourcesOnly = true)]
-    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string)] // load when a solution is opened
+    [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)] // load when a solution is opened
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [ProvideOptionPage(typeof(OptionsPage), ".NET Portability Analyzer", "General", 110, 113, true)]
     [ProvideToolWindow(typeof(AnalysisOutputToolWindow))]
-    public class ApiPortVSPackage : Package, IResultToolbar
+    [ProvideService(typeof(ApiPortVSPackage), IsAsyncQueryable = true)]
+    public class ApiPortVSPackage : AsyncPackage, IResultToolbar
     {
         private static ServiceProvider _serviceProvider;
         private readonly AssemblyRedirectResolver _assemblyResolver;
 
         internal static IServiceProvider LocalServiceProvider { get { return _serviceProvider; } }
+
+        internal static IAsyncServiceProvider LocalServiceProviderAsync { get { return _serviceProvider; } }
 
         public ApiPortVSPackage()
             : base()
@@ -51,13 +56,13 @@ namespace ApiPortVS
         }
 
         // Called after constructor when package is sited
-        protected override void Initialize()
+        protected async override System.Threading.Tasks.Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
-            base.Initialize();
+            await base.InitializeAsync(cancellationToken, progress);
 
-            if (GetService(typeof(IMenuCommandService)) is OleMenuCommandService mcs)
+            if (await GetServiceAsync(typeof(IMenuCommandService)) is OleMenuCommandService mcs)
             {
-                var menuInitializer = LocalServiceProvider.GetService(typeof(AnalyzeMenu)) as AnalyzeMenu;
+                var menuInitializer = await LocalServiceProviderAsync.GetServiceAsync(typeof(AnalyzeMenu)) as AnalyzeMenu;
 
                 // Add menu items for Analyze toolbar menu
                 CommandID anazlyMenuCommandID = new CommandID(Guids.AnalyzeMenuItemCmdSet, (int)PkgCmdID.CmdIdAnalyzeMenuItem);
@@ -98,6 +103,8 @@ namespace ApiPortVS
                 OleMenuCommand solutionContextMenuOptionsItem = new OleMenuCommand(ShowOptionsPage, solutionContextMenuOptionsCmdId);
                 solutionContextMenuOptionsItem.BeforeQueryStatus += menuInitializer.SolutionContextMenuItemBeforeQueryStatus;
                 mcs.AddCommand(solutionContextMenuOptionsItem);
+
+                return;
             }
         }
 

--- a/src/ApiPort/ApiPort.VisualStudio/ApiPortVSPackage.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/ApiPortVSPackage.cs
@@ -103,8 +103,6 @@ namespace ApiPortVS
                 OleMenuCommand solutionContextMenuOptionsItem = new OleMenuCommand(ShowOptionsPage, solutionContextMenuOptionsCmdId);
                 solutionContextMenuOptionsItem.BeforeQueryStatus += menuInitializer.SolutionContextMenuItemBeforeQueryStatus;
                 mcs.AddCommand(solutionContextMenuOptionsItem);
-
-                return;
             }
         }
 

--- a/src/ApiPort/ApiPort.VisualStudio/ServiceProvider.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/ServiceProvider.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+
 using static Microsoft.VisualStudio.VSConstants;
 
 namespace ApiPortVS
@@ -136,7 +137,7 @@ namespace ApiPortVS
 
             _container = builder.Build();
         }
-        
+
         public void Dispose()
         {
             _container.Dispose();

--- a/src/ApiPort/ApiPort.VisualStudio/ServiceProvider.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/ServiceProvider.cs
@@ -21,12 +21,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-
+using System.Threading.Tasks;
 using static Microsoft.VisualStudio.VSConstants;
 
 namespace ApiPortVS
 {
-    internal sealed class ServiceProvider : IDisposable, IServiceProvider
+    internal sealed class ServiceProvider : IDisposable, IAsyncServiceProvider, IServiceProvider
     {
         private const string DefaultEndpoint = @"https://portability.dot.net/";
         private static readonly DirectoryInfo AssemblyDirectory = new FileInfo(typeof(ServiceProvider).Assembly.Location).Directory;
@@ -136,12 +136,7 @@ namespace ApiPortVS
 
             _container = builder.Build();
         }
-
-        public object GetService(Type serviceType)
-        {
-            return _container.Resolve(serviceType);
-        }
-
+        
         public void Dispose()
         {
             _container.Dispose();
@@ -213,6 +208,16 @@ namespace ApiPortVS
             }
 
             return new OutputViewModel(validReports.Select(x => x.FullName));
+        }
+
+        Task<object> IAsyncServiceProvider.GetServiceAsync(Type serviceType)
+        {
+            return System.Threading.Tasks.Task.FromResult<object>(_container.Resolve(serviceType));
+        }
+
+        public object GetService(Type serviceType)
+        {
+            return _container.Resolve(serviceType);
         }
     }
 }

--- a/src/ApiPort/ApiPort.Vsix/ApiPort.Vsix.csproj
+++ b/src/ApiPort/ApiPort.Vsix/ApiPort.Vsix.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <TargetVsixContainerName>ApiPort.vsix</TargetVsixContainerName>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{C4301817-D6F9-43A4-9E24-5446C0A2C15C}</ProjectGuid>

--- a/src/ApiPort/ApiPort.Vsix/ApiPort.Vsix.csproj
+++ b/src/ApiPort/ApiPort.Vsix/ApiPort.Vsix.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <TargetVsixContainerName>ApiPort.vsix</TargetVsixContainerName>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{C4301817-D6F9-43A4-9E24-5446C0A2C15C}</ProjectGuid>
@@ -21,6 +21,11 @@
     <CreateVsixContainer>True</CreateVsixContainer>
     <UpdateAssemblyInfo>false</UpdateAssemblyInfo>
     <NoWarn>CS2008;$(NoWarn)</NoWarn>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>15.0</OldToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/ApiPort/ApiPort.Vsix/source.extension.vsixmanifest
+++ b/src/ApiPort/ApiPort.Vsix/source.extension.vsixmanifest
@@ -11,11 +11,11 @@
         <Tags>code analysis, cross-platform, .NET Framework, .NET, portable, cross platform, Portable Library</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Premium" />
-        <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Ultimate" />
-        <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
-        <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Premium" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Ultimate" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Community" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
@@ -24,7 +24,7 @@
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="ApiPort.VisualStudio" Path="|ApiPort.VisualStudio;PkgdefProjectOutputGroup|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-        <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[15.0,16.0)" DisplayName="C# and Visual Basic" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[15.0,)" DisplayName="C# and Visual Basic" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Modified the VSIX project and extension package project for compatibility with Visual Studio Dev16 internal build.  Changed the package to derive from AsyncPackage and removed blocking RPC calls from the initialization method, moving instead to await the async service variants.

During this process, I also updated the solution file for compatibility with Dev16.