### PR TITLE
Add reference to Microsoft.NETCore.Platforms package to workaround A SDK issue

### DIFF
--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
@@ -21,6 +21,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.4.0" />
     <PackageReference Include="Microsoft.NETCore.ILAsm" Version="2.0.5" />
+    <!--Reference to Microsoft.NETCore.Platforms to workaround https://github.com/dotnet/cli/issues/12341. Remove the reference once build machine moves to .NET Core 3.0-->
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="3.0.0" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />


### PR DESCRIPTION
There is a SDK issue in .NET Core 2.* (https://github.com/dotnet/cli/issues/12341). The issue results with ilasm.exe is not copied to Microsoft.Fx.Portability.MetadataReader.Tests\net461\win7-x86 output directory as it should be. Add reference to Microsoft.NETCore.Platforms package to workaround the issue. The issue has been fixed in .NET Core 3.0 SDK (verified on 3.0.100). The reference should be removed once build machine moves to .NET Core 3.0. 