### PR TITLE
Consistent label and narration for report file name field

### DIFF
--- a/src/ApiPort/ApiPort.VisualStudio.Common/Resources/LocalizedStrings.resx
+++ b/src/ApiPort/ApiPort.VisualStudio.Common/Resources/LocalizedStrings.resx
@@ -269,9 +269,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.</value>
   <data name="RefreshingOutputFormats" xml:space="preserve">
     <value>Refreshing output formats...</value>
   </data>
-  <data name="DefaultFileName" xml:space="preserve">
-    <value>Default output name</value>
-  </data>
   <data name="DefaultOutputDirectory" xml:space="preserve">
     <value>Default output directory</value>
   </data>

--- a/src/ApiPort/ApiPort.VisualStudio/Views/OptionsPageControl.xaml
+++ b/src/ApiPort/ApiPort.VisualStudio/Views/OptionsPageControl.xaml
@@ -58,7 +58,7 @@
                         AutomationProperties.Name="{x:Static const:LocalizedStrings.SelectDefaultOutputDirectory}"
                         KeyboardNavigation.TabIndex="0"
                         Grid.Column="4" Grid.Row="0" />
-                <TextBlock Text="{x:Static const:LocalizedStrings.DefaultFileName}"
+                <TextBlock Text="{x:Static const:LocalizedStrings.DefaultReportFilename}"
                            Grid.Column="0" Grid.Row="2" />
                 <TextBox Text="{Binding DefaultOutputName, Mode=TwoWay}"
                          AutomationProperties.Name="{x:Static const:LocalizedStrings.DefaultReportFilename}"


### PR DESCRIPTION
The label and automation name for the default report file name field of the settings control don't match, causing screen readers to describe the field inconsistently with its label. This makes both the label and the automation name "Default report file name".