### PR TITLE
Only use azure-pipeline.yml for dev branch

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -1,0 +1,35 @@
+trigger:
+  branches:
+    include:
+    - master
+
+parameters:
+- name: SignTypeSelection
+  displayName: Sign type
+  type: string
+  default: Real
+  values: [ 'Test', 'Real' ]
+
+variables:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  BuildConfiguration: Release
+  BuildPlatform: Any CPU
+  NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages
+  SignTypeSelection: ${{ parameters.SignTypeSelection }}
+  DeployExtension: false
+
+jobs:
+- job: Windows
+  pool: VSEng-MicroBuildVS2019
+  steps:
+  - template: azure-pipelines/build-windows.yml
+  - powershell: |
+      . azure-pipelines/vsixgallerytools.ps1
+      Vsix-PublishToGallery -path bin/$(BuildConfiguration)/ApiPort.Vsix/ApiPort.vsix
+    displayName: Push VSIX
+
+- job: Linux
+  pool:
+    vmImage: Ubuntu 18.04
+  steps:
+  - template: azure-pipelines/build-linux.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,6 @@
 trigger:
   branches:
     include:
-    - master
     - dev
     - 'validate/*'
 


### PR DESCRIPTION
With this change, below is the build pipeline and branch matching:

- azure-pipeline.yml for dev branch: test signed
- azure-pipeline-release.yml for dev branch: real signed and publish apiport.vsix to vsix gallery 