### PR TITLE
Added all changes from ApiExceptionTieIn branch the changed Fx.Portab…

### DIFF
--- a/src/lib/Microsoft.Fx.Portability.Offline/Data.cs
+++ b/src/lib/Microsoft.Fx.Portability.Offline/Data.cs
@@ -38,7 +38,10 @@ namespace Microsoft.Fx.Portability
                     catalog.Exceptions = stream.DecompressToObject<List<ApiExceptionStorage>>();
                 }
             }
-            catch (PortabilityAnalyzerException) { }
+            catch (PortabilityAnalyzerException)
+            {
+                Console.WriteLine("Unable to find exceptions.bin so exceptions will not be included in report.");
+            }
 
             return catalog;
         }

--- a/src/lib/Microsoft.Fx.Portability.Offline/Data.cs
+++ b/src/lib/Microsoft.Fx.Portability.Offline/Data.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 
 namespace Microsoft.Fx.Portability
@@ -20,6 +21,26 @@ namespace Microsoft.Fx.Portability
             {
                 return stream.DecompressToObject<DotNetCatalog>();
             }
+        }
+
+        /// <summary>
+        /// Location for loading in the Additional Data when ApiPort is being run in offline mode.
+        /// </summary>
+        /// <returns>An AdditionalDataCatalog containing found additional data.</returns>
+        public static AdditionalDataCatalog LoadAdditionalData()
+        {
+            var catalog = new AdditionalDataCatalog();
+
+            try
+            {
+                using (var stream = OpenFileOrResource($"exceptions.bin"))
+                {
+                    catalog.Exceptions = stream.DecompressToObject<List<ApiExceptionStorage>>();
+                }
+            }
+            catch (PortabilityAnalyzerException) { }
+
+            return catalog;
         }
 
         public static IEnumerable<BreakingChange> LoadBreakingChanges()

--- a/src/lib/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
+++ b/src/lib/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
@@ -13,6 +13,7 @@
     <DataPath>$(OutputFullPath)\.data\</DataPath>
     <BreakingChangePath>$(OutputFullPath)\docs\BreakingChanges\</BreakingChangePath>
     <CatalogDataFile>$(DataPath)catalog.bin</CatalogDataFile>
+	<ExceptionDataFile>$(DataPath)exceptions.bin</ExceptionDataFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,6 +24,9 @@
       <Link>data\%(Filename)%(Extension)</Link>
       <BreakingChange>true</BreakingChange>
     </EmbeddedResource>
+	<EmbeddedResource Include="$(ExceptionDataFile)" Condition="Exists($(ExceptionDataFile))">
+		<Link>data\exceptions.bin</Link>
+	</EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/lib/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
+++ b/src/lib/Microsoft.Fx.Portability.Offline/Microsoft.Fx.Portability.Offline.csproj
@@ -13,7 +13,7 @@
     <DataPath>$(OutputFullPath)\.data\</DataPath>
     <BreakingChangePath>$(OutputFullPath)\docs\BreakingChanges\</BreakingChangePath>
     <CatalogDataFile>$(DataPath)catalog.bin</CatalogDataFile>
-	<ExceptionDataFile>$(DataPath)exceptions.bin</ExceptionDataFile>
+    <ExceptionDataFile>$(DataPath)exceptions.bin</ExceptionDataFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,9 +24,9 @@
       <Link>data\%(Filename)%(Extension)</Link>
       <BreakingChange>true</BreakingChange>
     </EmbeddedResource>
