### PR TITLE
Reports.Html works on .NET Framework

### DIFF
--- a/src/lib/Microsoft.Fx.Portability.Reports.Html/HtmlRazorReportWriter.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Html/HtmlRazorReportWriter.cs
@@ -92,6 +92,9 @@ namespace Microsoft.Fx.Portability.Reports
         /// </summary>
         private static void ConfigureRazorViews(ApplicationPartManager partsManager, PhysicalFileProvider fileProvider)
         {
+            // Using StringComparison.OrdinalIgnoreCase because on .NET FX,
+            // binaries are output as .DLL sometimes rather than .dll, which
+            // leaves us unable to find the files.
             var comparison = StringComparison.OrdinalIgnoreCase;
 #if !NET461
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/lib/Microsoft.Fx.Portability.Reports.Html/HtmlRazorReportWriter.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Html/HtmlRazorReportWriter.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Internal;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
@@ -12,7 +13,9 @@ using Microsoft.Fx.Portability.Reporting;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Microsoft.Fx.Portability.Reports
@@ -57,8 +60,8 @@ namespace Microsoft.Fx.Portability.Reports
 
             services.AddSingleton<IHostingEnvironment>(new HostingEnvironment
             {
-                ApplicationName = Assembly.GetEntryAssembly().GetName().Name,
-                WebRootFileProvider = fileProvider
+                ApplicationName = Assembly.GetEntryAssembly()?.GetName().Name ?? string.Empty,
+                WebRootFileProvider = fileProvider,
             });
 
             services.Configure<RazorViewEngineOptions>(options =>
@@ -71,10 +74,55 @@ namespace Microsoft.Fx.Portability.Reports
 
             services.AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>();
             services.AddLogging();
-            services.AddMvc();
-            services.AddTransient<RazorViewToStringRenderer>();
+            services
+                .AddMvc()
+                .ConfigureApplicationPartManager(partsManager => ConfigureRazorViews(partsManager, fileProvider));
 
+            services.AddTransient<RazorViewToStringRenderer>();
             return services.BuildServiceProvider();
+        }
+
+        /// <summary>
+        /// Checks if the precompiled razor views have been added as an
+        /// ApplicationPart. If not, adds them.
+        /// On .NET 461, Microsoft.Fx.Portability.Reports.Html.dll
+        /// and Microsoft.Fx.Portability.Reports.Html.Views.dll are
+        /// not added to the ApplicationPartsManager by default.
+        /// For more information: https://github.com/aspnet/Razor/issues/2262.
+        /// </summary>
+        private static void ConfigureRazorViews(ApplicationPartManager partsManager, PhysicalFileProvider fileProvider)
+        {
+            var comparison = StringComparison.OrdinalIgnoreCase;
+#if !NET461
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                comparison = StringComparison.Ordinal;
+            }
+#endif
+
+            var assemblyName = typeof(HtmlRazorReportWriter).Assembly.GetName().Name;
+            if (partsManager.ApplicationParts.Any(x => string.Equals(x.Name, assemblyName, comparison)))
+            {
+                return;
+            }
+
+            var applicationParts = new DirectoryInfo(fileProvider.Root)
+                .EnumerateFiles()
+                .Where(x => x.Exists
+                    && x.Extension.Equals(".dll", comparison)
+                    && x.Name.StartsWith(assemblyName, comparison))
+                .SelectMany(file =>
+                {
+                    var assembly = Assembly.LoadFrom(file.FullName);
+                    return file.Name.EndsWith("Views.dll", comparison)
+                        ? CompiledRazorAssemblyApplicationPartFactory.GetDefaultApplicationParts(assembly)
+                        : new[] { new AssemblyPart(assembly) };
+                });
+
+            foreach (var part in applicationParts)
+            {
+                partsManager.ApplicationParts.Add(part);
+            }
         }
 
         public void Dispose()

--- a/src/lib/Microsoft.Fx.Portability.Reports.Html/Microsoft.Fx.Portability.Reports.Html.csproj
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Html/Microsoft.Fx.Portability.Reports.Html.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Description>An HTML formatter for ApiPort reports</Description>
   </PropertyGroup>
 
@@ -9,12 +9,6 @@
     <PackageReference Include="CommonMark.NET" Version="0.15.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Properties\version.txt">
-      <Pack>false</Pack>
-    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/lib/Microsoft.Fx.Portability.Reports.Html.Tests/Microsoft.Fx.Portability.Reports.Html.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.Reports.Html.Tests/Microsoft.Fx.Portability.Reports.Html.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <NonShipping>true</NonShipping>
   </PropertyGroup>
 


### PR DESCRIPTION
In .NET Framework, the precompiled views are not added to the ApplicationParts by default, so they cannot be resolved.

Fixes #749 