### PR TITLE
Change to MemoryStream.CopyToAsync()

### DIFF
--- a/src/lib/Microsoft.Fx.Portability.Reports.DGML/DGMLManager.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.DGML/DGMLManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 
 namespace Microsoft.Fx.Portability.Reports.DGML
@@ -114,13 +115,13 @@ namespace Microsoft.Fx.Portability.Reports.DGML
             nodes.Add(element);
         }
 
-        internal void Save(Stream stream)
+        internal async Task SaveAsync(Stream stream)
         {
             using (var ms = new MemoryStream())
             {
                 file.Save(ms);
                 ms.Position = 0;
-                ms.CopyToAsync(stream);
+                await ms.CopyToAsync(stream);
             }
         }
 

--- a/src/lib/Microsoft.Fx.Portability.Reports.DGML/DGMLManager.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.DGML/DGMLManager.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Fx.Portability.Reports.DGML
             {
                 file.Save(ms);
                 ms.Position = 0;
-                ms.CopyTo(stream);
+                ms.CopyToAsync(stream);
             }
         }
 

--- a/src/lib/Microsoft.Fx.Portability.Reports.DGML/DGMLOutputWriter.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.DGML/DGMLOutputWriter.cs
@@ -92,9 +92,7 @@ namespace Microsoft.Fx.Portability.Reports.DGML
                 }
             }
 
-            dgml.Save(stream);
-
-            return Task.CompletedTask;
+            return dgml.SaveAsync(stream);
         }
 
         private static string GenerateMissingTypes(string assembly, ReportingResult response, int i)


### PR DESCRIPTION

ASP.NET Core 3.1 disabled sync IO operation by default. 