-	<EmbeddedResource Include="$(ExceptionDataFile)" Condition="Exists($(ExceptionDataFile))">
-		<Link>data\exceptions.bin</Link>
-	</EmbeddedResource>
+    <EmbeddedResource Include="$(ExceptionDataFile)" Condition="Exists($(ExceptionDataFile))">
+	  <Link>data\exceptions.bin</Link>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/lib/Microsoft.Fx.Portability.Offline/OfflineApiCatalogLookup.cs
+++ b/src/lib/Microsoft.Fx.Portability.Offline/OfflineApiCatalogLookup.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Fx.Portability
     public class OfflineApiCatalogLookup : CloudApiCatalogLookup
     {
         public OfflineApiCatalogLookup(IProgressReporter progressReporter)
-            : base(GetData(progressReporter))
+            : base(GetData(progressReporter), GetAdditionalData(progressReporter))
         { }
 
         private static DotNetCatalog GetData(IProgressReporter progressReporter)
@@ -20,6 +20,22 @@ namespace Microsoft.Fx.Portability
                 try
                 {
                     return Data.LoadCatalog();
+                }
+                catch (Exception)
+                {
+                    progressTask.Abort();
+                    throw;
+                }
+            }
+        }
+
+        private static AdditionalDataCatalog GetAdditionalData(IProgressReporter progressReporter)
+        {
+            using (var progressTask = progressReporter.StartTask("Loading Additional Data"))
+            {
+                try
+                {
+                    return Data.LoadAdditionalData();
                 }
                 catch (Exception)
                 {

--- a/src/lib/Microsoft.Fx.Portability.Reports.Excel/ExcelOpenXmlOutputWriter.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Excel/ExcelOpenXmlOutputWriter.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Drawing.Charts;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using Microsoft.Fx.OpenXmlExtensions;
+using Microsoft.Fx.Portability.ObjectModel;
 using Microsoft.Fx.Portability.Reporting.ObjectModel;
 using Microsoft.Fx.Portability.Reports.Excel.Resources;
 using System;
@@ -12,6 +14,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 
 namespace Microsoft.Fx.Portability.Reports
@@ -44,12 +47,14 @@ namespace Microsoft.Fx.Portability.Reports
         private readonly ReportingResult _analysisReport;
         private readonly IEnumerable<BreakingChangeDependency> _breakingChanges;
         private readonly DateTimeOffset _catalogLastUpdated;
+        private readonly IList<ExceptionInfo> _throwingMembers;
 
         public ExcelOpenXmlOutputWriter(
             ITargetMapper mapper,
             ReportingResult analysisReport,
             IEnumerable<BreakingChangeDependency> breakingChanges,
             DateTimeOffset catalogLastUpdated,
+            IList<ExceptionInfo> throwingMembers = null,
             string description = null)
         {
             _mapper = mapper;
@@ -57,6 +62,7 @@ namespace Microsoft.Fx.Portability.Reports
             _breakingChanges = breakingChanges;
             _description = description ?? string.Empty;
             _catalogLastUpdated = catalogLastUpdated;
+            _throwingMembers = throwingMembers;
         }
 
         public async Task WriteToAsync(Stream outputStream)
@@ -88,6 +94,11 @@ namespace Microsoft.Fx.Portability.Reports
                     if (_analysisReport.NuGetPackages?.Any() ?? false)
                     {
                         GenerateNuGetInfoPage(spreadsheet.AddWorksheet(LocalizedStrings.SupportedPackages), _analysisReport);
+                    }
+
+                    if (_throwingMembers.Any())
+                    {
+                        GenerateExceptionsPage(spreadsheet.AddWorksheet("Exceptions"), _throwingMembers, _analysisReport.Targets);
                     }
                 }
 
@@ -404,6 +415,93 @@ namespace Microsoft.Fx.Portability.Reports
 
             page.AddTable(1, rowCount, 1, header.ToArray());
             page.AddColumnWidth(70, 40, 30, 30);
+        }
+
+        private void GenerateExceptionsPage(Worksheet worksheet, IList<ExceptionInfo> throwingMembers, IList<FrameworkName> targets)
+        {
+            List<string> exceptionsPageHeader = new List<string>() { LocalizedStrings.AssemblyHeader, LocalizedStrings.TargetMemberHeader, "Exception Thrown" };
+
+            exceptionsPageHeader.AddRange(_mapper.GetTargetNames(targets, alwaysIncludeVersion: true));
+
+            int exceptionRows = 0;
+            worksheet.AddRow(exceptionsPageHeader.ToArray());
+            exceptionRows++;
+
+            foreach (var member in throwingMembers.OrderBy(info => info.MemberDocId))
+            {
+                var exceptionsByType = member.ExceptionsThrown.GroupBy(exc => exc.Exception, (exception, exceptionList) => new { Key = exception, exceptions = exceptionList });
+                foreach (var grouping in exceptionsByType)
+                {
+                    var rowContent = new List<object> { member.DefinedInAssemblyIdentity, member.MemberDocId, grouping.Key };
+                    var groupsByTarget = grouping.exceptions.GroupBy(exc => new FrameworkName(exc.Platform, Version.Parse(exc.Version)), (framework, exceptionList) => new { Key = framework, exceptionsByPlatform = exceptionList });
+                    foreach (var target in targets)
+                    {
+                        bool hasExceptions = false;
+                        foreach (var exceptionsByTarget in groupsByTarget)
+                        {
+                            if (exceptionsByTarget.Key.Equals(target))
+                            {
+                                hasExceptions = true;
+                                string resourceIDHolder = string.Empty;
+                                foreach (var exception in exceptionsByTarget.exceptionsByPlatform.OrderBy(exc => exc.RID))
+                                {
+                                    resourceIDHolder = string.Concat(resourceIDHolder, exception.RID + ";");
+                                }
+
+                                if (resourceIDHolder.Length > 0)
+                                {
+                                    rowContent.Add(resourceIDHolder);
+                                }
+                                else
+                                {
+                                    rowContent.Add("No Notable Exceptions");
+                                }
+                            }
+                        }
+
+                        if (!hasExceptions)
+                        {
+                            rowContent.Add("No Notable Exceptions");
+                        }
+                    }
+
+                    worksheet.AddRow(rowContent.ToArray());
+                    exceptionRows++;
+                }
+            }
+
+        /*foreach (var api in throwingMembers)
+        {
+            foreach (var exception in api.ExceptionsThrown)
+            {
+                var rowContent = new object[]
+                {
+                api.DefinedInAssemblyIdentity,
+                api.MemberDocId,
+                exception.Exception,
+                exception.RID,
+                exception.Platform,
+                exception.Version,
+                string.Empty
+                };
+
+                worksheet.AddRow(rowContent);
+                exceptionRows++;
+            }
+        }*/
+
+            worksheet.AddTable(1, exceptionRows, 1, exceptionsPageHeader.ToArray());
+
+            // Generate the columns
+            var columnWidths = new List<double>
+            {
+                ColumnWidths.DetailsPage.AssemblyName, // Assembly name
+                ColumnWidths.DetailsPage.TargetMember, // Target member
+                40 // Exception Width
+            };
+            columnWidths.AddRange(Enumerable.Repeat(ColumnWidths.Targets, targets.Count)); // Targets
+
+            worksheet.AddColumnWidth(columnWidths);
         }
 
         private object CreateHyperlink(string displayString, string link)

--- a/src/lib/Microsoft.Fx.Portability.Reports.Excel/ExcelOpenXmlOutputWriter.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Excel/ExcelOpenXmlOutputWriter.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Fx.Portability.Reports
 
                     if (_throwingMembers.Any())
                     {
-                        GenerateExceptionsPage(spreadsheet.AddWorksheet("Exceptions"), _throwingMembers, _analysisReport.Targets);
+                        GenerateExceptionsPage(spreadsheet.AddWorksheet(LocalizedStrings.ExceptionsWorksheetTitle), _throwingMembers, _analysisReport.Targets);
                     }
                 }
 
