### PR TITLE
Adding support for running tests cross-platform

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -39,12 +39,9 @@ function Invoke-Tests() {
     foreach ($test in $(Get-ChildItem $testFolder | ? { $_.PsIsContainer })) {
         $csprojs = Get-ChildItem $test.FullName -Recurse | ? { $_.Extension -eq ".csproj" }
         foreach ($proj in $csprojs) {
-            $trx = "$($proj.BaseName).$(Get-Date -Format "yyyy-MM-dd.hh_mm_ss").trx"
-            $fullpath = Join-Path $testResults $trx
-
             Write-Host "Testing $($proj.Name). Output: $trx"
 
-            dotnet test "$($proj.FullName)" --configuration $Configuration --logger "trx;LogFileName=$fullpath" --no-build
+            dotnet test "$($proj.FullName)" --configuration $Configuration --logger "trx" --no-build
         }
     }
 }

--- a/build.sh
+++ b/build.sh
@@ -12,10 +12,11 @@ RootDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DotNetSDKPath=$RootDir"/.tools/dotnet/"$DotNetSDKVersion
 DotNetExe=$DotNetSDKPath"/dotnet"
 
-TestResults=$RootDir"/TestResults"
+BuildApps=true
+RunTests=false
 
 usage() {
-	echo "Usage: build.sh [-c|--configuration <Debug|Release>] [--downloadCatalog]"
+	echo "Usage: build.sh [-c|--configuration <Debug|Release>] [--downloadCatalog] [--runTests] [--no-build]"
 }
 
 downloadCatalog() {
@@ -39,6 +40,14 @@ downloadCatalog() {
 }
 
 installSDK() {
+	local dotnetPath=$(command -v dotnet)
+
+	if [[ $dotnetPath != "" ]]; then
+		echo "dotnet is found on PATH. using that."
+		DotNetExe=$dotnetPath
+		return 0
+	fi
+
 	if [[ -e $DotNetExe ]]; then
 		echo $DotNetExe" exists.  Skipping install..."
 		return 0
@@ -53,18 +62,28 @@ installSDK() {
 	curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel Current --install-dir $DotNetSDKPath
 }
 
+tryGetTargetFramework() {
+	local file=$1
+	local targetFramework=$(awk -F: '/<TargetFramework(s)?>.*netcoreapp[1-9]\.[0-9].*<\/TargetFramework(s)?>/ { print $0 }' $file | sed 's/.*\(netcoreapp[1-9]\.[0-9]\).*/\1/')
+	echo $targetFramework
+}
+
 build() {
 	echo "Building ApiPort... Configuration: ["$Configuration"]"
 
 	pushd src/ApiPort/ApiPort >/dev/null
-	$DotNetExe build ApiPort.csproj -f netcoreapp2.1 -c $Configuration
-	$DotNetExe build ApiPort.Offline.csproj -f netcoreapp2.1 -c $Configuration
+
+	local targetFramework=$(tryGetTargetFramework ApiPort.props)
+	echo "Building for: $targetFramework"
+
+	$DotNetExe build ApiPort.csproj -f $targetFramework -c $Configuration
+	$DotNetExe build ApiPort.Offline.csproj -f $targetFramework -c $Configuration
 	popd >/dev/null
 }
 
 runTest() {
 	ls $1/*.csproj | while read file; do
-		local targetFramework=$(awk -F: '/<TargetFramework(s)?>.*netcoreapp[1-9]\.[0-9].*<\/TargetFramework(s)?>/ { print $0 }' $file | sed 's/.*\(netcoreapp[1-9]\.[0-9]\).*/\1/')
+		local targetFramework=$(tryGetTargetFramework $file)
 
 		if [[ $targetFramework == "" ]]; then
 			echo "Skipping "$file
@@ -73,14 +92,6 @@ runTest() {
 			echo "Testing "$file
 			$DotNetExe test $file -c $Configuration --logger trx --framework $targetFramework --results-directory $2
 		fi
-	done
-
-	if [ ! -d $TestResults ]; then
-		mkdir $TestResults
-	fi
-
-	find $RootDir/tests/ -type f -name "*.trx" | while read line; do
-		mv $line $TestResults/
 	done
 }
 
@@ -109,6 +120,14 @@ while [[ $# -gt 0 ]]; do
 	"-c" | "--configuration")
 		Configuration="$2"
 		shift 2
+		;;
+	"--runtests")
+		RunTests=true
+		shift
+		;;
+	"--no-build")
+		BuildApps=false
+		shift
 		;;
 	"--downloadcatalog")
 		downloadCatalog "true"
@@ -140,10 +159,17 @@ if [[ ! -e $DotNetExe ]]; then
 	exit 2
 fi
 
-downloadCatalog
+if [[ $BuildApps == "true" ]]; then
+	downloadCatalog
+	build
+fi
 
-#build
+if [[ $RunTests == "true" ]]; then
+	if [[$BuildApps != "true" ]]; then
+		echo "WARNING: Not building applications because --no-build is set."
+	fi
 
-findAndRunTests
+	findAndRunTests
+fi
 
 echo "Finished!"

--- a/build.sh
+++ b/build.sh
@@ -71,7 +71,7 @@ runTest() {
 			echo "--- Desktop .NET Framework testing is not currently supported on Unix."
 		else
 			echo "Testing "$file
-			$DotNetExe test $file -c $Configuration --logger trx --framework $targetFramework
+			$DotNetExe test $file -c $Configuration --logger trx --framework $targetFramework --results-directory $2
 		fi
 	done
 
@@ -85,8 +85,17 @@ runTest() {
 }
 
 findAndRunTests() {
+	local testResultsDirectory=$COMMON_TESTRESULTSDIRECTORY
+
+	if [[ $testResultsDirectory == "" ]]; then
+		testResultsDirectory=$RootDir/TestResults
+		echo "Results directory not specified, using $testResultsDirectory."
+	else
+		echo "Using common one set by build agent."
+	fi
+
 	find tests/ -type d -name "*\.Tests" | while read file; do
-		runTest $file
+		runTest $file $testResultsDirectory
 	done
 }
 
@@ -133,7 +142,7 @@ fi
 
 downloadCatalog
 
-build
+#build
 
 findAndRunTests
 

--- a/src/ApiPort/ApiPort/ApiPort.props
+++ b/src/ApiPort/ApiPort/ApiPort.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
-    <RuntimeIdentifiers>win7-x64;win7-x86</RuntimeIdentifiers>
+    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <DefineConstants>$(DefineConstants);FEATURE_SYSTEM_PROXY;FEATURE_NETWORK_CREDENTIAL</DefineConstants>
   </PropertyGroup>
 

--- a/src/ApiPort/ApiPort/ApiPort.props
+++ b/src/ApiPort/ApiPort/ApiPort.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
-    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
+    <RuntimeIdentifiers>win7-x64;win7-x86</RuntimeIdentifiers>
     <DefineConstants>$(DefineConstants);FEATURE_SYSTEM_PROXY;FEATURE_NETWORK_CREDENTIAL</DefineConstants>
   </PropertyGroup>
 

--- a/src/lib/Microsoft.Fx.Portability/AssemblyFileComparer.cs
+++ b/src/lib/Microsoft.Fx.Portability/AssemblyFileComparer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Fx.Portability
 {
@@ -21,7 +22,16 @@ namespace Microsoft.Fx.Portability
                 return y == null ? 0 : -1;
             }
 
-            return string.Compare(x.Name, y?.Name, StringComparison.Ordinal);
+            // Filenames are case insensitive on Windows.
+            var comparison = StringComparison.OrdinalIgnoreCase;
+
+#if !NET461
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                comparison = StringComparison.Ordinal;
+            }
+#endif
+            return string.Compare(x.Name, y?.Name, comparison);
         }
     }
 }

