### PR TITLE
Make apiport package id starts with "Microsoft"

### DIFF
--- a/src/ApiPort/ApiPort/ApiPort.props
+++ b/src/ApiPort/ApiPort/ApiPort.props
@@ -14,6 +14,7 @@
         <TargetFramework>netcoreapp2.1</TargetFramework>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>ApiPort</ToolCommandName>
+          <PackageId>Microsoft.ApiPort</PackageId>
       </PropertyGroup>
     </When>
     <Otherwise>

--- a/src/ApiPort/ApiPort/ApiPort.props
+++ b/src/ApiPort/ApiPort/ApiPort.props
@@ -14,7 +14,7 @@
         <TargetFramework>netcoreapp2.1</TargetFramework>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>ApiPort</ToolCommandName>
-          <PackageId>Microsoft.ApiPort</PackageId>
+        <PackageId>Microsoft.ApiPort</PackageId>
       </PropertyGroup>
     </When>
     <Otherwise>

--- a/src/ApiPort/ApiPort/ApiPort.props
+++ b/src/ApiPort/ApiPort/ApiPort.props
@@ -72,12 +72,6 @@
     <ProjectReference Include="..\..\lib\Microsoft.Fx.Portability\Microsoft.Fx.Portability.csproj" />
   </ItemGroup>
 
-  <Target Name="GetSignNuGetPackFiles" BeforeTargets="SignNuGetPackage">
-    <ItemGroup>
-      <SignNuGetPackFiles Include="$(PackageOutputPath)$(PackageId).$(PackageVersion).nupkg" />
-    </ItemGroup>
-  </Target>
-
   <Target Name="AfterBuild">
     <Copy SourceFiles="@(BinPlaceContent)" DestinationFiles="@(BinPlaceContent->'$(TargetDir)\%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
   </Target>


### PR DESCRIPTION
to follow Microsoft released tool guidance at https://docs.microsoft.com/en-us/dotnet/core/tools/troubleshoot-usage-issues#package-naming-enforcement.
Also remove the target "GetSignNuGetPackFiles", which is not needed.