### PR TITLE
Added the retrieval of the exceptions.bin file to the init script.

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -53,6 +53,7 @@ if (!$NoPrerequisites) {
 }
 
 & "$PSScriptRoot\tools\Get-CatalogBin.ps1"
+& "$PSScriptRoot\tools\Get-AdditionalDataBin.ps1"
 
 # Workaround nuget credential provider bug that causes very unreliable package restores on Azure Pipelines
 $env:NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS=20

--- a/tools/Get-AdditionalDataBin.ps1
+++ b/tools/Get-AdditionalDataBin.ps1
@@ -1,0 +1,33 @@
+$ErrorActionPreference = "Stop"
+
+function DownloadFile($url, $outputPath) {
+	Write-Host "Attempt to download to $outputPath"
+
+	# If the file has been downloaded don't download again. An empty file implies a failed download
+	if(Test-Path $outputPath) {
+		$file = Get-ChildItem $outputPath
+
+		if($file.Length -gt 0) {
+			Write-Host "$outputPath is already downloaded"
+			return;
+		}
+	}
+
+	try {
+		# Create placeholder so directory exists
+		New-Item -Type File $OutputPath -Force | Out-Null
+
+		# Attempt to download.  If fails, placeholder remains so msbuild won't complain
+		(New-Object System.Net.WebClient).DownloadFile($url, $OutputPath) | Out-Null
+
+		Write-Host "Downloaded $OutputPath"
+	} catch {
+		Write-Warning "Failed to download '$url', it will not be included in the available additional data. $($Error[0])"
+	}
+}
+
+# Setup the URLs for downloading the different additionaldata binaries
+$exceptionAddress = "https://portability.blob.core.windows.net/additionaldata/exceptions-stable.bin"
+
+# Download each additionaldata binary individually
+DownloadFile "$exceptionAddress" "$PSScriptRoot\..\.data\exceptions.bin"


### PR DESCRIPTION
Added the retrieval of the exceptions.bin file to the init script. It is setup to use the same storage as the catalog.bin file. However, the exceptions file is not there yet so a warning will be thrown until the file is added, but I tested with a dev blob storage to make sure it works in general and it did download.

**This should not be merged until the exceptions file is added to the portability storage but will only show warnings if used before then.**