### PR TITLE
Fix APIScan

### DIFF
--- a/azure-pipelines/microbuild.after.yml
+++ b/azure-pipelines/microbuild.after.yml
@@ -45,14 +45,14 @@ steps:
     AnalyzeSymPath: $(Build.StagingDirectory)\symbols
   continueOnError: true
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-apiscan.APIScan@2
-  displayName: 'Run APIScan netcoreapp3.1'
-  inputs:
-    softwareFolder: '$(Build.StagingDirectory)\drop\raw\binaries\netcoreapp3.1'
-    softwareName: 'API Port'
-    softwareVersionNum: 4.XX
-    symbolsFolder: '$(Build.StagingDirectory)\drop\raw\symbols\netcoreapp3.1'
-    isLargeApp: false
+#- task: securedevelopmentteam.vss-secure-development-tools.build-task-apiscan.APIScan@2
+#  displayName: 'Run APIScan netcoreapp3.1'
+#  inputs:
+#    softwareFolder: '$(Build.StagingDirectory)\drop\raw\binaries\netcoreapp3.1'
+#    softwareName: 'API Port'
+#    softwareVersionNum: 4.XX
+#    symbolsFolder: '$(Build.StagingDirectory)\drop\raw\symbols\netcoreapp3.1'
+#    isLargeApp: false
 
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
   displayName: 'Publish Security Analysis Logs'

--- a/azure-pipelines/microbuild.after.yml
+++ b/azure-pipelines/microbuild.after.yml
@@ -45,14 +45,30 @@ steps:
     AnalyzeSymPath: $(Build.StagingDirectory)\symbols
   continueOnError: true
 
-#- task: securedevelopmentteam.vss-secure-development-tools.build-task-apiscan.APIScan@2
-#  displayName: 'Run APIScan netcoreapp3.1'
-#  inputs:
-#    softwareFolder: '$(Build.StagingDirectory)\drop\raw\binaries\netcoreapp3.1'
-#    softwareName: 'API Port'
-#    softwareVersionNum: 4.XX
-#    symbolsFolder: '$(Build.StagingDirectory)\drop\raw\symbols\netcoreapp3.1'
-#    isLargeApp: false
+  ### Copy files for APIScan
+- task: CopyFiles@2
+  displayName: 'Copy Files for APIScan'
+  inputs:
+    SourceFolder: '$(Build.StagingDirectory)\drop\raw\binaries\netcoreapp3.1'
+    Contents: |
+      **\apiport*.dll
+      **\apiport*.pdb
+      **\Microsoft.Fx.Portability*.dll
+      **\Microsoft.Fx.Portability*.pdb
+    TargetFolder: $(Agent.TempDirectory)\APIScanFiles
+  condition: and(succeeded(), ne(variables['DisableAPIScan'], 'true'))
+
+- task: APIScan@2
+  displayName: 'Run APIScan netcoreapp3.1'
+  inputs:
+    softwareFolder: '$(Agent.TempDirectory)\APIScanFiles'
+    softwareName: 'API Port'
+    softwareVersionNum: 4.XX
+    isLargeApp: false
+    toolVersion: 'Latest'
+  condition: and(succeeded(), ne(variables['DisableAPIScan'], 'true'))
+  env:
+    AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
 
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
   displayName: 'Publish Security Analysis Logs'


### PR DESCRIPTION
- Copy only APIPort binaries to a temp folder for scan to save build time.
- Add AzureServicesAuthConnectionString 