### PR TITLE
Added exception info capabilities into apiport

### DIFF
--- a/src/ApiPort/ApiPort/CommandLineOptions.cs
+++ b/src/ApiPort/ApiPort/CommandLineOptions.cs
@@ -27,6 +27,7 @@ namespace ApiPort
             bool showNonPortableApis = true;
             bool showBreakingChanges = false;
             bool showRetargettingIssues = false;
+            bool showExceptionApis = false;
             bool noDefaultIgnoreFile = false;
             IReadOnlyList<string> ignoreAssemblyFile = Array.Empty<string>();
             IReadOnlyList<string> suppressBreakingChange = Array.Empty<string>();
@@ -51,6 +52,7 @@ namespace ApiPort
                     syntax.DefineOption("p|showNonPortableApis", ref showNonPortableApis, LocalizedStrings.CmdAnalyzeShowNonPortableApis);
                     syntax.DefineOption("b|showBreakingChanges", ref showBreakingChanges, LocalizedStrings.CmdAnalyzeShowBreakingChanges);
                     syntax.DefineOption("u|showRetargettingIssues", ref showRetargettingIssues, LocalizedStrings.CmdAnalyzeShowRetargettingIssues);
+                    syntax.DefineOption("x|showExceptionApis", ref showExceptionApis, LocalizedStrings.CmdAnalyzeShowRetargettingIssues);
                     syntax.DefineOption("force", ref overwriteOutput, LocalizedStrings.OverwriteFile);
                     syntax.DefineOption("noDefaultIgnoreFile", ref noDefaultIgnoreFile, LocalizedStrings.CmdAnalyzeNoDefaultIgnoreFile);
                     syntax.DefineOptionList("i|ignoreAssemblyFile", ref ignoreAssemblyFile, LocalizedStrings.CmdAnalyzeIgnoreAssembliesFile);
@@ -107,14 +109,14 @@ namespace ApiPort
                 OutputFileName = outFile,
                 OutputFormats = result,
                 OverwriteOutputFile = overwriteOutput,
-                RequestFlags = GetRequestFlags(showBreakingChanges, showRetargettingIssues, showNonPortableApis),
+                RequestFlags = GetRequestFlags(showBreakingChanges, showRetargettingIssues, showNonPortableApis, showExceptionApis),
                 ServiceEndpoint = endpoint,
                 TargetMapFile = targetMap,
                 Targets = target,
             };
         }
 
-        private static AnalyzeRequestFlags GetRequestFlags(bool showBreakingChanges, bool showRetargettingIssues, bool showNonPortableApis)
+        private static AnalyzeRequestFlags GetRequestFlags(bool showBreakingChanges, bool showRetargettingIssues, bool showNonPortableApis, bool showExceptionApis)
         {
             var requestFlags = default(AnalyzeRequestFlags);
 
@@ -132,6 +134,11 @@ namespace ApiPort
             if (showNonPortableApis)
             {
                 requestFlags |= AnalyzeRequestFlags.ShowNonPortableApis;
+            }
+
+            if (showExceptionApis)
+            {
+                requestFlags |= AnalyzeRequestFlags.ShowExceptionApis;
             }
 
             // If nothing is set, default to ShowNonPortableApis

--- a/src/lib/Microsoft.Fx.Portability.Offline/Data.cs
+++ b/src/lib/Microsoft.Fx.Portability.Offline/Data.cs
@@ -22,6 +22,23 @@ namespace Microsoft.Fx.Portability
             }
         }
 
+        public static AdditionalDataCatalog LoadAdditionalData()
+        {
+            var catalog = new AdditionalDataCatalog();
+            try
+            {
+                using (var stream = OpenFileOrResource($"exceptions.bin"))
+                {
+                    catalog.Exceptions = stream.DecompressToObject<List<ApiExceptionStorage>>();
+                }
+            }
+            catch
+            {
+                return null;
+            }
+            return catalog;
+        }
+
         public static IEnumerable<BreakingChange> LoadBreakingChanges()
         {
             // Prefer a local 'BreakingChanges' directory to embedded breaking changes

--- a/src/lib/Microsoft.Fx.Portability.Offline/Data.cs
+++ b/src/lib/Microsoft.Fx.Portability.Offline/Data.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 
 namespace Microsoft.Fx.Portability
@@ -32,10 +33,12 @@ namespace Microsoft.Fx.Portability
                     catalog.Exceptions = stream.DecompressToObject<List<ApiExceptionStorage>>();
                 }
             }