--- a/tests/ApiPort/ApiPort.Tests/AnalyzeOptionsTests.cs
+++ b/tests/ApiPort/ApiPort.Tests/AnalyzeOptionsTests.cs
@@ -115,15 +115,22 @@ namespace ApiPort.Tests
         {
             var directoryPath = Directory.GetCurrentDirectory();
             var currentAssemblyPath = typeof(AnalyzeOptionsTests).GetTypeInfo().Assembly.Location;
+            var currentAssemblyDirectory = Path.GetDirectoryName(currentAssemblyPath);
+
+            // The scenario tested is when an assembly is passed in twice, once explicitly and once as part of the folder
+            // Assert that we test this scenario.
+            if (!string.Equals(currentAssemblyDirectory, directoryPath, StringComparison.OrdinalIgnoreCase))
+            {
+                Directory.SetCurrentDirectory(currentAssemblyDirectory);
+                directoryPath = Directory.GetCurrentDirectory();
+            }
 
             var options = GetOptions($"analyze -f {directoryPath} -f {currentAssemblyPath}");
 
             Assert.Equal(AppCommand.AnalyzeAssemblies, options.Command);
             Assert.NotEmpty(options.InputAssemblies);
 
-            // The scenario tested is when an assembly is passed in twice, once explicitly and once as part of the folder
-            // Assert that we test this scenario.
-            Assert.Equal(Path.GetDirectoryName(currentAssemblyPath), directoryPath, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(currentAssemblyDirectory, Directory.GetCurrentDirectory(), StringComparer.OrdinalIgnoreCase);
 
             foreach (var element in options.InputAssemblies)
             {

--- a/tests/ApiPort/ApiPort.Tests/ApiPort.Tests.csproj
+++ b/tests/ApiPort/ApiPort.Tests/ApiPort.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/lib/Microsoft.Fx.Portability.Cci.Tests/Microsoft.Fx.Portability.Cci.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.Cci.Tests/Microsoft.Fx.Portability.Cci.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NonShipping>true</NonShipping>

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -31,12 +31,17 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         [InlineData("OpImplicitMethod2Parameter.cs", "M:Microsoft.Fx.Portability.MetadataReader.Tests.OpImplicit_Method_2Parameter`1.op_Implicit(`0,`0)")]
         [InlineData("OpExplicit.cs", "M:Microsoft.Fx.Portability.MetadataReader.Tests.Class2_OpExplicit`1.op_Explicit(Microsoft.Fx.Portability.MetadataReader.Tests.Class2_OpExplicit{`0})~Microsoft.Fx.Portability.MetadataReader.Tests.Class1_OpExplicit{`0}")]
         [InlineData("NestedGenericTypesWithInvalidNames.cs", "M:Microsoft.Fx.Portability.MetadataReader.Tests.OtherClass.<GetValues>d__0`1.System#Collections#Generic#IEnumerable{System#Tuple{T@System#Int32}}#GetEnumerator")]
-        [InlineData("modopt.il", "M:TestClass.Foo(System.Int32 optmod System.Runtime.CompilerServices.IsConst)")]
-        [InlineData("modopt.il", "M:TestClass.Bar(System.SByte optmod System.Runtime.CompilerServices.IsConst reqmod System.Runtime.CompilerServices.IsSignUnspecifiedByte*)")]
         [InlineData("NestedGenericTypes.cs", "M:OuterClass`2.InnerClass`2.InnerInnerClass.InnerInnerMethod(OuterClass{`3,`2}.InnerClass{System.Int32,`0}.InnerInnerClass)")]
         [InlineData("NestedGenericTypes.cs", "M:OuterClass`2.InnerClass`2.InnerMethod(OuterClass{`2,`2}.InnerClass{`1,`1})")]
         [InlineData("NestedGenericTypes.cs", "M:OuterClass`2.OuterMethod(`0,OuterClass{`1,`0}.InnerClass{`1,`0})")]
 
+        [Theory]
+        public void TestForDocId(string source, string docid)
+        {
+            TestForDocIdHelper(source, docid, false);
+        }
+
+#if FEATURE_ILDASM
         // IL can, bizarrely, define non-generic types that take generic paratmers
         [InlineData("NonGenericTypesWithGenericParameters.il", "M:OuterClass.InnerClass.InnerMethod(OuterClass.InnerClass{`2,`2})")]
         [InlineData("NonGenericTypesWithGenericParameters.il", "M:OuterClass.OuterMethod(`0,OuterClass.InnerClass{`1,`0,System.Object,`0})")]
@@ -45,12 +50,14 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         // This is not possible to construct in C#, but was being encoded incorrectly by the metadata reader parser.
         [InlineData("NestedGenericTypes.il", "M:OuterClass`2.InnerClass`2.InnerMethod(OuterClass{`2,`2}.InnerClass`2)")]
         [InlineData("NestedGenericTypes.il", "M:OuterClass`2.OuterMethod(`0,OuterClass{`1,`0}.InnerClass{`1,`0})")]
-
+        [InlineData("modopt.il", "M:TestClass.Foo(System.Int32 optmod System.Runtime.CompilerServices.IsConst)")]
+        [InlineData("modopt.il", "M:TestClass.Bar(System.SByte optmod System.Runtime.CompilerServices.IsConst reqmod System.Runtime.CompilerServices.IsSignUnspecifiedByte*)")]
         [Theory]
-        public void TestForDocId(string source, string docid)
+        public void TestForDocIdIL(string source, string docid)
         {
             TestForDocIdHelper(source, docid, false);
         }
+#endif
 
         [InlineData("Spec.cs", "T:N.X`1")]
         [InlineData("Spec.cs", "M:N.X`1.#ctor")]
@@ -242,6 +249,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             Assert.IsType<SystemObjectNotFoundException>(exception.InnerException);
         }
 
+#if FEATURE_ILDASM
         [Fact]
         public void AssemblyWithNoReferencesIsSkipped()
         {
@@ -259,6 +267,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
 
             Assert.Equal("NoReferences, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null", assembly.AssemblyIdentity);
         }
+#endif
 
         private static IEnumerable<Tuple<string, int>> EmptyProjectMemberDocId()
         {

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -34,13 +34,6 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         [InlineData("NestedGenericTypes.cs", "M:OuterClass`2.InnerClass`2.InnerInnerClass.InnerInnerMethod(OuterClass{`3,`2}.InnerClass{System.Int32,`0}.InnerInnerClass)")]
         [InlineData("NestedGenericTypes.cs", "M:OuterClass`2.InnerClass`2.InnerMethod(OuterClass{`2,`2}.InnerClass{`1,`1})")]
         [InlineData("NestedGenericTypes.cs", "M:OuterClass`2.OuterMethod(`0,OuterClass{`1,`0}.InnerClass{`1,`0})")]
-
-        [Theory]
-        public void TestForDocId(string source, string docid)
-        {
-            TestForDocIdHelper(source, docid, false);
-        }
-
 #if FEATURE_ILASM
         // IL can, bizarrely, define non-generic types that take generic paratmers
         [InlineData("NonGenericTypesWithGenericParameters.il", "M:OuterClass.InnerClass.InnerMethod(OuterClass.InnerClass{`2,`2})")]
@@ -52,12 +45,12 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         [InlineData("NestedGenericTypes.il", "M:OuterClass`2.OuterMethod(`0,OuterClass{`1,`0}.InnerClass{`1,`0})")]
         [InlineData("modopt.il", "M:TestClass.Foo(System.Int32 optmod System.Runtime.CompilerServices.IsConst)")]
         [InlineData("modopt.il", "M:TestClass.Bar(System.SByte optmod System.Runtime.CompilerServices.IsConst reqmod System.Runtime.CompilerServices.IsSignUnspecifiedByte*)")]
+#endif
         [Theory]
-        public void TestForDocIdIL(string source, string docid)
+        public void TestForDocId(string source, string docid)
         {
             TestForDocIdHelper(source, docid, false);
         }
-#endif
 
         [InlineData("Spec.cs", "T:N.X`1")]
         [InlineData("Spec.cs", "M:N.X`1.#ctor")]

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             TestForDocIdHelper(source, docid, false);
         }
 
-#if FEATURE_ILDASM
+#if FEATURE_ILASM
         // IL can, bizarrely, define non-generic types that take generic paratmers
         [InlineData("NonGenericTypesWithGenericParameters.il", "M:OuterClass.InnerClass.InnerMethod(OuterClass.InnerClass{`2,`2})")]
         [InlineData("NonGenericTypesWithGenericParameters.il", "M:OuterClass.OuterMethod(`0,OuterClass.InnerClass{`1,`0,System.Object,`0})")]
@@ -249,7 +249,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             Assert.IsType<SystemObjectNotFoundException>(exception.InnerException);
         }
 
-#if FEATURE_ILDASM
+#if FEATURE_ILASM
         [Fact]
         public void AssemblyWithNoReferencesIsSkipped()
         {

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NonShipping>true</NonShipping>
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
@@ -7,6 +7,10 @@
     <NonShipping>true</NonShipping>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(TargetFramework) == 'net461'">
+    <DefineConstants>$(DefineConstants);FEATURE_ILDASM</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.4.0" />
     <PackageReference Include="Microsoft.NETCore.ILAsm" Version="2.0.5" />

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <RuntimeIdentifiers>win;linux-x64;osx-x64</RuntimeIdentifiers>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NonShipping>true</NonShipping>

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
@@ -15,7 +15,7 @@
     during dotnet test even when using RuntimeIdentifier. See:
     https://github.com/dotnet/sdk/issues/2765 -->
     <RuntimeIdentifier>win7-x86</RuntimeIdentifier>
-    <DefineConstants>$(DefineConstants);FEATURE_ILDASM</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ILASM</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
@@ -2,13 +2,19 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
-    <RuntimeIdentifiers>win;linux-x64;osx-x64</RuntimeIdentifiers>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NonShipping>true</NonShipping>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework) == 'net461'">
+    <!-- Need to specify RuntimeIdentifier in here because using
+    RuntimeIdentifiers will not copy native assets (ildasm) to the output.
+    folder.
+    TODO: ilasm exists on Linux but for some reason the assets are not copied
+    during dotnet test even when using RuntimeIdentifier. See:
+    https://github.com/dotnet/sdk/issues/2765 -->
+    <RuntimeIdentifier>win7-x86</RuntimeIdentifier>
     <DefineConstants>$(DefineConstants);FEATURE_ILDASM</DefineConstants>
   </PropertyGroup>
 

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/SystemObjectFinderTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/SystemObjectFinderTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             _output = output;
         }
 
