### PR TITLE
Change entrypoint on request to be a list

### DIFF
--- a/src/lib/Microsoft.Fx.Portability/Analyzer/RequestAnalyzer.cs
+++ b/src/lib/Microsoft.Fx.Portability/Analyzer/RequestAnalyzer.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Fx.Portability.Analyzer
                 UnresolvedUserAssemblies = missingUserAssemblies,
                 Targets = targets,
                 ReportingResult = reportingResult,
-                RecommendedOrder = _orderer.GetOrder(request.Entrypoint, request.UserAssemblies),
+                RecommendedOrder = _orderer.GetOrder(request.Entrypoints.FirstOrDefault(), request.UserAssemblies),
                 SubmissionId = submissionId,
                 BreakingChanges = breakingChanges,
                 BreakingChangeSkippedAssemblies = breakingChangeSkippedAssemblies,

--- a/src/lib/Microsoft.Fx.Portability/ApiPortClient.cs
+++ b/src/lib/Microsoft.Fx.Portability/ApiPortClient.cs
@@ -277,7 +277,7 @@ namespace Microsoft.Fx.Portability
 
             return new AnalyzeRequest
             {
-                Entrypoint = options.Entrypoint,
+                Entrypoints = new[] { options.Entrypoint },
                 Targets = options.Targets.SelectMany(_targetMapper.GetNames).ToList(),
                 Dependencies = dependencyInfo.Dependencies,
 

--- a/src/lib/Microsoft.Fx.Portability/ObjectModel/AnalyzeRequest.cs
+++ b/src/lib/Microsoft.Fx.Portability/ObjectModel/AnalyzeRequest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Fx.Portability.ObjectModel
 
         public IDictionary<MemberInfo, ICollection<AssemblyInfo>> Dependencies { get; set; }
 
-        public string Entrypoint { get; set; }
+        public IReadOnlyCollection<string> Entrypoints { get; set; } = Array.Empty<string>();
 
         public ICollection<string> UnresolvedAssemblies { get; set; }
 


### PR DESCRIPTION
This is to future proof the API so that multiple entrypoints could be provided in the future. Currently, only the first one is used, but that could change in the future. Keeping it a string would be a breaking change for future changes if multiple are desired.