### PR TITLE
Reduce top duplicate strings

### DIFF
--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
@@ -36,7 +36,11 @@ namespace Microsoft.Fx.Portability.ObjectModel
             // we want to recreate the fast look-up data structures.
             _apiMapping = catalog.Apis.AsParallel()
                 .ToDictionary(key => key.DocId,
+#if NETSTANDARD1_3
                                 value => value.Targets.ToDictionary(innerkey => innerkey.Identifier,
+#else
+                                value => value.Targets.ToDictionary(innerkey => string.Intern(innerkey.Identifier),
+#endif
                                                                         innervalue => innervalue.Version, StringComparer.OrdinalIgnoreCase));
 
             _apiMetadata = catalog.Apis.AsParallel()
@@ -62,7 +66,18 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
             _frameworkAssemblies = new HashSet<string>(catalog.FrameworkAssemblyIdenties, StringComparer.OrdinalIgnoreCase);
 
-            _docIdToApi = catalog.Apis.ToDictionary(key => key.DocId, key => new ApiDefinition { DocId = key.DocId, Name = key.Name, ReturnType = key.Type, FullName = key.FullName, Parent = key.Parent });
+            _docIdToApi = catalog.Apis.ToDictionary(key => key.DocId, key => new ApiDefinition
+            {
+                DocId = key.DocId,
+                Name = key.Name,
+#if NETSTANDARD1_3
+                ReturnType = key.Type,
+#else
+                ReturnType = string.Intern(key.Type),
+#endif
+                FullName = key.FullName,
+                Parent = key.Parent
+            });
         }
 
         public virtual IEnumerable<string> DocIds


### PR DESCRIPTION
by interning framework names and return type names.