### PR TITLE
Switch to FxCop analyzers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,16 +63,6 @@ jobs:
   - script: dotnet publish src/ApiPort/ApiPort/ApiPort.csproj -r win7-x86 -f netcoreapp2.1 --self-contained true
     displayName: publish self-contained apiport - win7-x86
 
-  - powershell: |
-      # Extract rule Ids into a plaintext file that is expected by the Roslyn Analyzer build task
-      $xdoc = [xml](Get-Content ".\rules.ruleset")
-      $xdoc.RuleSet.Rules.Rule.Id | Out-File "bin\RoslynAnalyzerSuppressions.txt"
-
-      # Add NoWarn Ids
-      $xdoc = [xml](Get-Content ".\Directory.Build.props")
-      $xdoc.Project.PropertyGroup.NoWarn -split "," | Select -skip 1 | Where {$_} | Add-Content ".\bin\RoslynAnalyzerSuppressions.txt"
-    displayName: Extract suppression ids for Roslyn Analyzer task
-
   - task: VSTest@2
     displayName: Test with VSTest
     inputs:
@@ -118,11 +108,6 @@ jobs:
       Contents: '**\*.pdb'
       TargetFolder: $(Build.StagingDirectory)\symbols
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
-    displayName: Run Roslyn Analyzers
-    inputs:
-      suppressionFileForCompilerWarnings: bin\RoslynAnalyzerSuppressions.txt
-
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: Component Detection
 
@@ -130,17 +115,6 @@ jobs:
     displayName: Publish drop
     artifact: drop-$(Agent.JobName)
     enabled: false
-
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-fxcop.FxCop@2
-    displayName: 'Run FxCop'
-    inputs:
-      inputType: Basic
-      targets: 'bin\$(BuildConfiguration)\ApiPort*\net4*\**\ApiPort*.*;bin\$(BuildConfiguration)\ApiPort.Offline\net4*\**\Microsoft.Fx.*.dll;'
-      recursive: false
-      directory: 'C:\Windows\Microsoft.NET\Framework\v4.0.30319'
-      verbose: true
-    enabled: false
-    continueOnError: true
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
     displayName: 'Run BinSkim '

--- a/src/ApiPort/ApiPort.VisualStudio/AnalyzeMenu.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/AnalyzeMenu.cs
@@ -71,7 +71,9 @@ namespace ApiPortVS
                 _output.WriteLine();
                 _output.WriteLine(ex.Message);
             }
+#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 _output.WriteLine();
                 _output.WriteLine(LocalizedStrings.UnknownError);
@@ -140,7 +142,9 @@ namespace ApiPortVS
                 _output.WriteLine();
                 _output.WriteLine(ex.Message);
             }
+#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 _output.WriteLine();
                 _output.WriteLine(LocalizedStrings.UnknownError);

--- a/src/ApiPort/ApiPort.VisualStudio/OutputWindowWriter.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/OutputWindowWriter.cs
@@ -24,7 +24,7 @@ namespace ApiPortVS
         public OutputWindowWriter(DTE dte, IVsOutputWindowPane outputWindow)
             : base(CultureInfo.CurrentCulture)
         {
-            _outputWindow = outputWindow;
+            _outputWindow = outputWindow ?? throw new ArgumentNullException(nameof(outputWindow));
             _dte = dte;
 
             _outputWindow.Clear();
@@ -43,7 +43,9 @@ namespace ApiPortVS
                 Window window = _dte.Windows.Item(Constants.VsWindowKindOutput);
                 window.Activate();
             }
+#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception)
+#pragma warning restore CA1031 // Do not catch general exception types
             {
             }
         }

--- a/src/ApiPort/ApiPort.VisualStudio/Reporting/VsBrowserReportViewer.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/Reporting/VsBrowserReportViewer.cs
@@ -29,7 +29,7 @@ namespace ApiPortVS.Reporting
 
         public async Task ViewAsync(IEnumerable<string> urls)
         {
-            foreach (var url in urls)
+            foreach (var url in urls ?? throw new ArgumentNullException(nameof(urls)))
             {
                 if (IsHtml(url))
                 {

--- a/src/ApiPort/ApiPort.VisualStudio/ServiceProvider.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/ServiceProvider.cs
@@ -15,6 +15,7 @@ using Microsoft.Fx.Portability;
 using Microsoft.Fx.Portability.Analyzer;
 using Microsoft.Fx.Portability.Proxy;
 using Microsoft.Fx.Portability.Reporting;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -172,20 +173,14 @@ namespace ApiPortVS
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            if (outputWindow.GetPane(ref _outputWindowGuid, out var windowPane) == S_OK)
+            if (ErrorHandler.Succeeded(outputWindow.GetPane(ref _outputWindowGuid, out var windowPane)))
             {
                 return windowPane;
             }
 
-            if (outputWindow.CreatePane(ref _outputWindowGuid, LocalizedStrings.PortabilityOutputTitle, 1, 0) == S_OK)
-            {
-                if (outputWindow.GetPane(ref _outputWindowGuid, out windowPane) == S_OK)
-                {
-                    return windowPane;
-                }
-            }
-
-            throw new InvalidOperationException("Could not create pane");
+            ErrorHandler.ThrowOnFailure(outputWindow.CreatePane(ref _outputWindowGuid, LocalizedStrings.PortabilityOutputTitle, 1, 0));
+            ErrorHandler.ThrowOnFailure(outputWindow.GetPane(ref _outputWindowGuid, out windowPane));
+            return windowPane;
         }
 
         private static OutputViewModel GetOutputViewModel(IComponentContext context)


### PR DESCRIPTION
This removes the the deprecated fxcop task in favor of running the newer fxcop Roslyn analyzers.
In fact the new fxcop roslyn analyzers are *already* running in this repo, as brought in by Directory.Build.targets. It's not the latest version, but updating it can happen sometime after we update the SDK we're using since right now, analyzer warnings aren't even showing up in VS.

I do fix a few issues that came up when updating the fxcop analyzer version temporarily though.

I also remove the special steps that "Run Roslyn Analyzers". I don't know what that task is meant to do, but roslyn analyzers run as part of the build, and this task not only repeats that to some extent, it also repeats the package restore and build to some extent. It also fails for virtually every PR (all unrelated), so removing it allows us to move forward.