### PR TITLE
Don't require AssemblyReferenceInformation for IDependencyFilter

### DIFF
--- a/src/lib/Microsoft.Fx.Portability.MetadataReader/MetadataReaderExtensions.cs
+++ b/src/lib/Microsoft.Fx.Portability.MetadataReader/MetadataReaderExtensions.cs
@@ -122,11 +122,11 @@ namespace Microsoft.Fx.Portability
                         count++;
                     }
 
-                    return ImmutableArray.Create(token);
+                    return new PublicKeyToken(ImmutableArray.Create(token));
                 }
             }
 
-            return ImmutableArray.Create(bytes);
+            return new PublicKeyToken(ImmutableArray.Create(bytes));
         }
 
         private static bool IsTargetFrameworkMonikerAttribute(this MetadataReader metadataReader, CustomAttributeHandle handle)

--- a/src/lib/Microsoft.Fx.Portability.MetadataReader/MetadataReaderExtensions.cs
+++ b/src/lib/Microsoft.Fx.Portability.MetadataReader/MetadataReaderExtensions.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Fx.Portability
         {
             if (handle.IsNil)
             {
-                return default;
+                return PublicKeyToken.Empty;
             }
 
             var bytes = metadataReader.GetBlobBytes(handle);

--- a/src/lib/Microsoft.Fx.Portability.MetadataReader/MetadataReaderExtensions.cs
+++ b/src/lib/Microsoft.Fx.Portability.MetadataReader/MetadataReaderExtensions.cs
@@ -93,52 +93,40 @@ namespace Microsoft.Fx.Portability
                 ? "neutral"
                 : metadataReader.GetString(cultureHandle);
 
-            var publicKeyToken = publicKeyTokenHandle.IsNil
-                ? "null"
-                : metadataReader.FormatPublicKeyToken(publicKeyTokenHandle);
-
-            return new AssemblyReferenceInformation(name, version, culture, publicKeyToken);
+            return new AssemblyReferenceInformation(name, version, culture, metadataReader.GetPublicKeyToken(publicKeyTokenHandle));
         }
 
-        /// <summary>
-        /// Convert a blob referencing a public key token from a PE file into a human-readable string.
-        ///
-        /// If there are no bytes, the return will be 'null'
-        /// If the length is greater than 8, it is a strong name signed assembly
-        /// Otherwise, the key is the byte sequence.
-        /// </summary>
-        [SuppressMessage("Microsoft.Security.Cryptography", "CA5354:SHA1CannotBeUsed", Justification = "Public key tokens are calculated using a SHA-1 hash.")]
-        private static string FormatPublicKeyToken(this MetadataReader metadataReader, BlobHandle handle)
+        public static PublicKeyToken GetPublicKeyToken(this MetadataReader metadataReader, BlobHandle handle)
         {
-            byte[] bytes = metadataReader.GetBlobBytes(handle);
-
-            if (bytes == null || bytes.Length <= 0)
+            if (handle.IsNil)
             {
-                return "null";
+                return default;
             }
 
+            var bytes = metadataReader.GetBlobBytes(handle);
+
             // Strong named assembly
-            if (bytes.Length > 8)
+            if (bytes != null && bytes.Length > 8)
             {
                 // Get the public key token, which is the last 8 bytes of the SHA-1 hash of the public key
                 using (var sha1 = SHA1.Create())
                 {
-                    var token = sha1.ComputeHash(bytes);
+                    var hash = sha1.ComputeHash(bytes);
 
-                    bytes = new byte[8];
+                    var token = new byte[8];
                     int count = 0;
-                    for (int i = token.Length - 1; i >= token.Length - 8; i--)
+
+                    for (int i = hash.Length - 1; i >= hash.Length - 8; i--)
                     {
-                        bytes[count] = token[i];
+                        token[count] = hash[i];
                         count++;
                     }
+
+                    return ImmutableArray.Create(token);
                 }
             }
 
-            // Convert bytes to string, but we don't want the '-' characters and need it to be lower case
-            return BitConverter.ToString(bytes)
-                .Replace("-", string.Empty)
-                .ToLowerInvariant();
+            return ImmutableArray.Create(bytes);
         }
 
         private static bool IsTargetFrameworkMonikerAttribute(this MetadataReader metadataReader, CustomAttributeHandle handle)