@@ -419,7 +419,7 @@ namespace Microsoft.Fx.Portability.Reports
 
         private void GenerateExceptionsPage(Worksheet worksheet, IList<ExceptionInfo> throwingMembers, IList<FrameworkName> targets)
         {
-            List<string> exceptionsPageHeader = new List<string>() { LocalizedStrings.AssemblyHeader, LocalizedStrings.TargetMemberHeader, "Exception Thrown" };
+            List<string> exceptionsPageHeader = new List<string>() { LocalizedStrings.AssemblyHeader, LocalizedStrings.TargetMemberHeader, LocalizedStrings.ExceptionColumnHeader };
 
             exceptionsPageHeader.AddRange(_mapper.GetTargetNames(targets, alwaysIncludeVersion: true));
 
@@ -454,14 +454,14 @@ namespace Microsoft.Fx.Portability.Reports
                                 }
                                 else
                                 {
-                                    rowContent.Add("No Notable Exceptions");
+                                    rowContent.Add(LocalizedStrings.NoExceptionNoted);
                                 }
                             }
                         }
 
                         if (!hasExceptions)
                         {
-                            rowContent.Add("No Notable Exceptions");
+                            rowContent.Add(LocalizedStrings.NoExceptionNoted);
                         }
                     }
 
@@ -470,26 +470,6 @@ namespace Microsoft.Fx.Portability.Reports
                 }
             }
 
