### PR TITLE
fix MissingMemberInfo.UsedIn doesn't return anything

### DIFF
--- a/src/lib/Microsoft.Fx.Portability/Reporting/ObjectModel/MissingMemberInfo.cs
+++ b/src/lib/Microsoft.Fx.Portability/Reporting/ObjectModel/MissingMemberInfo.cs
@@ -12,7 +12,10 @@ namespace Microsoft.Fx.Portability.Reporting.ObjectModel
     {
         private readonly HashSet<AssemblyInfo> _usedInAssemblies;
 
-        public IEnumerable<AssemblyInfo> UsedIn { get; }
+        public IEnumerable<AssemblyInfo> UsedIn
+        {
+            get { return _usedInAssemblies; }
+        }
 
         public int Uses
         {

--- a/src/lib/Microsoft.Fx.Portability/Reporting/ObjectModel/MissingMemberInfo.cs
+++ b/src/lib/Microsoft.Fx.Portability/Reporting/ObjectModel/MissingMemberInfo.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Fx.Portability.Reporting.ObjectModel
 
         public IEnumerable<AssemblyInfo> UsedIn
         {
-            get { return _usedInAssemblies; }
+            get { return _usedInAssemblies.ToList().AsReadOnly(); }
         }
 
         public int Uses


### PR DESCRIPTION
Fix #776 . This also fixed the Usedby column in MissingAssembly worksheet is empty. 