### PR TITLE
Require v2.2 in build lab as well to fix build error

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,3 +1,6 @@
 {
-    "sources": [ "src" ]
+    "sources": [ "src" ],
+"sdk": {
+  "version": "2.2.401"
+}
 }


### PR DESCRIPTION
Without specify the .NET Core version to use, in build lab with VS2019, 3.0 is used by default, we got the following build error. Using .NET Core 2.2 avoid these build errors
C:\Program Files\dotnet\sdk\3.1.200\Sdks\Microsoft.NET.Sdk.Razor\build\netstandard2.0\Microsoft.NET.Sdk.Razor.Compilation.targets(130,10): Error MSB4064: The "DisableSdkPath" parameter is not supported by the "Csc" task. Verify the parameter exists on the task, and it is a settable public instance property.

C:\Program Files\dotnet\sdk\3.1.200\Sdks\Microsoft.NET.Sdk.Razor\build\netstandard2.0\Microsoft.NET.Sdk.Razor.Compilation.targets(114,5): Error MSB4063: The "Csc" task could not be initialized with its input parameters. 