+            catch (PortabilityAnalyzerException e) { }
             catch
             {
-                return null;
+                throw;
             }
+
             return catalog;
         }
 

--- a/src/lib/Microsoft.Fx.Portability.Offline/Data.cs
+++ b/src/lib/Microsoft.Fx.Portability.Offline/Data.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Fx.Portability
         public static AdditionalDataCatalog LoadAdditionalData()
         {
             var catalog = new AdditionalDataCatalog();
+
             try
             {
                 using (var stream = OpenFileOrResource($"exceptions.bin"))
@@ -34,10 +35,6 @@ namespace Microsoft.Fx.Portability
                 }
             }
             catch (PortabilityAnalyzerException e) { }
-            catch
-            {
-                throw;
-            }
 
             return catalog;
         }

--- a/src/lib/Microsoft.Fx.Portability.Offline/Data.cs
+++ b/src/lib/Microsoft.Fx.Portability.Offline/Data.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Fx.Portability
             }
         }
 
+        /// <summary>
+        /// Location for loading in the Additional Data when ApiPort is being run in offline mode.
+        /// </summary>
+        /// <returns>An AdditionalDataCatalog containing found additional data.</returns>
         public static AdditionalDataCatalog LoadAdditionalData()
         {
             var catalog = new AdditionalDataCatalog();
@@ -34,7 +38,7 @@ namespace Microsoft.Fx.Portability
                     catalog.Exceptions = stream.DecompressToObject<List<ApiExceptionStorage>>();
                 }
             }
-            catch (PortabilityAnalyzerException e) { }
+            catch (PortabilityAnalyzerException) { }
 
             return catalog;
         }

--- a/src/lib/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
+++ b/src/lib/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
@@ -13,6 +13,7 @@
     <DataPath>$(OutputFullPath)\.data\</DataPath>
     <BreakingChangePath>$(OutputFullPath)\docs\BreakingChanges\</BreakingChangePath>
     <CatalogDataFile>$(DataPath)catalog.bin</CatalogDataFile>
+	<ExceptionDataFile>$(DataPath)exceptions.bin</ExceptionDataFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,6 +24,9 @@
       <Link>data\%(Filename)%(Extension)</Link>
       <BreakingChange>true</BreakingChange>
     </EmbeddedResource>
