### PR TITLE
Add command 'order' to show recommended ordering of porting activities.

### DIFF
--- a/src/ApiPort/ApiPort.VisualStudio.Common/Analyze/AnalysisOptions.cs
+++ b/src/ApiPort/ApiPort.VisualStudio.Common/Analyze/AnalysisOptions.cs
@@ -56,5 +56,7 @@ namespace ApiPortVS
         public bool OverwriteOutputFile { get; }
 
         public IEnumerable<string> ReferencedNuGetPackages { get; } = Enumerable.Empty<string>();
+
+        public string EntryPoint => string.Empty;
     }
 }

--- a/src/ApiPort/ApiPort.VisualStudio/ServiceProvider.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/ServiceProvider.cs
@@ -56,6 +56,8 @@ namespace ApiPortVS
             builder.RegisterType<ApiPortVsAnalyzer>()
                 .As<IVsApiPortAnalyzer>()
                 .InstancePerLifetimeScope();
+            builder.RegisterType<DependencyOrderer>()
+                .As<IDependencyOrderer>();
 
             // Service registration
             builder.RegisterInstance(new ProductInformation("ApiPort_VS"))

--- a/src/ApiPort/ApiPort/AppCommand.cs
+++ b/src/ApiPort/ApiPort/AppCommand.cs
@@ -8,6 +8,7 @@ namespace ApiPort
         ListTargets,
         AnalyzeAssemblies,
         ListOutputFormats,
+        Order,
         DumpAnalysis,
         DocIdSearch,
         Help,

--- a/src/ApiPort/ApiPort/ConsoleApiPort.cs
+++ b/src/ApiPort/ApiPort/ConsoleApiPort.cs
@@ -101,6 +101,23 @@ namespace ApiPort
             }
         }
 
+        public async Task DetermineOrderAsync()
+        {
+            var order = await _apiPortClient.DetermineDependencyOrderAsync(_options);
+
+            Console.WriteLine();
+
+            if (order.Any())
+            {
+                Console.WriteLine("Order porting should be addressed:");
+
+                foreach (var assembly in order)
+                {
+                    Console.WriteLine(LocalizedStrings.TargetsListNoVersion, assembly.GetAssemblyName());
+                }
+            }
+        }
+
         public async Task AnalyzeAssembliesAsync()
         {
             var outputPaths = await _apiPortClient.WriteAnalysisReportsAsync(_options);

--- a/src/ApiPort/ApiPort/DependencyBuilder.cs
+++ b/src/ApiPort/ApiPort/DependencyBuilder.cs
@@ -34,6 +34,9 @@ namespace ApiPort
             builder.RegisterInstance<ProductInformation>(productInformation);
             builder.RegisterInstance<ICommandLineOptions>(options);
 
+            builder.RegisterType<DependencyOrderer>()
+                .As<IDependencyOrderer>();
+
             builder.RegisterType<ConsoleCredentialProvider>()
                 .As<ICredentialProvider>()
                 .SingleInstance();

--- a/src/ApiPort/ApiPort/Program.cs
+++ b/src/ApiPort/ApiPort/Program.cs
@@ -52,6 +52,9 @@ namespace ApiPort
                         case AppCommand.ListOutputFormats:
                             await client.ListOutputFormatsAsync();
                             break;
+                        case AppCommand.Order:
+                            await client.DetermineOrderAsync();
+                            break;
                     }
 
                     return 0;

