### PR TITLE
Show full identity and handle list of items in row

### DIFF
--- a/src/lib/Microsoft.Fx.Portability.Reports.Excel/ExcelOpenXmlOutputWriter.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Excel/ExcelOpenXmlOutputWriter.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Fx.Portability.Reports
 
                 foreach (var item in analysisResult.GetAssemblyUsageInfo().OrderBy(a => a.SourceAssembly.AssemblyIdentity))
                 {
-                    var summaryData = new List<object> { analysisResult.GetNameForAssemblyInfo(item.SourceAssembly), item.SourceAssembly.TargetFrameworkMoniker ?? string.Empty };
+                    var summaryData = new List<object> { item.SourceAssembly.AssemblyIdentity, item.SourceAssembly.TargetFrameworkMoniker ?? string.Empty };
 
                     // TODO: figure out how to add formatting to cells to show percentages.
                     summaryData.AddRange(item.UsageData.Select(pui => (object)Math.Round(pui.PortabilityIndex * 100.0, 2)));
@@ -191,6 +191,12 @@ namespace Microsoft.Fx.Portability.Reports
             summaryPage.AddRow();
             summaryPage.AddRow(LocalizedStrings.CatalogLastUpdated, _response.CatalogLastUpdated.ToString("D", CultureInfo.CurrentCulture));
             summaryPage.AddRow(LocalizedStrings.HowToReadTheExcelTable);
+
+            if (!_response.RecommendedOrder.Any())
+            {
+                summaryPage.AddRow();
+                summaryPage.AddRow(LocalizedStrings.RecommendedOrderMissing);
+            }
         }
 
         private static void GenerateUnreferencedAssembliesPage(Worksheet missingAssembliesPage, AnalyzeResponse response)

--- a/src/lib/Microsoft.Fx.Portability.Reports.Excel/OpenXmlExtensions.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Excel/OpenXmlExtensions.cs
@@ -145,6 +145,9 @@ namespace Microsoft.Fx.OpenXmlExtensions
         }
 
         public static void AddRow(this Worksheet ws, params object[] data)
+            => ws.AddRow((IEnumerable<object>)data);
+
+        public static void AddRow(this Worksheet ws, IEnumerable<object> data)
         {
             var sd = ws.GetFirstChild<SheetData>();
             if (sd == null)

--- a/src/lib/Microsoft.Fx.Portability.Reports.Excel/Resources/LocalizedStrings.Designer.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Excel/Resources/LocalizedStrings.Designer.cs
@@ -196,6 +196,15 @@ namespace Microsoft.Fx.Portability.Reports.Excel.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No entrypoint was provided. If a submission includes an entrypoint, a recommendation for what order to migrate projects can be provided..
+        /// </summary>
+        internal static string RecommendedOrderMissing {
+            get {
+                return ResourceManager.GetString("RecommendedOrderMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Skipped Assembly.
         /// </summary>
         internal static string SkippedAssembly {

--- a/src/lib/Microsoft.Fx.Portability.Reports.Excel/Resources/LocalizedStrings.resx
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Excel/Resources/LocalizedStrings.resx
@@ -193,4 +193,7 @@
   <data name="UnresolvedAssemblyStatus" xml:space="preserve">
     <value>Reason</value>
   </data>
+  <data name="RecommendedOrderMissing" xml:space="preserve">
+    <value>No entrypoint was provided. If a submission includes an entrypoint, a recommendation for what order to migrate projects can be provided.</value>
+  </data>
 </root>


### PR DESCRIPTION
A recent change removed a `.ToArray()` call on row entries, which made it bind to the wrong overload. This fixes it by adding an overload for `AddRow(this Worksheet, IEnumerable<object>)` in addition to the `params` one so that we don't need to call `ToArray()`.

Fixes #902 