+	<EmbeddedResource Include="$(ExceptionDataFile)" Condition="Exists($(ExceptionDataFile))">
+		<Link>data\exceptions.bin</Link>
+	</EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/lib/Microsoft.Fx.Portability.Offline/OfflineApiCatalogLookup.cs
+++ b/src/lib/Microsoft.Fx.Portability.Offline/OfflineApiCatalogLookup.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Fx.Portability
     public class OfflineApiCatalogLookup : CloudApiCatalogLookup
     {
         public OfflineApiCatalogLookup(IProgressReporter progressReporter)
-            : base(GetData(progressReporter))
+            : base(GetData(progressReporter), GetAdditionalData(progressReporter))
         { }
 
         private static DotNetCatalog GetData(IProgressReporter progressReporter)
@@ -20,6 +20,22 @@ namespace Microsoft.Fx.Portability
                 try
                 {
                     return Data.LoadCatalog();
+                }
+                catch (Exception)
+                {
+                    progressTask.Abort();
+                    throw;
+                }
+            }
+        }
+
+        private static AdditionalDataCatalog GetAdditionalData(IProgressReporter progressReporter)
+        {
+            using (var progressTask = progressReporter.StartTask("Loading Additional Data"))
+            {
+                try
+                {
+                    return Data.LoadAdditionalData();
                 }
                 catch (Exception)
                 {

--- a/src/lib/Microsoft.Fx.Portability.Reports.Excel/ExcelOpenXmlOutputWriter.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Excel/ExcelOpenXmlOutputWriter.cs
@@ -436,10 +436,12 @@ namespace Microsoft.Fx.Portability.Reports
                     var groupsByTarget = grouping.exceptions.GroupBy(exc => new FrameworkName(exc.Platform, Version.Parse(exc.Version)), (framework, exceptionList) => new { Key = framework, exceptionsByPlatform = exceptionList });
                     foreach (var target in targets)
                     {
+                        bool hasExceptions = false;
                         foreach (var exceptionsByTarget in groupsByTarget)
                         {
                             if (exceptionsByTarget.Key.Equals(target))
                             {
+                                hasExceptions = true;
                                 string resourceIDHolder = string.Empty;
                                 foreach (var exception in exceptionsByTarget.exceptionsByPlatform.OrderBy(exc => exc.RID))
                                 {
@@ -455,6 +457,11 @@ namespace Microsoft.Fx.Portability.Reports
                                     rowContent.Add("No Notable Exceptions");
                                 }
                             }
+                        }
+
+                        if (!hasExceptions)
+                        {
+                            rowContent.Add("No Notable Exceptions");
                         }
                     }
 

--- a/src/lib/Microsoft.Fx.Portability.Reports.Excel/ExcelOpenXmlOutputWriter.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Excel/ExcelOpenXmlOutputWriter.cs
@@ -441,7 +441,7 @@ namespace Microsoft.Fx.Portability.Reports
                             if (exceptionsByTarget.Key.Equals(target))
                             {
                                 string resourceIDHolder = string.Empty;
-                                foreach (var exception in exceptionsByTarget.exceptionsByPlatform)
+                                foreach (var exception in exceptionsByTarget.exceptionsByPlatform.OrderBy(exc => exc.RID))
                                 {
                                     resourceIDHolder = string.Concat(resourceIDHolder, exception.RID + ";");
                                 }

--- a/src/lib/Microsoft.Fx.Portability.Reports.Excel/ExcelReportWriter.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Excel/ExcelReportWriter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Fx.Portability.Reports
 
         public Task WriteStreamAsync(Stream stream, AnalyzeResponse response)
         {
-            var excelWriter = new ExcelOpenXmlOutputWriter(_targetMapper, response.ReportingResult, response.BreakingChanges, response.CatalogLastUpdated, description: null);
+            var excelWriter = new ExcelOpenXmlOutputWriter(_targetMapper, response.ReportingResult, response.BreakingChanges, response.CatalogLastUpdated, response.ThrowingMembers, description: null);
 
             return excelWriter.WriteToAsync(stream);
         }

--- a/src/lib/Microsoft.Fx.Portability/Analysis/AnalysisEngine.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analysis/AnalysisEngine.cs
@@ -202,9 +202,9 @@ namespace Microsoft.Fx.Portability.Analysis
             return member;
         }
 
-        private static List<ApiExceptionStorage> GetThrownExceptions(IApiCatalogLookup catalog, string memberDocId, IEnumerable<FrameworkName> targets)
+        private static List<ApiException> GetThrownExceptions(IApiCatalogLookup catalog, string memberDocId, IEnumerable<FrameworkName> targets)
         {
-            List<ApiExceptionStorage> excepts;
+            List<ApiException> excepts;
             if ((excepts = catalog.GetApiExceptions(memberDocId)) != null)
             {
                 return excepts.Where(exc => !exc.Equals(null) && targets.Any(tg => tg.Equals(new FrameworkName(exc.Platform, Version.Parse(exc.Version))))).ToList();

--- a/src/lib/Microsoft.Fx.Portability/Analysis/AnalysisEngine.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analysis/AnalysisEngine.cs
@@ -146,6 +146,13 @@ namespace Microsoft.Fx.Portability.Analysis
             return missingMembers;
         }
 
+        /// <summary>
+        /// Finds the members that could throw an exception on the specified targets.
+        /// </summary>
+        /// <param name="targets">Frameworks to check for exceptions on.</param>
+        /// <param name="submittedAssemblies">Assemblies submitted for checking if the member is a part of the assemblies.</param>
+        /// <param name="dependencies">Dictionary of members with their corresponding assembly information.</param>
+        /// <returns>A list of ExceptionInfo providing necessary information on each member that may throw.</returns>
         public IList<ExceptionInfo> FindMembersMayThrow(IEnumerable<FrameworkName> targets, ICollection<string> submittedAssemblies, IDictionary<MemberInfo, ICollection<AssemblyInfo>> dependencies)
         {
             // Trace.TraceInformation("Computing members not in target");
@@ -213,17 +220,6 @@ namespace Microsoft.Fx.Portability.Analysis
             exceptionHold.ExceptionsThrown = GetThrownExceptions(catalog, member.MemberDocId, targets);
 
             return exceptionHold;
-        }
-
-        private static List<ApiException> GetThrownExceptions(IApiCatalogLookup catalog, string memberDocId, IEnumerable<FrameworkName> targets)
-        {
-            List<ApiException> excepts;
-            if ((excepts = catalog.GetApiExceptions(memberDocId)) != null)
-            {
-                return excepts.Where(exc => !exc.Equals(null) && targets.Any(tg => tg.Equals(new FrameworkName(exc.Platform, Version.Parse(exc.Version))))).ToList();
-            }
-
-            return null;
         }
 
         /// <summary>
@@ -421,6 +417,24 @@ namespace Microsoft.Fx.Portability.Analysis
             {
                 return obj.Item1.GetHashCode();
             }
+        }
+
+        /// <summary>
+        /// Gets the exceptions thrown by the <paramref name="memberDocId"/> for each <paramref name="targets"/>.
+        /// </summary>
+        /// <param name="catalog">Catalog to lookup from.</param>
+        /// <param name="memberDocId">DocId to find exceptions for.</param>
+        /// <param name="targets">Targets to find exceptions for.</param>
+        /// <returns>A list of the ApiExceptions for the <paramref name="memberDocId"/>. Returns null if no exceptions were found.</returns>
+        private static List<ApiException> GetThrownExceptions(IApiCatalogLookup catalog, string memberDocId, IEnumerable<FrameworkName> targets)
+        {
+            List<ApiException> excepts;
+            if ((excepts = catalog.GetApiExceptions(memberDocId)) != null)
+            {
+                return excepts.Where(exc => !exc.Equals(null) && targets.Any(tg => tg.Equals(new FrameworkName(exc.Platform, Version.Parse(exc.Version))))).ToList();
+            }
+
+            return null;
         }
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/RequestAnalyzer.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/RequestAnalyzer.cs
@@ -81,7 +81,9 @@ namespace Microsoft.Fx.Portability.Analyzer
                 ? _analysisEngine.FindBreakingChanges(targets, request.Dependencies, breakingChangeSkippedAssemblies, request.BreakingChangesToSuppress, userAssemblies, request.RequestFlags.HasFlag(AnalyzeRequestFlags.ShowRetargettingIssues)).ToList()
                 : new List<BreakingChangeDependency>();
 
-            var apiPotentialExceptions = _analysisEngine.FindMembersMayThrow(targets, userAssemblies, dependencies);
+            var apiPotentialExceptions = request.RequestFlags.HasFlag(AnalyzeRequestFlags.ShowExceptionApis)
+                ? _analysisEngine.FindMembersMayThrow(targets, userAssemblies, dependencies)
+                : Array.Empty<MemberInfo>();
 
             var reportingResult = _reportGenerator.ComputeReport(
                 targets,

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/RequestAnalyzer.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/RequestAnalyzer.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Fx.Portability.Analyzer
 
             var apiPotentialExceptions = request.RequestFlags.HasFlag(AnalyzeRequestFlags.ShowExceptionApis)
                 ? _analysisEngine.FindMembersMayThrow(targets, userAssemblies, dependencies)
-                : Array.Empty<MemberInfo>();
+                : Array.Empty<ExceptionInfo>();
 
             var reportingResult = _reportGenerator.ComputeReport(
                 targets,

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/RequestAnalyzer.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/RequestAnalyzer.cs
@@ -81,6 +81,8 @@ namespace Microsoft.Fx.Portability.Analyzer
                 ? _analysisEngine.FindBreakingChanges(targets, request.Dependencies, breakingChangeSkippedAssemblies, request.BreakingChangesToSuppress, userAssemblies, request.RequestFlags.HasFlag(AnalyzeRequestFlags.ShowRetargettingIssues)).ToList()
                 : new List<BreakingChangeDependency>();
 
+            var apiPotentialExceptions = _analysisEngine.FindMembersMayThrow(targets, userAssemblies, dependencies);
+
             var reportingResult = _reportGenerator.ComputeReport(
                 targets,
                 submissionId,
@@ -104,6 +106,7 @@ namespace Microsoft.Fx.Portability.Analyzer
                 BreakingChanges = breakingChanges,
                 BreakingChangeSkippedAssemblies = breakingChangeSkippedAssemblies,
                 NuGetPackages = nugetPackages,
+                ThrowingMembers = apiPotentialExceptions,
                 Request = request
             };
         }

--- a/src/lib/Microsoft.Fx.Portability/IAnalysisEngine.cs
+++ b/src/lib/Microsoft.Fx.Portability/IAnalysisEngine.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Fx.Portability
             IEnumerable<AssemblyInfo> userAssemblies,
             IEnumerable<IgnoreAssemblyInfo> assembliesToIgnore);
 
-        public IList<MemberInfo> FindMembersMayThrow(IEnumerable<FrameworkName> targets,
+        public IList<ExceptionInfo> FindMembersMayThrow(IEnumerable<FrameworkName> targets,
             ICollection<string> submittedAssemblies,
             IDictionary<MemberInfo,
             ICollection<AssemblyInfo>> dependencies);

--- a/src/lib/Microsoft.Fx.Portability/IAnalysisEngine.cs
+++ b/src/lib/Microsoft.Fx.Portability/IAnalysisEngine.cs
@@ -26,6 +26,11 @@ namespace Microsoft.Fx.Portability
             IEnumerable<AssemblyInfo> userAssemblies,
             IEnumerable<IgnoreAssemblyInfo> assembliesToIgnore);
 
+        public IList<MemberInfo> FindMembersMayThrow(IEnumerable<FrameworkName> targets,
+            ICollection<string> submittedAssemblies,
+            IDictionary<MemberInfo,
+            ICollection<AssemblyInfo>> dependencies);
+
         IEnumerable<BreakingChangeDependency> FindBreakingChanges(
             IEnumerable<FrameworkName> targets,
             IDictionary<MemberInfo, ICollection<AssemblyInfo>> dependencies,

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/AdditionalDataCatalog.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/AdditionalDataCatalog.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
 
 namespace Microsoft.Fx.Portability.ObjectModel
 {

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/AdditionalDataCatalog.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/AdditionalDataCatalog.cs
@@ -8,6 +8,11 @@ using System.Reflection;
 
 namespace Microsoft.Fx.Portability.ObjectModel
 {
+    /// <summary>
+    /// Catalog used for hold additional data not from ApiCatalog.
+    /// To be used to easily add data into the pipeline without having to change existing models.
+    /// Each field needs to be individually retrieved by the portability service and will likely be stored their own file/blob.
+    /// </summary>
     public class AdditionalDataCatalog
     {
         public IEnumerable<ApiExceptionStorage> Exceptions { get; set; }

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/AdditionalDataCatalog.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/AdditionalDataCatalog.cs
@@ -5,10 +5,8 @@ using System.Collections.Generic;
 
 namespace Microsoft.Fx.Portability.ObjectModel
 {
-    public class ApiExceptionStorage
+    public class AdditionalDataCatalog
     {
-        public string DocId { get; set; }
-
-        public IEnumerable<ApiException> Exceptions { get; set; }
+        public IEnumerable<ApiExceptionStorage> Exceptions { get; set; }
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/AnalyzeRequestFlags.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/AnalyzeRequestFlags.cs
@@ -14,5 +14,6 @@ namespace Microsoft.Fx.Portability.ObjectModel
         ShowBreakingChanges = 1 << 2,
         NoDefaultIgnoreFile = 1 << 3,
         ShowRetargettingIssues = 1 << 4,
+        ShowExceptionApis = 1 << 5
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/AnalyzeResponse.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/AnalyzeResponse.cs
@@ -43,6 +43,8 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         public IList<AssemblyInfo> BreakingChangeSkippedAssemblies { get; set; }
 
+        public IList<MemberInfo> ThrowingMembers { get; set; }
+
         public int CompareTo(object obj)
         {
             var analyzeObject = obj as AnalyzeResponse;

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/AnalyzeResponse.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/AnalyzeResponse.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         public IList<AssemblyInfo> BreakingChangeSkippedAssemblies { get; set; }
 
-        public IList<MemberInfo> ThrowingMembers { get; set; }
+        public IList<ExceptionInfo> ThrowingMembers { get; set; }
 
         public int CompareTo(object obj)
         {

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiException.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiException.cs
@@ -3,6 +3,10 @@
 
 namespace Microsoft.Fx.Portability.ObjectModel
 {
+    /// <summary>
+    /// A single ApiException used for holding the data of the single exception.
+    /// Includes override methods for Equals and ToString.
+    /// </summary>
     public class ApiException
     {
         public string Exception { get; set; }
@@ -26,6 +30,11 @@ namespace Microsoft.Fx.Portability.ObjectModel
         public virtual bool Equals(ApiException exc)
         {
             return exc != null && ToString().Equals(exc.ToString(), System.StringComparison.Ordinal);
+        }
+
+        public override int GetHashCode()
+        {
+            return ToString().GetHashCode();
         }
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiException.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiException.cs
@@ -12,5 +12,20 @@ namespace Microsoft.Fx.Portability.ObjectModel
         public string Platform { get; set; }
 
         public string Version { get; set; }
+
+        public override string ToString()
+        {
+            return $"{Exception}:{RID}_{Platform},v{Version}";
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ApiException);
+        }
+
+        public virtual bool Equals(ApiException exc)
+        {
+            return exc != null && ToString().Equals(exc.ToString(), System.StringComparison.Ordinal);
+        }
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiException.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiException.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-
 namespace Microsoft.Fx.Portability.ObjectModel
 {
-    public class ApiExceptionStorage
+    public class ApiException
     {
-        public string DocId { get; set; }
+        public string Exception { get; set; }
 
-        public IEnumerable<ApiException> Exceptions { get; set; }
+        public string RID { get; set; }
+
+        public string Platform { get; set; }
+
+        public string Version { get; set; }
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiExceptionStorage.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiExceptionStorage.cs
@@ -7,6 +7,10 @@ namespace Microsoft.Fx.Portability.ObjectModel
     {
         public string Exception { get; set; }
 
-        public string TFRIDS { get; set; }
+        public string RID { get; set; }
+
+        public string Platform { get; set; }
+
+        public string Version { get; set; }
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiExceptionStorage.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiExceptionStorage.cs
@@ -5,6 +5,9 @@ using System.Collections.Generic;
 
 namespace Microsoft.Fx.Portability.ObjectModel
 {
+    /// <summary>
+    /// Holds a DocId with corresponding Exceptions for easy storage of the exceptions thrown by Apis.
+    /// </summary>
     public class ApiExceptionStorage
     {
         public string DocId { get; set; }

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiExceptionStorage.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiExceptionStorage.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Fx.Portability.ObjectModel
+{
+    public class ApiExceptionStorage
+    {
+        public string Exception { get; set; }
+
+        public string TFRIDS { get; set; }
+    }
+}

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiInfoStorage.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiInfoStorage.cs
@@ -26,6 +26,6 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         public IReadOnlyCollection<ApiMetadataStorage> Metadata { get; set; }
 
-        public IReadOnlyCollection<ApiExceptionStorage> Exceptions { get; set; }
+        public IEnumerable<ApiExceptionStorage> Exceptions { get; set; }
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiInfoStorage.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiInfoStorage.cs
@@ -25,5 +25,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
         public IReadOnlyCollection<FrameworkName> Targets { get; set; }
 
         public IReadOnlyCollection<ApiMetadataStorage> Metadata { get; set; }
+
+        public IReadOnlyCollection<ApiExceptionStorage> Exceptions { get; set; }
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiInfoStorage.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiInfoStorage.cs
@@ -25,7 +25,5 @@ namespace Microsoft.Fx.Portability.ObjectModel
         public IReadOnlyCollection<FrameworkName> Targets { get; set; }
 
         public IReadOnlyCollection<ApiMetadataStorage> Metadata { get; set; }
-
-        public IEnumerable<ApiExceptionStorage> Exceptions { get; set; }
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
                 Parent = key.Parent
             });
 
+            // Populate the exception list if the additional data catalog contains exceptions.
             if (extra != null && extra.Exceptions != null)
             {
                 _apiExceptions = extra.Exceptions.AsParallel()

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
@@ -156,16 +156,14 @@ namespace Microsoft.Fx.Portability.ObjectModel
             return metadataValue;
         }
 
-        public virtual string GetApiException(string docId, string exceptionType)
+        public virtual Dictionary<string, string> GetApiExceptions(string docId)
         {
-            string exceptionTFRIDs = null;
-
             if (_apiExceptions.TryGetValue(docId, out var exceptions))
             {
-                exceptions.TryGetValue(exceptionType, out exceptionTFRIDs);
+                return exceptions;
             }
 
-            return exceptionTFRIDs;
+            return null;
         }
 
         public virtual string GetRecommendedChange(string docId)

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
         private readonly string _builtBy;
         private readonly Dictionary<string, Dictionary<string, Version>> _apiMapping;
         private readonly Dictionary<string, Dictionary<string, string>> _apiMetadata;
+        private readonly Dictionary<string, Dictionary<string, string>> _apiExceptions;
         private readonly Dictionary<string, FrameworkName> _latestTargetVersion;
         private readonly ICollection<string> _frameworkAssemblies;
         private readonly IReadOnlyCollection<FrameworkName> _publicTargets;
@@ -50,6 +51,16 @@ namespace Microsoft.Fx.Portability.ObjectModel
                                 value => value.Metadata.ToDictionary(
                                             innerKey => innerKey.MetadataKey,
                                             innerValue => innerValue.Value,
+                                            StringComparer.Ordinal),
+                                StringComparer.Ordinal);
+
+            _apiExceptions = catalog.Apis.AsParallel()
+                            .Where(api => api.Exceptions != null)
+                            .ToDictionary(
+                                key => key.DocId,
+                                value => value.Exceptions.ToDictionary(
+                                            innerKey => innerKey.Exception,
+                                            innerValue => innerValue.TFRIDS,
                                             StringComparer.Ordinal),
                                 StringComparer.Ordinal);
 
@@ -143,6 +154,18 @@ namespace Microsoft.Fx.Portability.ObjectModel
             }
 
             return metadataValue;
+        }
+
+        public virtual string GetApiException(string docId, string exceptionType)
+        {
+            string exceptionTFRIDs = null;
+
+            if (_apiExceptions.TryGetValue(docId, out var exceptions))
+            {
+                exceptions.TryGetValue(exceptionType, out exceptionTFRIDs);
+            }
+
+            return exceptionTFRIDs;
         }
 
         public virtual string GetRecommendedChange(string docId)

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
@@ -89,7 +89,10 @@ namespace Microsoft.Fx.Portability.ObjectModel
                      key => key.DocId,
                      value => value.Exceptions.ToList());
             }
-            else _apiExceptions = new Dictionary<string, List<ApiException>>();
+            else
+            {
+                _apiExceptions = new Dictionary<string, List<ApiException>>();
+            }
         }
 
         public virtual IEnumerable<string> DocIds

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
         private readonly string _builtBy;
         private readonly Dictionary<string, Dictionary<string, Version>> _apiMapping;
         private readonly Dictionary<string, Dictionary<string, string>> _apiMetadata;
-        private readonly Dictionary<string, Dictionary<string, string>> _apiExceptions;
+        private readonly Dictionary<string, List<ApiExceptionStorage>> _apiExceptions;
         private readonly Dictionary<string, FrameworkName> _latestTargetVersion;
         private readonly ICollection<string> _frameworkAssemblies;
         private readonly IReadOnlyCollection<FrameworkName> _publicTargets;
@@ -58,11 +58,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
                             .Where(api => api.Exceptions != null)
                             .ToDictionary(
                                 key => key.DocId,
-                                value => value.Exceptions.ToDictionary(
-                                            innerKey => innerKey.Exception,
-                                            innerValue => innerValue.TFRIDS,
-                                            StringComparer.Ordinal),
-                                StringComparer.Ordinal);
+                                value => value.Exceptions.ToList());
 
             _publicTargets = catalog.SupportedTargets
                                                 .Where(sp => sp.IsReleased)
@@ -156,7 +152,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
             return metadataValue;
         }
 
-        public virtual Dictionary<string, string> GetApiExceptions(string docId)
+        public virtual List<ApiExceptionStorage> GetApiExceptions(string docId)
         {
             if (_apiExceptions.TryGetValue(docId, out var exceptions))
             {

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/ExceptionInfo.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/ExceptionInfo.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Fx.Portability.ObjectModel
+{
+    public class ExceptionInfo
+    {
+        public string DefinedInAssemblyIdentity { get; set; }
+
+        public string MemberDocId { get; set; }
+
+        public List<ApiException> ExceptionsThrown { get; set; }
+
+        [JsonIgnore]
+        public bool IsSupportedAcrossTargets { get; set; }
+    }
+}

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/ExceptionInfo.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/ExceptionInfo.cs
@@ -5,6 +5,10 @@ using System.Text;
 
 namespace Microsoft.Fx.Portability.ObjectModel
 {
+    /// <summary>
+    /// Model used to pass exception data through the Analyze response.
+    /// Includes the Apis assembly, DocId, and the list of exceptions that it throws.
+    /// </summary>
     public class ExceptionInfo
     {
         public string DefinedInAssemblyIdentity { get; set; }

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/IApiCatalogLookup.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/IApiCatalogLookup.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         IEnumerable<TargetInfo> GetAllTargets();
 
+        Dictionary<string, string> GetApiExceptions(string docId);
+
         string GetRecommendedChange(string docId);
 
         string GetSourceCompatibilityEquivalent(string docId);

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/IApiCatalogLookup.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/IApiCatalogLookup.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         IEnumerable<TargetInfo> GetAllTargets();
 
-        Dictionary<string, string> GetApiExceptions(string docId);
+        List<ApiExceptionStorage> GetApiExceptions(string docId);
 
         string GetRecommendedChange(string docId);
 

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/IApiCatalogLookup.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/IApiCatalogLookup.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         IEnumerable<TargetInfo> GetAllTargets();
 
-        List<ApiExceptionStorage> GetApiExceptions(string docId);
+        List<ApiException> GetApiExceptions(string docId);
 
         string GetRecommendedChange(string docId);
 

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/MemberInfo.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/MemberInfo.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
         [JsonIgnore]
         public bool IsSupportedAcrossTargets { get; set; }
 
-        public Dictionary<string, string> ExceptionsThrown { get; set; }
+        public List<ApiExceptionStorage> ExceptionsThrown { get; set; }
 
         public override string ToString()
         {

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/MemberInfo.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/MemberInfo.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
         [JsonIgnore]
         public bool IsSupportedAcrossTargets { get; set; }
 
-        public List<ApiExceptionStorage> ExceptionsThrown { get; set; }
+        public List<ApiException> ExceptionsThrown { get; set; }
 
         public override string ToString()
         {

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/MemberInfo.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/MemberInfo.cs
@@ -4,6 +4,8 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Runtime.ExceptionServices;
 
 namespace Microsoft.Fx.Portability.ObjectModel
 {
@@ -69,6 +71,8 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         [JsonIgnore]
         public bool IsSupportedAcrossTargets { get; set; }
+
+        public Dictionary<string, string> ExceptionsThrown { get; set; }
 
         public override string ToString()
         {

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/MemberInfo.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/MemberInfo.cs
@@ -72,8 +72,6 @@ namespace Microsoft.Fx.Portability.ObjectModel
         [JsonIgnore]
         public bool IsSupportedAcrossTargets { get; set; }
 
-        public List<ApiException> ExceptionsThrown { get; set; }
-
         public override string ToString()
         {
             return MemberDocId;

--- a/tests/lib/Microsoft.Fx.Portability.Tests/TestData/TestCatalog.cs
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/TestData/TestCatalog.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Fx.Portability.TestData
             throw new NotImplementedException();
         }
 
-        public List<ApiExceptionStorage> GetApiExceptions(string docId)
+        public List<ApiException> GetApiExceptions(string docId)
         {
             throw new NotImplementedException();
         }

--- a/tests/lib/Microsoft.Fx.Portability.Tests/TestData/TestCatalog.cs
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/TestData/TestCatalog.cs
@@ -125,5 +125,10 @@ namespace Microsoft.Fx.Portability.TestData
         {
             throw new NotImplementedException();
         }
+
+        public List<ApiExceptionStorage> GetApiExceptions(string docId)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
Added models and methods to allow for the finding of APIs that may throw exceptions in addition to the general catalog API information. A majority of the changes are in the portability libraries because that is what does a majority of the processing and what holds the API lookup class. Also updated the Excel writer to all for the writing of the exception information.