### PR TITLE
Update Newtonsoft.Json to 12.x as it is required for .NET Core empty arrays

### DIFF
--- a/src/lib/Microsoft.Fx.Portability.Reports.Json/Microsoft.Fx.Portability.Reports.Json.csproj
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Json/Microsoft.Fx.Portability.Reports.Json.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/lib/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
+++ b/src/lib/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />

--- a/tests/ApiPort/ApiPortVS.Tests/ApiPortVS.Tests.csproj
+++ b/tests/ApiPort/ApiPortVS.Tests/ApiPortVS.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/tests/lib/Microsoft.Fx.Portability.Cci.Tests/Microsoft.Fx.Portability.Cci.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.Cci.Tests/Microsoft.Fx.Portability.Cci.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
@@ -24,7 +24,7 @@
     <!--Reference to Microsoft.NETCore.Platforms to workaround https://github.com/dotnet/cli/issues/12341. Remove the reference once build machine moves to .NET Core 3.0-->
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="3.0.0" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="System.Diagnostics.FileVersionInfo " Version="4.3.0" />

--- a/tests/lib/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="System.Diagnostics.FileVersionInfo " Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
The internal type for empty enumerables changed in .NET Core, and Newtonsoft.Json had assumed it was `Array.Empty`. The fix for this is available in v12.x of the library.