### PR TITLE
Deprecation and offline capability/guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # .NET API Portability
 
+> ***Note:** We're in the process of deprecating API Port in favor of integrating binary analysis directly into [.NET Upgrade Assistant](https://github.com/dotnet/upgrade-assistant). However, the functionality in Upgrade Assistant isn't fully there yet, so until then we still recommend API Port. In the upcoming months, we're going to shutdown the backend service of API Port which will require to use the tool in offline mode. The instructions to use API Port in offline mode can be found [here](docs/Console/README.md#run-the-tool-in-an-offline-mode).*
+
 This repository contains the source code for .NET Portability Analyzer tools and
 dependencies.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # .NET API Portability
 
-> ***Note:** We're in the process of deprecating API Port in favor of integrating binary analysis directly into [.NET Upgrade Assistant](https://github.com/dotnet/upgrade-assistant). However, the functionality in Upgrade Assistant isn't fully there yet, so until then we still recommend API Port. In the upcoming months, we're going to shutdown the backend service of API Port which will require to use the tool in offline mode. The instructions to use API Port in offline mode can be found [here](docs/Console/README.md#run-the-tool-in-an-offline-mode).*
+> ***Note:** We're in the process of deprecating API Port in favor of integrating binary analysis directly into [.NET Upgrade Assistant](https://github.com/dotnet/upgrade-assistant). In the upcoming months, we're going to shutdown the backend service of API Port which will require to use the tool in offline mode. The instructions to use API Port in offline mode can be found [here](docs/Console/README.md#run-the-tool-in-an-offline-mode).*
 
 This repository contains the source code for .NET Portability Analyzer tools and
 dependencies.


### PR DESCRIPTION
Including the catalog in the repo so offline execution is more affordable and doesn't require the backend service.
Adding deprecation notice to README.