-        /*foreach (var api in throwingMembers)
-        {
-            foreach (var exception in api.ExceptionsThrown)
-            {
-                var rowContent = new object[]
-                {
-                api.DefinedInAssemblyIdentity,
-                api.MemberDocId,
-                exception.Exception,
-                exception.RID,
-                exception.Platform,
-                exception.Version,
-                string.Empty
-                };
-
-                worksheet.AddRow(rowContent);
-                exceptionRows++;
-            }
-        }*/
-
             worksheet.AddTable(1, exceptionRows, 1, exceptionsPageHeader.ToArray());
 
             // Generate the columns
@@ -497,7 +477,7 @@ namespace Microsoft.Fx.Portability.Reports
             {
                 ColumnWidths.DetailsPage.AssemblyName, // Assembly name
                 ColumnWidths.DetailsPage.TargetMember, // Target member
-                40 // Exception Width
+                ColumnWidths.DetailsPage.TargetMember // Exception Width
             };
             columnWidths.AddRange(Enumerable.Repeat(ColumnWidths.Targets, targets.Count)); // Targets
 

--- a/src/lib/Microsoft.Fx.Portability.Reports.Excel/ExcelReportWriter.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Excel/ExcelReportWriter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Fx.Portability.Reports
 
         public Task WriteStreamAsync(Stream stream, AnalyzeResponse response)
         {
-            var excelWriter = new ExcelOpenXmlOutputWriter(_targetMapper, response.ReportingResult, response.BreakingChanges, response.CatalogLastUpdated, description: null);
+            var excelWriter = new ExcelOpenXmlOutputWriter(_targetMapper, response.ReportingResult, response.BreakingChanges, response.CatalogLastUpdated, response.ThrowingMembers, description: null);
 
             return excelWriter.WriteToAsync(stream);
         }

