### PR TITLE
Remove state in DGMLOutputWriter

### DIFF
--- a/src/lib/Microsoft.Fx.Portability.Reports.DGML/DGMLOutputWriter.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.DGML/DGMLOutputWriter.cs
@@ -22,17 +22,16 @@ namespace Microsoft.Fx.Portability.Reports.DGML
             FileExtension = ".dgml"
         };
 
-        private DGMLManager dgml;
-
         public Task WriteStreamAsync(Stream stream, AnalyzeResponse response)
         {
             // Create a new dgml every time write to a new stream.
-            dgml = new DGMLManager();
-            ReferenceGraph rg = ReferenceGraph.CreateGraph(response);
+            var dgml = new DGMLManager();
+            var rg = ReferenceGraph.CreateGraph(response);
 
-            ReportingResult analysisResult = response.ReportingResult;
+            var analysisResult = response.ReportingResult;
             var targets = analysisResult.Targets;
-            GenerateTargetContainers(targets);
+
+            GenerateTargetContainers(dgml, targets);
             dgml.SetTitle(response.ApplicationName);
 
             // For each target, let's generate the assemblies
@@ -111,7 +110,7 @@ namespace Microsoft.Fx.Portability.Reports.DGML
             return string.Join("\n", missingTypesForFramework);
         }
 
-        private void GenerateTargetContainers(IList<FrameworkName> targets)
+        private static void GenerateTargetContainers(DGMLManager dgml, IList<FrameworkName> targets)
         {
             for (int i = 0; i < targets.Count; i++)
             {


### PR DESCRIPTION
Output Writers are expected to be stateless and can have their WriteStreamAsync called concurrently (such as in the service). By storing the DGMLManager to a field, this would end up potentially being overwritten part way through a request output.

Fixes #814