### PR TITLE
Update ApiPort from alpha release to stable and some apiport package changes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,7 +50,10 @@
     <PackageProjectUrl>https://github.com/Microsoft/dotnet-apiport</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>.NET portability apiport</PackageTags>
-    <Copyright>Copyright 2017</Copyright>
+    <Copyright>Microsoft Corporation. All rights reserved.</Copyright>
+    <RepositoryUrl>https://github.com/Microsoft/dotnet-apiport</RepositoryUrl>
+    <RepositoryType>Git</RepositoryType>
+    <Description>The .NET Portability Analyzer (ApiPort) is a tool that analyzes assemblies and provides a detailed report on .NET APIs that are missing for the applications or libraries to be portable on your specified targeted .NET platforms.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/azure-pipelines/build-windows.yml
+++ b/azure-pipelines/build-windows.yml
@@ -78,8 +78,8 @@ steps:
     arguments: '--configuration $(BuildConfiguration) -f netcoreapp3.1 --output $(Build.StagingDirectory) --no-build'
     zipAfterPublish: True
 
-- publish: $(Build.StagingDirectory)\drop
-  displayName: Publish drop
+- publish: $(Build.StagingDirectory)
+  displayName: Publish
   artifact: drop-$(Agent.JobName)
 
 - publish: bin/$(BuildConfiguration)/ApiPort.Vsix/ApiPort.vsix

--- a/src/ApiPort/ApiPort/ApiPort.props
+++ b/src/ApiPort/ApiPort/ApiPort.props
@@ -12,11 +12,6 @@
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Projects default to being signed, but Microsoft.Configuration.* assemblies are not signed -->
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="Autofac.Configuration" Version="4.1.0" />

--- a/src/ApiPort/ApiPort/ApiPort.props
+++ b/src/ApiPort/ApiPort/ApiPort.props
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>ApiPort</ToolCommandName>
-    <PackageId>Microsoft.ApiPort</PackageId>
+    <PackageId>ApiPort</PackageId>
     <OutputType>Exe</OutputType>
     <AssemblyName>ApiPort</AssemblyName>
     <RootNamespace>ApiPort</RootNamespace>

--- a/src/ApiPort/ApiPort/Properties/AssemblyInfo.cs
+++ b/src/ApiPort/ApiPort/Properties/AssemblyInfo.cs
@@ -2,4 +2,4 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
-[assembly: InternalsVisibleTo("ApiPort.Tests")]
+[assembly: InternalsVisibleTo("ApiPort.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100e582b4d26e58c079fe92f419c429dfad3353fd55014becf8c0b0ba92b1b577a01f3012ce5d7a2bce9a3dd5641a0620793f345107bb1fdfe34289283a8929fa5c6d8b28da13ca9545c25b9460e341983bc6fe0fff8420e457e053aa3ed8def02dac7bc9f54bf4a0adc57683730686f3df167d45535ad5a0bd2a49c449b16620c5")]

--- a/tests/ApiPort/ApiPort.Tests/ApiPort.Tests.csproj
+++ b/tests/ApiPort/ApiPort.Tests/ApiPort.Tests.csproj
@@ -5,11 +5,6 @@
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Projects default to being signed, but ApiPort cannot be signed at the moment -->
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.8-alpha",
+  "version": "2.8",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Updated ApiPort from alpha release to stable so that it's easy to install it as global tool.
Changed ApiPort NuGet package ID to be consistent with App name.
Updated copyright
Added a few package properties 