### PR TITLE
The previous "'$(TargetExt)'=='.nupkg' condision doesn't make the glo…

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -27,7 +27,8 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <FilesToSign Include="$(OutDir)\$(TargetName).nupkg">
+        <!-- try to sign all nupkg files under $(OutDir)-->
+        <FilesToSign Include="$(OutDir)\**\%(Filename).nupkg">
           <Authenticode>NuGet</Authenticode>
         </FilesToSign>
       </ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
-  <!-- Depending on whether it is a VSIX or MSIL, choose the correct certificate.
+  <!-- Depending on whether it is a VSIX, MSIL or nupkg, choose the correct certificate.
        1) By default, the VSIX project just packages the contents, so
        CopyBuildOutputToOutputDirectory/IncludeAssemblyInVSIXContainer will be
        false. But if you have a VSIX that builds a DLL as well, it will have both
@@ -18,17 +18,17 @@
         </FilesToSign>
       </ItemGroup>
     </When>
-    <When Condition="'$(TargetExt)'=='.nupkg'">
+    <When Condition="'$(TargetExt)'!='.nupkg'">
       <ItemGroup>
         <FilesToSign Include="$(OutDir)\$(TargetName)$(TargetExt)">
-          <Authenticode>NuGet</Authenticode>
+          <Authenticode>Microsoft400</Authenticode>
         </FilesToSign>
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <FilesToSign Include="$(OutDir)\$(TargetName)$(TargetExt)">
-          <Authenticode>Microsoft400</Authenticode>
+        <FilesToSign Include="$(OutDir)\$(TargetName).nupkg">
+          <Authenticode>NuGet</Authenticode>
         </FilesToSign>
       </ItemGroup>
     </Otherwise>


### PR DESCRIPTION
…bal tool package to be signed, switch the conditions.