--- a/src/ApiPort/ApiPort/Resources/LocalizedStrings.Designer.cs
+++ b/src/ApiPort/ApiPort/Resources/LocalizedStrings.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace ApiPort.Resources {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace ApiPort.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class LocalizedStrings {
@@ -40,7 +39,7 @@ namespace ApiPort.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("ApiPort.Resources.LocalizedStrings", typeof(LocalizedStrings).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("ApiPort.Resources.LocalizedStrings", typeof(LocalizedStrings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -247,6 +246,24 @@ namespace ApiPort.Resources {
         internal static string CmdEndpoint {
             get {
                 return ResourceManager.GetString("CmdEndpoint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Entrypoint assembly. Used to identify order of dependencies to address any porting activities..
+        /// </summary>
+        internal static string CmdEntryPointAssembly {
+            get {
+                return ResourceManager.GetString("CmdEntryPointAssembly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Identify the order of supplied assemblies to be ported..
+        /// </summary>
+        internal static string CmdOrder {
+            get {
+                return ResourceManager.GetString("CmdOrder", resourceCulture);
             }
         }
         

--- a/src/ApiPort/ApiPort/Resources/LocalizedStrings.resx
+++ b/src/ApiPort/ApiPort/Resources/LocalizedStrings.resx
@@ -295,4 +295,10 @@ Versions marked with an asterisk (*) implies that these are default targets if n
   <data name="CmdDumpAnalysis" xml:space="preserve">
     <value>Write the analysis request to the output file without sending any data to the service</value>
   </data>
+  <data name="CmdEntryPointAssembly" xml:space="preserve">
+    <value>Entrypoint assembly. Used to identify order of dependencies to address any porting activities.</value>
+  </data>
+  <data name="CmdOrder" xml:space="preserve">
+    <value>Identify the order of supplied assemblies to be ported.</value>
+  </data>
 </root>

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/DependencyFilterExtensions.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/DependencyFilterExtensions.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Reflection;
+
+namespace Microsoft.Fx.Portability.Analyzer
+{
+    public static class DependencyFilterExtensions
+    {
+        public static bool IsFrameworkAssembly(this IDependencyFilter filter, AssemblyName assembly)
+        {
+            var publicKey = assembly.GetPublicKeyToken();
+
+            return filter.IsFrameworkAssembly(assembly.Name, publicKey is null ? PublicKeyToken.Empty : new PublicKeyToken(publicKey.ToImmutableArray()));
+        }
+    }
+}

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/DotNetFrameworkFilter.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/DotNetFrameworkFilter.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Fx.Portability.Analyzer
             "Microsoft.AspNetCore.",
             "Microsoft.CSharp.",
             "Microsoft.EntityFrameworkCore.",
+            "Microsoft.Extensions.",
             "Microsoft.Win32.",
             "Microsoft.VisualBasic.",
             "Windows."

--- a/src/lib/Microsoft.Fx.Portability/DependencyOrderer.cs
+++ b/src/lib/Microsoft.Fx.Portability/DependencyOrderer.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Fx.Portability.Analyzer;
+using Microsoft.Fx.Portability.ObjectModel;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.Fx.Portability
+{
+    public class DependencyOrderer : IDependencyOrderer
+    {
+        private readonly IDependencyFilter _filter;
+
+        public DependencyOrderer(IDependencyFilter filter)
+        {
+            _filter = filter;
+        }
+
+        public IEnumerable<AssemblyInfo> GetOrder(AssemblyInfo entryPoint, IEnumerable<AssemblyInfo> userAssemblies)
+        {
+            if (entryPoint is null)
+            {
+                return Enumerable.Empty<AssemblyInfo>();
+            }
+
+            var assemblies = userAssemblies
+                .Where(a => !_filter.IsFrameworkAssembly(a.GetAssemblyName()))
+                .ToDictionary(t => t.GetAssemblyName().Name, StringComparer.Ordinal);
+
+            return PostOrderTraversal(
+                new[] { entryPoint },
+                a => a.AssemblyReferences?.Select(r =>
+                    {
+                        if (assemblies.TryGetValue(r.Name, out var info))
+                        {
+                            return info;
+                        }
+                        else
+                        {
+                            return null;
+                        }
+                    })
+                    .Where(r => r != null) ?? Enumerable.Empty<AssemblyInfo>());
+        }
+
+        private static IEnumerable<T> PostOrderTraversal<T>(IEnumerable<T> initial, Func<T, IEnumerable<T>> selector, IEqualityComparer<T> comparer = null)
+        {
+            var result = new List<T>();
+            var visited = new HashSet<T>(comparer);
+
+            void Visit(T item)
+            {
+                if (!visited.Add(item))
+                {
+                    return;
+                }
+
+                foreach (var inner in selector(item))
+                {
+                    Visit(inner);
+                }
+
+                result.Add(item);
+            }
+
+            foreach (var item in initial)
+            {
+                Visit(item);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/lib/Microsoft.Fx.Portability/IApiPortOptions.cs
+++ b/src/lib/Microsoft.Fx.Portability/IApiPortOptions.cs
@@ -38,5 +38,7 @@ namespace Microsoft.Fx.Portability
         bool OverwriteOutputFile { get; }
 
         IEnumerable<string> ReferencedNuGetPackages { get; }
+
+        string EntryPoint { get; }
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/IDependencyOrderer.cs
+++ b/src/lib/Microsoft.Fx.Portability/IDependencyOrderer.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Fx.Portability.ObjectModel;
+using System.Collections.Generic;
+
+namespace Microsoft.Fx.Portability
+{
+    public interface IDependencyOrderer
+    {
+        IEnumerable<AssemblyInfo> GetOrder(AssemblyInfo entryPoint, IEnumerable<AssemblyInfo> assemblies);
+    }
+}

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/AssemblyInfo.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/AssemblyInfo.cs
@@ -6,10 +6,12 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
+using System.Reflection;
 
 namespace Microsoft.Fx.Portability.ObjectModel
 {
-    public sealed class AssemblyInfo : IComparable
+    public sealed class AssemblyInfo : IComparable, IComparable<AssemblyInfo>
     {
         private bool _hashComputed;
         private int _hashCode;
@@ -31,6 +33,8 @@ namespace Microsoft.Fx.Portability.ObjectModel
                 _hashComputed = false;
             }
         }
+
+        public AssemblyName GetAssemblyName() => new AssemblyName(AssemblyIdentity);
 
         /// <summary>
         /// Gets or sets the assembly location.
@@ -103,11 +107,16 @@ namespace Microsoft.Fx.Portability.ObjectModel
             return string.Format(CultureInfo.InvariantCulture, LocalizedStrings.FullAssemblyIdentity, AssemblyIdentity, FileVersion);
         }
 
-        public int CompareTo(object obj)
-        {
-            var obj2 = obj as AssemblyInfo;
+        public int CompareTo(object obj) => CompareTo(obj as AssemblyInfo);
 
-            return string.Compare(AssemblyIdentity, obj2.AssemblyIdentity, StringComparison.Ordinal);
+        public int CompareTo(AssemblyInfo other)
+        {
+            if (other is null)
+            {
+                return -1;
+            }
+
+            return string.Compare(AssemblyIdentity, other.AssemblyIdentity, StringComparison.Ordinal);
         }
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/AssemblyReferenceInformation.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/AssemblyReferenceInformation.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Fx.Portability.Resources;
 using System;
+using System.Collections.Immutable;
 using System.Globalization;
 
 namespace Microsoft.Fx.Portability.ObjectModel
@@ -12,6 +13,24 @@ namespace Microsoft.Fx.Portability.ObjectModel
         private static readonly StringComparer DefaultComparer = StringComparer.OrdinalIgnoreCase;
 
         private readonly string _string;
+
+        public AssemblyReferenceInformation(AssemblyInfo info)
+        {
+            var name = info.GetAssemblyName();
+
+            Name = name.Name;
+            Version = name.Version;
+            Culture = name.CultureName;
+
+            var publicKey = name.GetPublicKeyToken();
+
+            if (publicKey != null)
+            {
+                PublicKeyToken = new PublicKeyToken(publicKey.ToImmutableArray());
+            }
+
+            _string = string.Format(CultureInfo.CurrentCulture, LocalizedStrings.AssemblyReferenceInformation, Name, Version, Culture, PublicKeyToken);
+        }
 
         public AssemblyReferenceInformation(string name, Version version, string culture, PublicKeyToken publicKeyToken)
         {

--- a/src/lib/Microsoft.Fx.Portability/ReadWriteApiPortOptions.cs
+++ b/src/lib/Microsoft.Fx.Portability/ReadWriteApiPortOptions.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Fx.Portability
             OutputFileName = other.OutputFileName;
             OverwriteOutputFile = other.OverwriteOutputFile;
             ReferencedNuGetPackages = other.ReferencedNuGetPackages;
+            EntryPoint = other.EntryPoint;
         }
 
         public virtual IEnumerable<string> BreakingChangeSuppressions { get; set; }
@@ -53,5 +54,7 @@ namespace Microsoft.Fx.Portability
         public virtual bool OverwriteOutputFile { get; set; }
 
         public IEnumerable<string> ReferencedNuGetPackages { get; }
+
+        public string EntryPoint { get; set; }
     }
 }

--- a/tests/ApiPort/ApiPortVS.Tests/OptionsViewModelTest.cs
+++ b/tests/ApiPort/ApiPortVS.Tests/OptionsViewModelTest.cs
@@ -34,9 +34,10 @@ namespace ApiPortVS.Tests
             var dependencyFinder = Substitute.For<IDependencyFinder>();
             var reportGenerator = Substitute.For<IReportGenerator>();
             var ignoreAssemblyInfoList = Substitute.For<IEnumerable<IgnoreAssemblyInfo>>();
+            var orderer = Substitute.For<IDependencyOrderer>();
             var writer = Substitute.For<IFileWriter>();
 
-            var client = new ApiPortClient(service, progressReporter, targetMapper, dependencyFinder, reportGenerator, ignoreAssemblyInfoList, writer);
+            var client = new ApiPortClient(service, progressReporter, targetMapper, dependencyFinder, reportGenerator, ignoreAssemblyInfoList, writer, orderer);
             var options = Substitute.For<IApiPortOptions>();
 
             var resultFormats = Enumerable.Range(0, 5)
@@ -121,9 +122,10 @@ namespace ApiPortVS.Tests
             var dependencyFinder = Substitute.For<IDependencyFinder>();
             var reportGenerator = Substitute.For<IReportGenerator>();
             var ignoreAssemblyInfoList = Substitute.For<IEnumerable<IgnoreAssemblyInfo>>();
+            var orderer = Substitute.For<IDependencyOrderer>();
             var writer = Substitute.For<IFileWriter>();
 
-            var client = new ApiPortClient(service, progressReporter, targetMapper, dependencyFinder, reportGenerator, ignoreAssemblyInfoList, writer);
+            var client = new ApiPortClient(service, progressReporter, targetMapper, dependencyFinder, reportGenerator, ignoreAssemblyInfoList, writer, orderer);
             var options = Substitute.For<IApiPortOptions>();
 
             var resultFormats = Enumerable.Range(0, 5)
@@ -196,9 +198,10 @@ namespace ApiPortVS.Tests
             var dependencyFinder = Substitute.For<IDependencyFinder>();
             var reportGenerator = Substitute.For<IReportGenerator>();
             var ignoreAssemblyInfoList = Substitute.For<IEnumerable<IgnoreAssemblyInfo>>();
+            var orderer = Substitute.For<IDependencyOrderer>();
             var writer = Substitute.For<IFileWriter>();
 
-            var client = new ApiPortClient(service, progressReporter, targetMapper, dependencyFinder, reportGenerator, ignoreAssemblyInfoList, writer);
+            var client = new ApiPortClient(service, progressReporter, targetMapper, dependencyFinder, reportGenerator, ignoreAssemblyInfoList, writer, orderer);
             var options = Substitute.For<IApiPortOptions>();
 
             var platforms = Enumerable.Range(0, 20).Select(platform =>

--- a/tests/lib/Microsoft.Fx.Portability.Tests/Analyzer/DependencyOrderTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/Analyzer/DependencyOrderTests.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Fx.Portability.ObjectModel;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Fx.Portability.Analyzer.Tests
+{
+    public class DependencyOrderTests
+    {
+        [Fact]
+        public void NoEntrypoint()
+        {
+            var filter = Substitute.For<IDependencyFilter>();
+            var orderer = new DependencyOrderer(filter);
+            var result = orderer.GetOrder(null, new[] { new AssemblyInfo() });
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void AssembliesFiltered()
+        {
+            var filter = Substitute.For<IDependencyFilter>();
+            var orderer = new DependencyOrderer(filter);
+            var test1 = new AssemblyInfo { AssemblyIdentity = "Test1" };
+            var test2 = new AssemblyInfo { AssemblyIdentity = "Test2" };
+            var entryPoint = new AssemblyInfo
+            {
+                AssemblyIdentity = "Test",
+                AssemblyReferences = new[]
+                {
+                    new AssemblyReferenceInformation(test1),
+                    new AssemblyReferenceInformation(test2)
+                }
+            };
+
+            filter.IsFrameworkAssembly("Test1", Arg.Any<PublicKeyToken>()).Returns(true);
+
+            var result = orderer.GetOrder(entryPoint, new[] { entryPoint, test1, test2 });
+
+            Assert.Collection(result,
+                t => Assert.Same(test2, t),
+                t => Assert.Same(entryPoint, t));
+        }
+
+        /// <summary>
+        /// Tests the following graph.
+        ///
+        /// <![CDATA[
+        ///      +---+
+        ///      | A |
+        ///      +---+
+        ///        |
+        ///        |
+        ///        v
+        ///      +---+
+        ///      | B |
+        ///      +---+
+        ///        |
+        ///   +----+----+
+        ///   |         |
+        ///   v         v
+        /// +---+     +---+
+        /// | C | --> | D |
+        /// +---+     +---+
+        ///   |         |
+        ///   |         |
+        ///   |         v
+        ///   |       +---+
+        ///   ------> | E |
+        ///           +---+
+        /// ]]>
+        /// </summary>
+        [Fact]
+        public void DeepDependency()
+        {
+            var filter = Substitute.For<IDependencyFilter>();
+            var orderer = new DependencyOrderer(filter);
+            var e = new AssemblyInfo { AssemblyIdentity = "e" };
+            var d = new AssemblyInfo
+            {
+                AssemblyIdentity = "d",
+                AssemblyReferences = new[] { new AssemblyReferenceInformation(e) }
+            };
+            var c = new AssemblyInfo
+            {
+                AssemblyIdentity = "c",
+                AssemblyReferences = new[]
+                {
+                    new AssemblyReferenceInformation(e),
+                    new AssemblyReferenceInformation(d),
+                }
+            };
+            var b = new AssemblyInfo
+            {
+                AssemblyIdentity = "b",
+                AssemblyReferences = new[]
+                {
+                    new AssemblyReferenceInformation(c),
+                    new AssemblyReferenceInformation(d),
+                }
+            };
+            var a = new AssemblyInfo
+            {
+                AssemblyIdentity = "a",
+                AssemblyReferences = new[]
+                {
+                    new AssemblyReferenceInformation(b),
+                }
+            };
+
+            var result = orderer.GetOrder(a, new[] { a, b, c, d, e });
+
+            Assert.Collection(result,
+                t => Assert.Same(e, t),
+                t => Assert.Same(d, t),
+                t => Assert.Same(c, t),
+                t => Assert.Same(b, t),
+                t => Assert.Same(a, t));
+        }
+    }
+}

--- a/tests/lib/Microsoft.Fx.Portability.Tests/Analyzer/DotNetFrameworkFilterTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/Analyzer/DotNetFrameworkFilterTests.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Fx.Portability.Analyzer;
 using Xunit;
 
-namespace Microsoft.Fx.Portability.MetadataReader.Tests
+namespace Microsoft.Fx.Portability.Analyzer.Tests
 {
     public class DotNetFrameworkFilterTests
     {
@@ -53,6 +52,7 @@ namespace Microsoft.Fx.Portability.MetadataReader.Tests
         [InlineData("Microsoft.AspNetCore.Http", true)]
         [InlineData("microsoft.aspnetcore.http", true)]
         [InlineData("Microsoft.Win32.VisualBasic", true)]
+        [InlineData("Microsoft.Extensions.Configuration", true)]
         [InlineData("mono.something", false)]
         [InlineData("Mono.something", false)]
         [InlineData("mscorlib", true)]

--- a/tests/lib/Microsoft.Fx.Portability.Tests/ApiPortClientTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/ApiPortClientTests.cs
@@ -33,12 +33,13 @@ namespace Microsoft.Fx.Portability.Tests
             var dependencyFinder = Substitute.For<IDependencyFinder>();
             var reportGenerator = Substitute.For<IReportGenerator>();
             var ignoreAssemblyInfoList = Substitute.For<IEnumerable<IgnoreAssemblyInfo>>();
+            var orderer = Substitute.For<IDependencyOrderer>();
             var writer = Substitute.For<IFileWriter>();
 
             var apiPortService = Substitute.For<IApiPortService>();
             apiPortService.GetTargetsAsync().Returns(CreateResponse<IEnumerable<AvailableTarget>>(targets.AsReadOnly()));
 
-            var client = new ApiPortClient(apiPortService, progressReporter, targetMapper, dependencyFinder, reportGenerator, ignoreAssemblyInfoList, writer);
+            var client = new ApiPortClient(apiPortService, progressReporter, targetMapper, dependencyFinder, reportGenerator, ignoreAssemblyInfoList, writer, orderer);
 
             var actualTargets = await client.GetTargetsAsync();
 
@@ -54,9 +55,10 @@ namespace Microsoft.Fx.Portability.Tests
             var dependencyFinder = Substitute.For<IDependencyFinder>();
             var reportGenerator = Substitute.For<IReportGenerator>();
             var ignoreAssemblyInfoList = Substitute.For<IEnumerable<IgnoreAssemblyInfo>>();
+            var orderer = Substitute.For<IDependencyOrderer>();
             var writer = Substitute.For<IFileWriter>();
 
-            var client = new ApiPortClient(service, progressReporter, targetMapper, dependencyFinder, reportGenerator, ignoreAssemblyInfoList, writer);
+            var client = new ApiPortClient(service, progressReporter, targetMapper, dependencyFinder, reportGenerator, ignoreAssemblyInfoList, writer, orderer);
             var options = Substitute.For<IApiPortOptions>();
             options.Targets.Returns(Enumerable.Range(0, 16).Select(x => x.ToString(CultureInfo.CurrentCulture)));
             options.OutputFormats.Returns(new[] { "HTML", "Excel" });
@@ -162,12 +164,13 @@ namespace Microsoft.Fx.Portability.Tests
             var dependencyFinder = Substitute.For<IDependencyFinder>();
             var reportGenerator = Substitute.For<IReportGenerator>();
             var ignoreAssemblyInfoList = Substitute.For<IEnumerable<IgnoreAssemblyInfo>>();
+            var orderer = Substitute.For<IDependencyOrderer>();
             var writer = Substitute.For<IFileWriter>();
 
             service.SendAnalysisAsync(Arg.Any<AnalyzeRequest>(), Arg.Any<IEnumerable<string>>()).Returns(
                 ServiceResponse.Create(Enumerable.Empty<ReportingResultWithFormat>()));
 
-            var client = new ApiPortClient(service, progressReporter, targetMapper, dependencyFinder, reportGenerator, ignoreAssemblyInfoList, writer);
+            var client = new ApiPortClient(service, progressReporter, targetMapper, dependencyFinder, reportGenerator, ignoreAssemblyInfoList, writer, orderer);
             var options = Substitute.For<IApiPortOptions>();
 
             IAssemblyFile CreateAssemblyFile(AssemblyInfo assemblyInfo)

--- a/tests/lib/Microsoft.Fx.Portability.Tests/ReadWriteApiPortOptionsTests.cs
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/ReadWriteApiPortOptionsTests.cs
@@ -52,6 +52,8 @@ namespace Microsoft.Fx.Portability.Tests
 
             public IEnumerable<string> ReferencedNuGetPackages { get; }
 
+            public string EntryPoint { get; } = GetRandomString();
+
             private static IEnumerable<string> GenerateRandomList(int length)
             {
                 return Enumerable.Range(0, length)


### PR DESCRIPTION
When looking at converting multiple projects, it works best to do a bottom-up approach so that when you start a new project, the dependencies are all available on .NET Standard/.NET Core. This provides a command to identify that.

Usage: apiport.exe order -f [file or directories] -e [entrypoint]

The entry point is needed to identify what dependencies are required to get that specific app (or library) ported. The result will be a list of supplied assemblies in the recommended order.