### PR TITLE
Remove version.txt includes

### DIFF
--- a/src/lib/Microsoft.Fx.Portability.Cci/Microsoft.Fx.Portability.Cci.csproj
+++ b/src/lib/Microsoft.Fx.Portability.Cci/Microsoft.Fx.Portability.Cci.csproj
@@ -18,12 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="Properties\version.txt">
-      <Pack>false</Pack>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Update="Resources\LocalizedStrings.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/lib/Microsoft.Fx.Portability.MetadataReader/Microsoft.Fx.Portability.MetadataReader.csproj
+++ b/src/lib/Microsoft.Fx.Portability.MetadataReader/Microsoft.Fx.Portability.MetadataReader.csproj
@@ -29,10 +29,4 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="Properties\version.txt">
-      <Pack>false</Pack>
-    </Content>
-  </ItemGroup>
-
 </Project>

--- a/src/lib/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
+++ b/src/lib/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
@@ -31,12 +31,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="Properties\version.txt">
-      <Pack>false</Pack>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Update="Resources\LocalizedStrings.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/lib/Microsoft.Fx.Portability.Reports.Html/Microsoft.Fx.Portability.Reports.Html.csproj
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Html/Microsoft.Fx.Portability.Reports.Html.csproj
@@ -12,12 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="Properties\version.txt">
-      <Pack>false</Pack>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Microsoft.Fx.Portability\Microsoft.Fx.Portability.csproj" />
   </ItemGroup>
 

--- a/src/lib/Microsoft.Fx.Portability.Reports.Json/Microsoft.Fx.Portability.Reports.Json.csproj
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Json/Microsoft.Fx.Portability.Reports.Json.csproj
@@ -16,10 +16,4 @@
     <ProjectReference Include="..\Microsoft.Fx.Portability\Microsoft.Fx.Portability.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="Properties\version.txt">
-      <Pack>false</Pack>
-    </Content>
-  </ItemGroup>
-
 </Project>

--- a/src/lib/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
+++ b/src/lib/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
@@ -43,10 +43,4 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="Properties\version.txt">
-      <Pack>false</Pack>
-    </Content>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
We use GitVersionTask, version.txt is not needed. Delete that include in our csprojs (the file doesn't exist anyways).