--- a/src/lib/Microsoft.Fx.Portability.Reports.Excel/Resources/LocalizedStrings.Designer.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Excel/Resources/LocalizedStrings.Designer.cs
@@ -106,6 +106,24 @@ namespace Microsoft.Fx.Portability.Reports.Excel.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Exception Thrown.
+        /// </summary>
+        internal static string ExceptionColumnHeader {
+            get {
+                return ResourceManager.GetString("ExceptionColumnHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exceptions.
+        /// </summary>
+        internal static string ExceptionsWorksheetTitle {
+            get {
+                return ResourceManager.GetString("ExceptionsWorksheetTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to See &apos;https://aka.ms/dotnet-portabilityanalyzer&apos; to learn how to read this table.
         /// </summary>
         internal static string HowToReadTheExcelTable {
@@ -129,6 +147,15 @@ namespace Microsoft.Fx.Portability.Reports.Excel.Resources {
         internal static string MissingAssemblyStatus {
             get {
                 return ResourceManager.GetString("MissingAssemblyStatus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No Notable Exceptions.
+        /// </summary>
+        internal static string NoExceptionNoted {
+            get {
+                return ResourceManager.GetString("NoExceptionNoted", resourceCulture);
             }
         }
         

--- a/src/lib/Microsoft.Fx.Portability.Reports.Excel/Resources/LocalizedStrings.resx
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Excel/Resources/LocalizedStrings.resx
@@ -178,4 +178,13 @@
   <data name="TooManyColumns" xml:space="preserve">
     <value>Only 26 colums supported overall!!</value>
   </data>
+  <data name="ExceptionColumnHeader" xml:space="preserve">
+    <value>Exception Thrown</value>
+  </data>
+  <data name="ExceptionsWorksheetTitle" xml:space="preserve">
+    <value>Exceptions</value>
+  </data>
+  <data name="NoExceptionNoted" xml:space="preserve">
+    <value>No Notable Exceptions</value>
+  </data>
 </root>

--- a/src/lib/Microsoft.Fx.Portability/Analysis/AnalysisEngine.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analysis/AnalysisEngine.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Fx.Portability.Analysis
                 .Where(m => MemberIsInFramework(m, submittedAssemblies) && IsSupportedOnAnyTarget(_catalog, m.MemberDocId))
                 .AsParallel()
                 .Select(memberInfo => ProcessExceptionInfo(_catalog, targets, memberInfo))
-                .Where(memberInfo => memberInfo.ExceptionsThrown != null && memberInfo.ExceptionsThrown.Count > 0)
+                .Where(memberInfo => memberInfo != null && memberInfo.ExceptionsThrown != null && memberInfo.ExceptionsThrown.Count > 0)
                 .ToList();
 
             sw.Stop();
@@ -211,13 +211,20 @@ namespace Microsoft.Fx.Portability.Analysis
         /// <summary>
         /// Identitifies the status of an API Exception for all of the targets.
         /// </summary>
+        /// <returns>ExceptionInfo will be null if no exceptions are thrown.</returns>
         private static ExceptionInfo ProcessExceptionInfo(IApiCatalogLookup catalog, IEnumerable<FrameworkName> targets, MemberInfo member)
         {
+            var exceptionsThrownList = GetThrownExceptions(catalog, member.MemberDocId, targets);
+            if (exceptionsThrownList == null)
+            {
+                return null;
+            }
+
             var exceptionHold = new ExceptionInfo();
             exceptionHold.MemberDocId = member.MemberDocId;
             exceptionHold.DefinedInAssemblyIdentity = member.DefinedInAssemblyIdentity;
             exceptionHold.IsSupportedAcrossTargets = IsSupportedAcrossTargets(catalog, member.MemberDocId, targets, out var ignore);
-            exceptionHold.ExceptionsThrown = GetThrownExceptions(catalog, member.MemberDocId, targets);
+            exceptionHold.ExceptionsThrown = exceptionsThrownList;
 
             return exceptionHold;
         }

--- a/src/lib/Microsoft.Fx.Portability/Analysis/AnalysisEngine.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analysis/AnalysisEngine.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Fx.Portability.Analysis
         /// <summary>
         /// Identitifies the status of an API Exception for all of the targets.
         /// </summary>
-        private ExceptionInfo ProcessExceptionInfo(IApiCatalogLookup catalog, IEnumerable<FrameworkName> targets, MemberInfo member)
+        private static ExceptionInfo ProcessExceptionInfo(IApiCatalogLookup catalog, IEnumerable<FrameworkName> targets, MemberInfo member)
         {
             var exceptionHold = new ExceptionInfo();
             exceptionHold.MemberDocId = member.MemberDocId;

--- a/src/lib/Microsoft.Fx.Portability/Analysis/AnalysisEngine.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analysis/AnalysisEngine.cs
@@ -146,6 +146,41 @@ namespace Microsoft.Fx.Portability.Analysis
             return missingMembers;
         }
 
+        /// <summary>
+        /// Finds the members that could throw an exception on the specified targets.
+        /// </summary>
+        /// <param name="targets">Frameworks to check for exceptions on.</param>
+        /// <param name="submittedAssemblies">Assemblies submitted for checking if the member is a part of the assemblies.</param>
+        /// <param name="dependencies">Dictionary of members with their corresponding assembly information.</param>
+        /// <returns>A list of ExceptionInfo providing necessary information on each member that may throw.</returns>
+        public IList<ExceptionInfo> FindMembersMayThrow(IEnumerable<FrameworkName> targets, ICollection<string> submittedAssemblies, IDictionary<MemberInfo, ICollection<AssemblyInfo>> dependencies)
+        {
+            // Trace.TraceInformation("Computing members not in target");
+            var sw = new Stopwatch();
+            sw.Start();
+
+            if (dependencies == null || dependencies.Keys == null || targets == null)
+            {
+                return new List<ExceptionInfo>();
+            }
+
+            // Find the missing members by:
+            //  -- Find the members that are defined in framework assemblies AND which are framework members.
+            //  -- For each member, identity which is the status for that docId for each of the targets.
+            //  -- Keep only the members that may throw exceptions
+            var mayThrowMembers = dependencies.Keys
+                .Where(m => MemberIsInFramework(m, submittedAssemblies) && IsSupportedOnAnyTarget(_catalog, m.MemberDocId))
+                .AsParallel()
+                .Select(memberInfo => ProcessExceptionInfo(_catalog, targets, memberInfo))
+                .Where(memberInfo => memberInfo.ExceptionsThrown != null && memberInfo.ExceptionsThrown.Count > 0)
+                .ToList();
+
+            sw.Stop();
+
+            // Trace.TraceInformation("Computing members not in target took '{0}'", sw.Elapsed);
+            return mayThrowMembers;
+        }
+
         private bool MemberIsInFramework(MemberInfo dep, ICollection<string> submittedAssemblies)
         {
             if (submittedAssemblies.Contains(dep.DefinedInAssemblyIdentity))
@@ -171,6 +206,20 @@ namespace Microsoft.Fx.Portability.Analysis
             member.SourceCompatibleChange = _recommendations.GetSourceCompatibleChanges(member.MemberDocId);
 
             return member;
+        }
+
+        /// <summary>
+        /// Identitifies the status of an API Exception for all of the targets.
+        /// </summary>
+        private ExceptionInfo ProcessExceptionInfo(IApiCatalogLookup catalog, IEnumerable<FrameworkName> targets, MemberInfo member)
+        {
+            var exceptionHold = new ExceptionInfo();
+            exceptionHold.MemberDocId = member.MemberDocId;
+            exceptionHold.DefinedInAssemblyIdentity = member.DefinedInAssemblyIdentity;
+            exceptionHold.IsSupportedAcrossTargets = IsSupportedAcrossTargets(catalog, member.MemberDocId, targets, out var ignore);
+            exceptionHold.ExceptionsThrown = GetThrownExceptions(catalog, member.MemberDocId, targets);
+
+            return exceptionHold;
         }
 
         /// <summary>
@@ -368,6 +417,24 @@ namespace Microsoft.Fx.Portability.Analysis
             {
                 return obj.Item1.GetHashCode();
             }
+        }
+
+        /// <summary>
+        /// Gets the exceptions thrown by the <paramref name="memberDocId"/> for each <paramref name="targets"/>.
+        /// </summary>
+        /// <param name="catalog">Catalog to lookup from.</param>
+        /// <param name="memberDocId">DocId to find exceptions for.</param>
+        /// <param name="targets">Targets to find exceptions for.</param>
+        /// <returns>A list of the ApiExceptions for the <paramref name="memberDocId"/>. Returns null if no exceptions were found.</returns>
+        private static List<ApiException> GetThrownExceptions(IApiCatalogLookup catalog, string memberDocId, IEnumerable<FrameworkName> targets)
+        {
+            List<ApiException> excepts;
+            if ((excepts = catalog.GetApiExceptions(memberDocId)) != null)
+            {
+                return excepts.Where(exc => !exc.Equals(null) && targets.Any(tg => tg.Equals(new FrameworkName(exc.Platform, Version.Parse(exc.Version))))).ToList();
+            }
+
+            return null;
         }
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/Analyzer/RequestAnalyzer.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/RequestAnalyzer.cs
@@ -81,6 +81,10 @@ namespace Microsoft.Fx.Portability.Analyzer
                 ? _analysisEngine.FindBreakingChanges(targets, request.Dependencies, breakingChangeSkippedAssemblies, request.BreakingChangesToSuppress, userAssemblies, request.RequestFlags.HasFlag(AnalyzeRequestFlags.ShowRetargettingIssues)).ToList()
                 : new List<BreakingChangeDependency>();
 
+            var apiPotentialExceptions = request.RequestFlags.HasFlag(AnalyzeRequestFlags.ShowExceptionApis)
+                ? _analysisEngine.FindMembersMayThrow(targets, userAssemblies, dependencies)
+                : Array.Empty<ExceptionInfo>();
+
             var reportingResult = _reportGenerator.ComputeReport(
                 targets,
                 submissionId,
@@ -104,6 +108,7 @@ namespace Microsoft.Fx.Portability.Analyzer
                 BreakingChanges = breakingChanges,
                 BreakingChangeSkippedAssemblies = breakingChangeSkippedAssemblies,
                 NuGetPackages = nugetPackages,
+                ThrowingMembers = apiPotentialExceptions,
                 Request = request
             };
         }

--- a/src/lib/Microsoft.Fx.Portability/IAnalysisEngine.cs
+++ b/src/lib/Microsoft.Fx.Portability/IAnalysisEngine.cs
@@ -26,6 +26,11 @@ namespace Microsoft.Fx.Portability
             IEnumerable<AssemblyInfo> userAssemblies,
             IEnumerable<IgnoreAssemblyInfo> assembliesToIgnore);
 
+        public IList<ExceptionInfo> FindMembersMayThrow(IEnumerable<FrameworkName> targets,
+            ICollection<string> submittedAssemblies,
+            IDictionary<MemberInfo,
+            ICollection<AssemblyInfo>> dependencies);
+
         IEnumerable<BreakingChangeDependency> FindBreakingChanges(
             IEnumerable<FrameworkName> targets,
             IDictionary<MemberInfo, ICollection<AssemblyInfo>> dependencies,

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/AdditionalDataCatalog.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/AdditionalDataCatalog.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+
+namespace Microsoft.Fx.Portability.ObjectModel
+{
+    /// <summary>
+    /// Catalog used for hold additional data not from ApiCatalog.
+    /// To be used to easily add data into the pipeline without having to change existing models.
+    /// Each field needs to be individually retrieved by the portability service and will likely be stored their own file/blob.
+    /// </summary>
+    public class AdditionalDataCatalog
+    {
+        public IEnumerable<ApiExceptionStorage> Exceptions { get; set; }
+    }
+}

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/AnalyzeRequestFlags.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/AnalyzeRequestFlags.cs
@@ -14,5 +14,6 @@ namespace Microsoft.Fx.Portability.ObjectModel
         ShowBreakingChanges = 1 << 2,
         NoDefaultIgnoreFile = 1 << 3,
         ShowRetargettingIssues = 1 << 4,
+        ShowExceptionApis = 1 << 5
     }
 }

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/AnalyzeResponse.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/AnalyzeResponse.cs
@@ -43,6 +43,8 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         public IList<AssemblyInfo> BreakingChangeSkippedAssemblies { get; set; }
 
+        public IList<ExceptionInfo> ThrowingMembers { get; set; }
+
         public int CompareTo(object obj)
         {
             var analyzeObject = obj as AnalyzeResponse;

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiException.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiException.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Fx.Portability.ObjectModel
+{
+    /// <summary>
+    /// A single ApiException used for holding the data of the single exception.
+    /// Includes override methods for Equals and ToString.
+    /// </summary>
+    public class ApiException
+    {
+        public string Exception { get; set; }
+
+        public string RID { get; set; }
+
+        public string Platform { get; set; }
+
+        public string Version { get; set; }
+
+        public override string ToString()
+        {
+            return $"{Exception}:{RID}_{Platform},v{Version}";
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ApiException);
+        }
+
+        public virtual bool Equals(ApiException exc)
+        {
+            return exc != null && ToString().Equals(exc.ToString(), System.StringComparison.Ordinal);
+        }
+
+        public override int GetHashCode()
+        {
+            return ToString().GetHashCode();
+        }
+    }
+}

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiExceptionStorage.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/ApiExceptionStorage.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Fx.Portability.ObjectModel
+{
+    /// <summary>
+    /// Holds a DocId with corresponding Exceptions for easy storage of the exceptions thrown by Apis.
+    /// </summary>
+    public class ApiExceptionStorage
+    {
+        public string DocId { get; set; }
+
+        public IEnumerable<ApiException> Exceptions { get; set; }
+    }
+}

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
@@ -54,7 +54,6 @@ namespace Microsoft.Fx.Portability.ObjectModel
                                             StringComparer.Ordinal),
                                 StringComparer.Ordinal);
 
-
             _publicTargets = catalog.SupportedTargets
                                                 .Where(sp => sp.IsReleased)
                                                 .Select(sp => sp.DisplayName)

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/CloudApiCatalogLookup.cs
@@ -22,13 +22,14 @@ namespace Microsoft.Fx.Portability.ObjectModel
         private readonly string _builtBy;
         private readonly Dictionary<string, Dictionary<string, Version>> _apiMapping;
         private readonly Dictionary<string, Dictionary<string, string>> _apiMetadata;
+        private readonly Dictionary<string, List<ApiException>> _apiExceptions;
         private readonly Dictionary<string, FrameworkName> _latestTargetVersion;
         private readonly ICollection<string> _frameworkAssemblies;
         private readonly IReadOnlyCollection<FrameworkName> _publicTargets;
         private readonly IReadOnlyCollection<TargetInfo> _allTargets;
         private readonly IDictionary<string, ApiDefinition> _docIdToApi;
 
-        public CloudApiCatalogLookup(DotNetCatalog catalog)
+        public CloudApiCatalogLookup(DotNetCatalog catalog, AdditionalDataCatalog extra = null)
         {
             _lastModified = catalog.LastModified;
             _builtBy = catalog.BuiltBy;
@@ -52,6 +53,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
                                             innerValue => innerValue.Value,
                                             StringComparer.Ordinal),
                                 StringComparer.Ordinal);
+
 
             _publicTargets = catalog.SupportedTargets
                                                 .Where(sp => sp.IsReleased)
@@ -78,6 +80,20 @@ namespace Microsoft.Fx.Portability.ObjectModel
                 FullName = key.FullName,
                 Parent = key.Parent
             });
+
+            // Populate the exception list if the additional data catalog contains exceptions.
+            if (extra != null && extra.Exceptions != null)
+            {
+                _apiExceptions = extra.Exceptions.AsParallel()
+                 .Where(api => api.Exceptions != null)
+                 .ToDictionary(
+                     key => key.DocId,
+                     value => value.Exceptions.ToList());
+            }
+            else
+            {
+                _apiExceptions = new Dictionary<string, List<ApiException>>();
+            }
         }
 
         public virtual IEnumerable<string> DocIds
@@ -143,6 +159,16 @@ namespace Microsoft.Fx.Portability.ObjectModel
             }
 
             return metadataValue;