+#if FEATURE_ILDASM
         [Fact]
         public void MultipleMscorlibReferencesFound()
         {
@@ -114,5 +115,6 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
                 }
             }
         }
+#endif
     }
 }

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/SystemObjectFinderTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/SystemObjectFinderTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
             _output = output;
         }
 
-#if FEATURE_ILDASM
+#if FEATURE_ILASM
         [Fact]
         public void MultipleMscorlibReferencesFound()
         {

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/TestAssembly.cs
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/TestAssembly.cs
@@ -63,10 +63,18 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         private class CSharpCompileAssemblyFile : ResourceStreamAssemblyFile
         {
             private const string TFM = @"[assembly: global::System.Runtime.Versioning.TargetFrameworkAttribute("".NETFramework,Version=v4.5.1"", FrameworkDisplayName = "".NET Framework 4.5.1"")]";
-            private static readonly IEnumerable<MetadataReference> References = new[] { typeof(object).GetTypeInfo().Assembly.Location, typeof(Uri).GetTypeInfo().Assembly.Location, typeof(Console).GetTypeInfo().Assembly.Location }
-                                                                     .Distinct()
-                                                                     .Select(r => MetadataReference.CreateFromFile(r))
-                                                                     .ToList();
+            private static readonly IEnumerable<MetadataReference> References = new[]
+            {
+                typeof(object).GetTypeInfo().Assembly.Location,
+                typeof(Uri).GetTypeInfo().Assembly.Location,
+                typeof(Console).GetTypeInfo().Assembly.Location,
+
+                // Reference to System.Runtime.dll rather than System.Private.CoreLib on .NET Core
+                typeof(RuntimeReflectionExtensions).Assembly.Location
+            }
+            .Distinct()
+            .Select(r => MetadataReference.CreateFromFile(r))
+            .ToList();
 
             private readonly bool _allowUnsafe;
             private readonly IEnumerable<string> _additionalReferences;

--- a/tests/lib/Microsoft.Fx.Portability.Offline.Tests/Microsoft.Fx.Portability.Offline.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.Offline.Tests/Microsoft.Fx.Portability.Offline.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <NonShipping>true</NonShipping>
   </PropertyGroup>
 
   <!-- FxCop does not understand this target platform and will output the
     following errors:
-    MSBUILD : error : CA0055 : Could not identify platform for 'bin\Debug\ApiPort\netcoreapp2.0\ApiPort.dll'
+    MSBUILD : error : CA0055 : Could not identify platform for 'bin\Debug\ApiPort\netcoreapp2.1\ApiPort.dll'
     MSBUILD : error : CA0052 : No targets were selected.
     -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">

--- a/tests/lib/Microsoft.Fx.Portability.Reports.Html.Tests/Microsoft.Fx.Portability.Reports.Html.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.Reports.Html.Tests/Microsoft.Fx.Portability.Reports.Html.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <NonShipping>true</NonShipping>
   </PropertyGroup>
 

--- a/tests/lib/Microsoft.Fx.Portability.Reports.Html.Tests/Microsoft.Fx.Portability.Reports.Html.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.Reports.Html.Tests/Microsoft.Fx.Portability.Reports.Html.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <NonShipping>true</NonShipping>
   </PropertyGroup>
 

--- a/tests/lib/Microsoft.Fx.Portability.Tests/BreakingChangeParserTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/BreakingChangeParserTests.cs
@@ -372,9 +372,14 @@ namespace Microsoft.Fx.Portability.Tests
 ...
 </runtime>
 </configuration>
-```".Replace(Environment.NewLine, "\n", StringComparison.InvariantCulture)
+```"
+#if NET461
+    .Replace(Environment.NewLine, "\n"),
+#else
+    .Replace(Environment.NewLine, "\n", StringComparison.InvariantCulture),
+#endif
         };
 
-        #endregion
+#endregion
     }
 }

--- a/tests/lib/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <NonShipping>true</NonShipping>
+    <DefineConstants>$(DefineConstants);FEATURE_XML_SCHEMA</DefineConstants>
   </PropertyGroup>
 
   <!-- FxCop does not understand this target platform and will output the
@@ -12,7 +13,6 @@
     -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <RunCodeAnalysis>false</RunCodeAnalysis>
-    <DefineConstants>$(DefineConstants);FEATURE_XML_SCHEMA</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/lib/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <NonShipping>true</NonShipping>
   </PropertyGroup>
 


### PR DESCRIPTION
* This is so we don't have to exclude random tests when running our CI/CD builds in our build definition
* Adds FEATURE_ILASM for running tests on .NET 4.6.1 (it should run on .NETCoreApp2.1) but for some reason, native assets aren't copied over when running on .NETCoreApp2.1. https://github.com/dotnet/sdk/issues/2765