### PR TITLE
Update TargetNameParser to understand versions

### DIFF
--- a/src/lib/Microsoft.Fx.Portability/Analysis/TargetNameParser.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analysis/TargetNameParser.cs
@@ -83,12 +83,13 @@ namespace Microsoft.Fx.Portability.Analysis
         /// Parse a string containing target names into FrameworkNames.
         ///
         /// Try the following in order:
-        ///   1. Check if the target specified uses the 'simple' name (i.e. Windows, .NET Framework) then get the latest version for it
-        ///   2. Try to parse it as a target name. If the target was not a valid FrameworkName, an ArgumentException will be thrown and passed down to user.
-        /// <exception cref="UnknownTargetException">Thrown when a target is unknown</exception>
+        ///   1. Check if the target specified uses a FrameworkName (ie. .NET Core, Version=1.0)
+        ///   2. Check if the target specified uses the 'simple' name (i.e. Windows, .NET Framework)
+        ///      then get the latest version for it.
         /// </summary>
         /// <param name="skipNonExistent">true to suppress <see cref="UnknownTargetException"/>
         /// when a target is not found. false, will not throw and skip that target instead.</param>
+        /// <exception cref="UnknownTargetException">Thrown when a target is unknown</exception>
         private ICollection<FrameworkName> ParseTargets(IEnumerable<string> targets, bool skipNonExistent)
         {
             bool TryParseFrameworkName(string targetName, out FrameworkName frameworkName)

--- a/src/lib/Microsoft.Fx.Portability/Analysis/TargetNameParser.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analysis/TargetNameParser.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Fx.Portability.Analysis
             DefaultTargets = GetDefaultTargets(defaultTargets).ToList();
         }
 
-        public IEnumerable<FrameworkName> DefaultTargets { get; private set; }
+        public IEnumerable<FrameworkName> DefaultTargets { get; }
 
         /// <summary>
         /// Maps the list of targets specified as strings to a list of supported target names.

--- a/tests/lib/Microsoft.Fx.Portability.Tests/Analysis/TargetNameParserTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/Analysis/TargetNameParserTests.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Fx.Portability.Analysis;
+using Microsoft.Fx.Portability.ObjectModel;
 using Microsoft.Fx.Portability.TestData;
+using NSubstitute;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Versioning;
 using Xunit;
@@ -98,6 +101,79 @@ namespace Microsoft.Fx.Portability.Tests
 
             Assert.Single(parser.DefaultTargets);
             Assert.Equal(target1Framework, parser.DefaultTargets.Single());
+        }
+
+        [Fact]
+        public static void RemovesNonPublicVersionedTargets()
+        {
+            // Arrange
+            var defaultTargets = "TargetA, Version=2.0;TargetB; TargetC,Version=1.0";
+            var target1 = new FrameworkName("TargetA", new Version("2.0"));
+
+            // The latest version is 1.5, but is this version not a public target.
+            var target2 = new FrameworkName("TargetB", new Version("1.5"));
+
+            // TargetC is not part of the public platform.
+            var target3 = new FrameworkName("TargetC", new Version("1.0"));
+            var expected = new HashSet<FrameworkName> { target1 };
+
+            var catalog = Substitute.For<IApiCatalogLookup>();
+            catalog.GetLatestVersion(target2.Identifier).Returns(target2);
+            catalog.GetPublicTargets().Returns(new[]
+            {
+                new FrameworkName(target1.Identifier, new Version("1.1")),
+                new FrameworkName(target2.Identifier, new Version("1.0")),
+                target1,
+            });
+
+            // Act
+            var parser = new TargetNameParser(catalog, defaultTargets);
+
+            // Assert
+            var actual = new HashSet<FrameworkName>(parser.DefaultTargets);
+
+            Assert.Equal(expected.Count, actual.Count);
+            Assert.All(parser.DefaultTargets, target =>
+            {
+                Assert.True(expected.Remove(target));
+            });
+            Assert.Empty(expected);
+        }
+
+        [Fact]
+        public static void CanParseSimplifiedAndVersionedTargets()
+        {
+            // Arrange
+            var defaultTargets = "TargetA, Version=2.0;TargetB; TargetC,Version=1.0";
+            var target1 = new FrameworkName("TargetA", new Version("2.0"));
+            var target2 = new FrameworkName("TargetB", new Version("1.5"));
+            var target3 = new FrameworkName("TargetC", new Version("1.0"));
+            var expected = new HashSet<FrameworkName> { target1, target2, target3 };
+
+            var catalog = Substitute.For<IApiCatalogLookup>();
+            catalog.GetLatestVersion(target2.Identifier).Returns(target2);
+            catalog.GetPublicTargets().Returns(new[]
+            {
+                new FrameworkName(target1.Identifier, new Version("1.1")),
+                new FrameworkName(target2.Identifier, new Version("1.2")),
+                new FrameworkName(target2.Identifier, new Version("2.0")),
+                target1,
+                target2,
+                target3
+            });
+
+            // Act
+            var parser = new TargetNameParser(catalog, defaultTargets);
+
+            // Assert
+            var actual = new HashSet<FrameworkName>(parser.DefaultTargets);
+
+            Assert.Equal(expected.Count, actual.Count);
+            Assert.All(parser.DefaultTargets, target =>
+            {
+                Assert.True(expected.Remove(target));
+            });
+            Assert.Empty(expected);
         }
     }
 }


### PR DESCRIPTION
Currently the parser only understands: ".NET Core;.NET Standard" and it'll find the latest version for these targets. This makes it so we can get default targets specified by: ".NET Core;.NET Standard, Version=1.6".