+        }
+
+        public virtual List<ApiException> GetApiExceptions(string docId)
+        {
+            if (_apiExceptions.TryGetValue(docId, out var exceptions))
+            {
+                return exceptions;
+            }
+
+            return null;
         }
 
         public virtual string GetRecommendedChange(string docId)

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/ExceptionInfo.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/ExceptionInfo.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Fx.Portability.ObjectModel
+{
+    /// <summary>
+    /// Model used to pass exception data through the Analyze response.
+    /// Includes the Apis assembly, DocId, and the list of exceptions that it throws.
+    /// </summary>
+    public class ExceptionInfo
+    {
+        public string DefinedInAssemblyIdentity { get; set; }
+
+        public string MemberDocId { get; set; }
+
+        public List<ApiException> ExceptionsThrown { get; set; }
+
+        [JsonIgnore]
+        public bool IsSupportedAcrossTargets { get; set; }
+    }
+}

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/ExceptionInfo.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/ExceptionInfo.cs
@@ -1,4 +1,7 @@
-﻿using Newtonsoft.Json;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/IApiCatalogLookup.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/IApiCatalogLookup.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         IEnumerable<TargetInfo> GetAllTargets();
 
+        List<ApiException> GetApiExceptions(string docId);
+
         string GetRecommendedChange(string docId);
 
         string GetSourceCompatibilityEquivalent(string docId);

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/MemberInfo.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/MemberInfo.cs
@@ -4,6 +4,8 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Runtime.ExceptionServices;
 
 namespace Microsoft.Fx.Portability.ObjectModel
 {

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/MemberInfo.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/MemberInfo.cs
@@ -4,8 +4,6 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Runtime.ExceptionServices;
 
 namespace Microsoft.Fx.Portability.ObjectModel
 {

--- a/tests/lib/Microsoft.Fx.Portability.Tests/TestData/TestCatalog.cs
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/TestData/TestCatalog.cs
@@ -125,5 +125,10 @@ namespace Microsoft.Fx.Portability.TestData
         {
             throw new NotImplementedException();
         }
+
+        public List<ApiException> GetApiExceptions(string docId)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
…ility. Took the changes to the fx.Portability library in the ApiExceptionTieIn branch and copied them into this branch so that the library and ApiPort changes are separate. These changes added an additional data catalog that holds data that the general apicatalog does not hold. Currently, this catalog is used to hold data on which methods throw PlatformNotSupported and NotImplemented exceptions. In addition to this additional catalog and the changes necessary to retrieve and use its data, this PR also adds the classes for how the exceptions are stored.