--- a/src/lib/Microsoft.Fx.Portability.MetadataReader/MethodSignatureExtensions.cs
+++ b/src/lib/Microsoft.Fx.Portability.MetadataReader/MethodSignatureExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Fx.Portability.Analyzer;
+using Microsoft.Fx.Portability.ObjectModel;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection.Metadata;
@@ -28,6 +29,11 @@ namespace Microsoft.Fx.Portability
                 methodSignature.RequiredParameterCount,
                 methodSignature.GenericParameterCount,
                 parameters);
+        }
+
+        public static bool IsFrameworkAssembly(this IDependencyFilter filter, AssemblyReferenceInformation assembly)
+        {
+            return filter.IsFrameworkAssembly(assembly.Name, assembly.PublicKeyToken);
         }
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/AlwaysTrueDependencyFilter.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/AlwaysTrueDependencyFilter.cs
@@ -5,6 +5,6 @@ namespace Microsoft.Fx.Portability.Analyzer
 {
     public class AlwaysTrueDependencyFilter : IDependencyFilter
     {
-        public bool IsFrameworkAssembly(string name, string publicKeyToken) => true;
+        public bool IsFrameworkAssembly(string name, PublicKeyToken publicKeyToken) => true;
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/AlwaysTrueDependencyFilter.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/AlwaysTrueDependencyFilter.cs
@@ -1,15 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Fx.Portability.ObjectModel;
-
 namespace Microsoft.Fx.Portability.Analyzer
 {
     public class AlwaysTrueDependencyFilter : IDependencyFilter
     {
-        public bool IsFrameworkAssembly(AssemblyReferenceInformation assembly)
-        {
-            return true;
-        }
+        public bool IsFrameworkAssembly(string name, string publicKeyToken) => true;
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/DotNetFrameworkFilter.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/DotNetFrameworkFilter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Fx.Portability.ObjectModel;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,25 +36,19 @@ namespace Microsoft.Fx.Portability.Analyzer
             "Windows."
         };
 
-        public bool IsFrameworkAssembly(AssemblyReferenceInformation assembly)
+        public bool IsFrameworkAssembly(string name, string publicKeyToken)
         {
-            if (assembly == null)
-            {
-                // If we don't have the assembly, default to including the API
-                return true;
-            }
-
-            if (MicrosoftKeys.Contains(assembly.PublicKeyToken))
+            if (MicrosoftKeys.Contains(publicKeyToken))
             {
                 return true;
             }
 
-            if (FrameworkAssemblyNamePrefixes.Any(p => assembly.Name.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
+            if (FrameworkAssemblyNamePrefixes.Any(p => name.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
             {
                 return true;
             }
 
-            if (string.Equals(assembly.Name, "mscorlib", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(name, "mscorlib", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/DotNetFrameworkFilter.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/DotNetFrameworkFilter.cs
@@ -54,12 +54,12 @@ namespace Microsoft.Fx.Portability.Analyzer
                 return true;
             }
 
-            if (FrameworkAssemblyNamePrefixes.Any(p => name.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
+            if (string.Equals(name, "mscorlib", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
 
-            if (string.Equals(name, "mscorlib", StringComparison.OrdinalIgnoreCase))
+            if (FrameworkAssemblyNamePrefixes.Any(p => name.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
             {
                 return true;
             }

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/DotNetFrameworkFilter.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/DotNetFrameworkFilter.cs
@@ -13,18 +13,18 @@ namespace Microsoft.Fx.Portability.Analyzer
         /// These keys are a collection of public key tokens derived from all the reference assemblies in
         /// "%ProgramFiles%\Reference Assemblies\Microsoft" on a Windows 10 machine with VS 2015 installed.
         /// </summary>
-        private static readonly ICollection<string> MicrosoftKeys = new HashSet<string>(new[]
+        private static readonly HashSet<PublicKeyToken> MicrosoftKeys = new HashSet<PublicKeyToken>(new[]
         {
-            "b77a5c561934e089", // ECMA
-            "b03f5f7f11d50a3a", // DEVDIV
-            "7cec85d7bea7798e", // SLPLAT
-            "31bf3856ad364e35", // SILVERLIGHT
-            "24eec0d8c86cda1e", // PHONE
-            "0738eb9f132ed756", // MONO
-            "cc7b13ffcd2ddd51" // NetStandard
-        }, StringComparer.OrdinalIgnoreCase);
+            PublicKeyToken.Parse("b77a5c561934e089"), // ECMA
+            PublicKeyToken.Parse("b03f5f7f11d50a3a"), // DEVDIV
+            PublicKeyToken.Parse("7cec85d7bea7798e"), // SLPLAT
+            PublicKeyToken.Parse("31bf3856ad364e35"), // SILVERLIGHT
+            PublicKeyToken.Parse("24eec0d8c86cda1e"), // PHONE
+            PublicKeyToken.Parse("0738eb9f132ed756"), // MONO
+            PublicKeyToken.Parse("cc7b13ffcd2ddd51") // NetStandard
+        });
 
-        private static readonly IEnumerable<string> FrameworkAssemblyNamePrefixes = new[]
+        private static readonly string[] FrameworkAssemblyNamePrefixes = new[]
         {
             "System.",
             "Microsoft.AspNet.",
@@ -36,9 +36,20 @@ namespace Microsoft.Fx.Portability.Analyzer
             "Windows."
         };
 
-        public bool IsFrameworkAssembly(string name, string publicKeyToken)
+        public bool IsFrameworkAssembly(string name, PublicKeyToken publicKeyToken)
         {
-            if (MicrosoftKeys.Contains(publicKeyToken))
+            return IsKnownPublicKeyToken(publicKeyToken) || IsKnownName(name);
+        }
+
+        private static bool IsKnownPublicKeyToken(PublicKeyToken publicKeyToken)
+        {
+            return MicrosoftKeys.Contains(publicKeyToken);
+        }
+
+        private static bool IsKnownName(string name)
+        {
+            // Name is null, default to submitting the API
+            if (name is null)
             {
                 return true;
             }

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/IDependencyFilter.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/IDependencyFilter.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Fx.Portability.ObjectModel;
+using System.Collections.Immutable;
 
 namespace Microsoft.Fx.Portability.Analyzer
 {
     public interface IDependencyFilter
     {
-        bool IsFrameworkAssembly(string name, string publicKeyToken);
+        bool IsFrameworkAssembly(string name, PublicKeyToken publicKeyToken);
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/IDependencyFilter.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/IDependencyFilter.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Fx.Portability.Analyzer
 {
     public interface IDependencyFilter
     {
-        bool IsFrameworkAssembly(AssemblyReferenceInformation assembly);
+        bool IsFrameworkAssembly(string name, string publicKeyToken);
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/IDependencyFilter.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/IDependencyFilter.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Immutable;
-
 namespace Microsoft.Fx.Portability.Analyzer
 {
     public interface IDependencyFilter

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/PublicKeyToken.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/PublicKeyToken.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Fx.Portability.Resources;
 using System;
 using System.Collections.Immutable;
 using System.Globalization;
@@ -16,6 +17,8 @@ namespace Microsoft.Fx.Portability
         {
             _token = bytes;
         }
+
+        public bool IsEmpty => _token.IsDefaultOrEmpty;
 
         public ImmutableArray<byte> Token => _token.IsDefault ? ImmutableArray<byte>.Empty : _token;
 
@@ -76,12 +79,13 @@ namespace Microsoft.Fx.Portability
 
         public static bool operator !=(PublicKeyToken left, PublicKeyToken right) => !(left == right);
 
-        public static implicit operator PublicKeyToken(ImmutableArray<byte> bytes) => new PublicKeyToken(bytes);
-
-        public static PublicKeyToken ToPublicKeyToken(ImmutableArray<byte> bytes) => new PublicKeyToken(bytes);
-
         private static ImmutableArray<byte> ParseString(string hex)
         {
+            if (hex.Length % 2 != 0)
+            {
+                throw new PortabilityAnalyzerException(string.Format(CultureInfo.InvariantCulture, LocalizedStrings.InvalidPublicKeyToken, hex));
+            }
+
             try
             {
                 var bytes = new byte[hex.Length / 2];
@@ -93,9 +97,9 @@ namespace Microsoft.Fx.Portability
 
                 return ImmutableArray.Create(bytes);
             }
-            catch (FormatException)
+            catch (FormatException e)
             {
-                return ImmutableArray.Create<byte>();
+                throw new PortabilityAnalyzerException(string.Format(CultureInfo.InvariantCulture, LocalizedStrings.InvalidPublicKeyToken, hex), e);
             }
         }
     }

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/PublicKeyToken.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/PublicKeyToken.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text;
+
+namespace Microsoft.Fx.Portability
+{
+    public readonly struct PublicKeyToken : IEquatable<PublicKeyToken>
+    {
+        private readonly ImmutableArray<byte> _token;
+
+        public PublicKeyToken(ImmutableArray<byte> bytes)
+        {
+            _token = bytes;
+        }
+
+        public ImmutableArray<byte> Token => _token.IsDefault ? ImmutableArray<byte>.Empty : _token;
+
+        public bool Equals(PublicKeyToken other)
+        {
+            if (Token.Length != other.Token.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < Token.Length; i++)
+            {
+                if (Token[i] != other.Token[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override bool Equals(object obj) => obj is PublicKeyToken other ? Equals(other) : false;
+
+        public override int GetHashCode()
+        {
+            int hash = 19;
+            unchecked
+            {
+                foreach (var item in Token)
+                {
+                    hash = (hash * 31) + item;
+                }
+            }
+
+            return hash;
+        }
+
+        public override string ToString()
+        {
+            if (Token.IsEmpty)
+            {
+                return "null";
+            }
+
+            var hex = new StringBuilder(Token.Length * 2);
+
+            foreach (byte b in Token)
+            {
+                hex.AppendFormat(CultureInfo.InvariantCulture, "{0:x2}", b);
+            }
+
+            return hex.ToString();
+        }
+
+        public static PublicKeyToken Parse(string input) => new PublicKeyToken(ParseString(input));
+
+        public static bool operator ==(PublicKeyToken left, PublicKeyToken right) => left.Equals(right);
+
+        public static bool operator !=(PublicKeyToken left, PublicKeyToken right) => !(left == right);
+
+        public static implicit operator PublicKeyToken(ImmutableArray<byte> bytes) => new PublicKeyToken(bytes);
+
+        public static PublicKeyToken ToPublicKeyToken(ImmutableArray<byte> bytes) => new PublicKeyToken(bytes);
+
+        private static ImmutableArray<byte> ParseString(string hex)
+        {
+            try
+            {
+                var bytes = new byte[hex.Length / 2];
+
+                for (int i = 0; i < hex.Length; i += 2)
+                {
+                    bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
+                }
+
+                return ImmutableArray.Create(bytes);
+            }
+            catch (FormatException)
+            {
+                return ImmutableArray.Create<byte>();
+            }
+        }
+    }
+}

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/PublicKeyToken.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/PublicKeyToken.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Fx.Portability
             _token = bytes;
         }
 
+        public static PublicKeyToken Empty => default;
+
         public bool IsEmpty => _token.IsDefaultOrEmpty;
 
         public ImmutableArray<byte> Token => _token.IsDefault ? ImmutableArray<byte>.Empty : _token;

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/AssemblyReferenceInformation.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/AssemblyReferenceInformation.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Fx.Portability.Resources;
 using System;
-using System.Collections.Immutable;
 using System.Globalization;
 
 namespace Microsoft.Fx.Portability.ObjectModel

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/AssemblyReferenceInformation.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/AssemblyReferenceInformation.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Fx.Portability.Resources;
 using System;
+using System.Collections.Immutable;
 using System.Globalization;
 
 namespace Microsoft.Fx.Portability.ObjectModel
@@ -13,7 +14,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         private readonly string _string;
 
-        public AssemblyReferenceInformation(string name, Version version, string culture, string publicKeyToken)
+        public AssemblyReferenceInformation(string name, Version version, string culture, PublicKeyToken publicKeyToken)
         {
             Name = name;
             Version = version;
@@ -29,7 +30,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         public Version Version { get; }
 
-        public string PublicKeyToken { get; }
+        public PublicKeyToken PublicKeyToken { get; }
 
         public override string ToString() => _string;
 

--- a/src/lib/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
+++ b/src/lib/Microsoft.Fx.Portability/Resources/LocalizedStrings.Designer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Fx.Portability.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class LocalizedStrings {
@@ -252,6 +252,15 @@ namespace Microsoft.Fx.Portability.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not parse public key token &apos;{0}&apos;.
+        /// </summary>
+        public static string InvalidPublicKeyToken {
+            get {
+                return ResourceManager.GetString("InvalidPublicKeyToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Malformed map: {0}.
         /// </summary>
         public static string MalformedMap {
@@ -279,7 +288,7 @@ namespace Microsoft.Fx.Portability.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No files were found to upload..
+        ///   Looks up a localized string similar to No files were found to analyze..
         /// </summary>
         public static string NoFilesToAnalyze {
             get {

--- a/src/lib/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
+++ b/src/lib/Microsoft.Fx.Portability/Resources/LocalizedStrings.resx
@@ -279,4 +279,7 @@
   <data name="NotSupported" xml:space="preserve">
     <value>Not supported</value>
   </data>
+  <data name="InvalidPublicKeyToken" xml:space="preserve">
+    <value>Could not parse public key token '{0}'</value>
+  </data>
 </root>

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         public void ThrowsSystemObjectNotFoundException()
         {
             var dependencyFilter = Substitute.For<IDependencyFilter>();
-            dependencyFilter.IsFrameworkAssembly(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+            dependencyFilter.IsFrameworkAssembly(Arg.Any<string>(), Arg.Any<PublicKeyToken>()).Returns(false);
             var dependencyFinder = new ReflectionMetadataDependencyFinder(dependencyFilter, new SystemObjectFinder(dependencyFilter));
             var assemblyToTest = TestAssembly.Create("FilterApis.cs", _output);
             var progressReporter = Substitute.For<IProgressReporter>();
@@ -247,7 +247,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         public void AssemblyWithNoReferencesIsSkipped()
         {
             var dependencyFilter = Substitute.For<IDependencyFilter>();
-            dependencyFilter.IsFrameworkAssembly(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+            dependencyFilter.IsFrameworkAssembly(Arg.Any<string>(), Arg.Any<PublicKeyToken>()).Returns(false);
             var dependencyFinder = new ReflectionMetadataDependencyFinder(dependencyFilter, new SystemObjectFinder(dependencyFilter));
             var file = TestAssembly.Create("ResourceAssembliesGetSkipped_NoReferences.il", _output);
             var progressReporter = Substitute.For<IProgressReporter>();
@@ -319,7 +319,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
                     StringComparer.Ordinal);
             }
 
-            public bool IsFrameworkAssembly(string name, string publicKeyToken)
+            public bool IsFrameworkAssembly(string name, PublicKeyToken publicKeyToken)
             {
                 if (string.IsNullOrEmpty(name))
                 {

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/ManagedMetadataReaderTests.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         public void ThrowsSystemObjectNotFoundException()
         {
             var dependencyFilter = Substitute.For<IDependencyFilter>();
-            dependencyFilter.IsFrameworkAssembly(Arg.Any<AssemblyReferenceInformation>()).Returns(false);
+            dependencyFilter.IsFrameworkAssembly(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
             var dependencyFinder = new ReflectionMetadataDependencyFinder(dependencyFilter, new SystemObjectFinder(dependencyFilter));
             var assemblyToTest = TestAssembly.Create("FilterApis.cs", _output);
             var progressReporter = Substitute.For<IProgressReporter>();
@@ -247,7 +247,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         public void AssemblyWithNoReferencesIsSkipped()
         {
             var dependencyFilter = Substitute.For<IDependencyFilter>();
-            dependencyFilter.IsFrameworkAssembly(Arg.Any<AssemblyReferenceInformation>()).Returns(false);
+            dependencyFilter.IsFrameworkAssembly(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
             var dependencyFinder = new ReflectionMetadataDependencyFinder(dependencyFilter, new SystemObjectFinder(dependencyFilter));
             var file = TestAssembly.Create("ResourceAssembliesGetSkipped_NoReferences.il", _output);
             var progressReporter = Substitute.For<IProgressReporter>();
@@ -319,10 +319,8 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
                     StringComparer.Ordinal);
             }
 
-            public bool IsFrameworkAssembly(AssemblyReferenceInformation assembly)
+            public bool IsFrameworkAssembly(string name, string publicKeyToken)
             {
-                var name = assembly?.Name;
-
                 if (string.IsNullOrEmpty(name))
                 {
                     return false;

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/SystemObjectFinderTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/SystemObjectFinderTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
                     Assert.Equal("mscorlib", assemblyInfo.Name);
                     Assert.Equal("4.0.0.0", assemblyInfo.Version.ToString());
                     Assert.Equal("neutral", assemblyInfo.Culture);
-                    Assert.Equal("b77a5c561934e089", assemblyInfo.PublicKeyToken);
+                    Assert.Equal("b77a5c561934e089", assemblyInfo.PublicKeyToken.ToString());
                 }
             }
         }
@@ -60,7 +60,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
                     Assert.Equal("netstandard", assemblyInfo.Name);
                     Assert.Equal("2.0.0.0", assemblyInfo.Version.ToString());
                     Assert.Equal("neutral", assemblyInfo.Culture);
-                    Assert.Equal("cc7b13ffcd2ddd51", assemblyInfo.PublicKeyToken);
+                    Assert.Equal("cc7b13ffcd2ddd51", assemblyInfo.PublicKeyToken.ToString());
                 }
             }
         }

--- a/tests/lib/Microsoft.Fx.Portability.Tests/Analyzer/DotNetFrameworkFilterTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/Analyzer/DotNetFrameworkFilterTests.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Fx.Portability.Analyzer;
-using Microsoft.Fx.Portability.ObjectModel;
-using System;
 using Xunit;
 
 namespace Microsoft.Fx.Portability.MetadataReader.Tests
@@ -15,7 +13,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         [Fact]
         public void NullIsTrue()
         {
-            Assert.True(_assemblyFilter.IsFrameworkAssembly(null, null));
+            Assert.True(_assemblyFilter.IsFrameworkAssembly(null, default));
         }
 
         // Microsoft public key token
@@ -30,11 +28,14 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         [InlineData("0738eb9F132ed756", true)]
 
         // Non-Microsoft public key token
+        [InlineData("1111111111111111", false)]
+
+        // Invalid key
         [InlineData("something", false)]
         [Theory]
         public void DotNetFrameworkFilterCheckPublicKeyToken(string publicKeyToken, bool succeed)
         {
-            Assert.Equal(succeed, _assemblyFilter.IsFrameworkAssembly(string.Empty, publicKeyToken));
+            Assert.Equal(succeed, _assemblyFilter.IsFrameworkAssembly(string.Empty, PublicKeyToken.Parse(publicKeyToken)));
         }
 
         [InlineData("System.something", true)]
@@ -53,7 +54,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         [Theory]
         public void AssemblyNameStartsWithSpecifiedString(string name, bool succeed)
         {
-            Assert.Equal(succeed, _assemblyFilter.IsFrameworkAssembly(name, string.Empty));
+            Assert.Equal(succeed, _assemblyFilter.IsFrameworkAssembly(name, default));
         }
     }
 }

--- a/tests/lib/Microsoft.Fx.Portability.Tests/Analyzer/DotNetFrameworkFilterTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/Analyzer/DotNetFrameworkFilterTests.cs
@@ -29,13 +29,21 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
 
         // Non-Microsoft public key token
         [InlineData("1111111111111111", false)]
-
-        // Invalid key
-        [InlineData("something", false)]
         [Theory]
         public void DotNetFrameworkFilterCheckPublicKeyToken(string publicKeyToken, bool succeed)
         {
             Assert.Equal(succeed, _assemblyFilter.IsFrameworkAssembly(string.Empty, PublicKeyToken.Parse(publicKeyToken)));
+        }
+
+        // Invalid characters
+        [InlineData("something")]
+
+        // Invalid length
+        [InlineData("111")]
+        [Theory]
+        public void InvalidPublicKeyToken(string publicKeyToken)
+        {
+            Assert.Throws<PortabilityAnalyzerException>(() => _assemblyFilter.IsFrameworkAssembly(string.Empty, PublicKeyToken.Parse(publicKeyToken)));
         }
 
         [InlineData("System.something", true)]

--- a/tests/lib/Microsoft.Fx.Portability.Tests/Analyzer/DotNetFrameworkFilterTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/Analyzer/DotNetFrameworkFilterTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         [Fact]
         public void NullIsTrue()
         {
-            Assert.True(_assemblyFilter.IsFrameworkAssembly(null));
+            Assert.True(_assemblyFilter.IsFrameworkAssembly(null, null));
         }
 
         // Microsoft public key token
@@ -34,9 +34,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         [Theory]
         public void DotNetFrameworkFilterCheckPublicKeyToken(string publicKeyToken, bool succeed)
         {
-            var assembly = new AssemblyReferenceInformation(string.Empty, Version.Parse("4.0"), string.Empty, publicKeyToken);
-
-            Assert.Equal(succeed, _assemblyFilter.IsFrameworkAssembly(assembly));
+            Assert.Equal(succeed, _assemblyFilter.IsFrameworkAssembly(string.Empty, publicKeyToken));
         }
 
         [InlineData("System.something", true)]
@@ -55,9 +53,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         [Theory]
         public void AssemblyNameStartsWithSpecifiedString(string name, bool succeed)
         {
-            var assembly = new AssemblyReferenceInformation(name, Version.Parse("4.0"), string.Empty, string.Empty);
-
-            Assert.Equal(succeed, _assemblyFilter.IsFrameworkAssembly(assembly));
+            Assert.Equal(succeed, _assemblyFilter.IsFrameworkAssembly(name, string.Empty));
         }
     }
 }

--- a/tests/lib/Microsoft.Fx.Portability.Tests/ObjectModel/AssemblyReferenceInformationTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/ObjectModel/AssemblyReferenceInformationTests.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         [Fact]
         public static void EqualityTests()
         {
-            var assemblyInfo1 = new AssemblyReferenceInformation("name", Version.Parse("4.0"), "neutral", "1234");
-            var assemblyInfo2 = new AssemblyReferenceInformation("Name", Version.Parse("4.0"), "neutral", "1234");
-            var assemblyInfo3 = new AssemblyReferenceInformation("name2", Version.Parse("4.0"), "neutral", "1234");
+            var assemblyInfo1 = new AssemblyReferenceInformation("name", Version.Parse("4.0"), "neutral", PublicKeyToken.Parse("1234"));
+            var assemblyInfo2 = new AssemblyReferenceInformation("Name", Version.Parse("4.0"), "neutral", PublicKeyToken.Parse("1234"));
+            var assemblyInfo3 = new AssemblyReferenceInformation("name2", Version.Parse("4.0"), "neutral", PublicKeyToken.Parse("1234"));
 
             Assert.Equal($"name, Version=4.0, Culture=neutral, PublicKeyToken=1234", assemblyInfo1.ToString());
             Assert.Equal($"Name, Version=4.0, Culture=neutral, PublicKeyToken=1234", assemblyInfo2.ToString());


### PR DESCRIPTION
If we don't already have an AssemblyReferenceInformation we don't want to have to create it when all we need is the assembly name and public key token. This also removes the need to manipulate strings and introduces a PublicKeyToken type that manages just the bytes of the token.