### PR TITLE
Fix "Analyze Assembly" to "Analyze Solution"

### DIFF
--- a/src/ApiPort/ApiPort.VisualStudio/ApiPort.VisualStudio.vsct
+++ b/src/ApiPort/ApiPort.VisualStudio/ApiPort.VisualStudio.vsct
@@ -83,7 +83,7 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <CommandFlag>DefaultInvisible</CommandFlag>
         <Strings>
-          <ButtonText>Analyze Assembly Portability</ButtonText>
+          <ButtonText>Analyze Solution Portability</ButtonText>
         </Strings>
       </Button>
 


### PR DESCRIPTION
This must have been a copy/paste error when it was put in. This is the selection on the solution node.