### PR TITLE
Pivot VSIX to use offline mode

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputDrop>$(TF_BUILD_BINARIESDIRECTORY)</OutputDrop>
-    <NoWarn>$(NoWarn),1570,1572,1573,1574,1591,1701</NoWarn>
+    <NoWarn>$(NoWarn),1570,1572,1573,1574,1591,1701,MSB3275,VSTHRD010,VSTHRD100,VSTHRD101,VSSDK006</NoWarn>
     <Features>IOperation;$(Features)</Features>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\rules.ruleset</CodeAnalysisRuleSet>
     <WriteVersionInfoToBuildLog>True</WriteVersionInfoToBuildLog>
@@ -36,6 +36,7 @@
     our PRs because of the CI builds -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn)</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/ApiPort/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
+++ b/src/ApiPort/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
@@ -130,6 +130,14 @@
       <Project>{f3d148ca-d49d-4315-9cd6-ae7b0eea9549}</Project>
       <Name>Microsoft.Fx.Portability.Offline</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\lib\Microsoft.Fx.Portability.Reports.DGML\Microsoft.Fx.Portability.Reports.DGML.csproj">
+      <Project>{1b6e53a7-9180-4d79-9556-e5ce59483ea1}</Project>
+      <Name>Microsoft.Fx.Portability.Reports.DGML</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\lib\Microsoft.Fx.Portability.Reports.Excel\Microsoft.Fx.Portability.Reports.Excel.csproj">
+      <Project>{47008779-1d31-4e0c-b21a-5f4fb84470a0}</Project>
+      <Name>Microsoft.Fx.Portability.Reports.Excel</Name>
+    </ProjectReference>
     <ProjectReference Include="..\ApiPort.VisualStudio.Common\ApiPort.VisualStudio.Common.csproj">
       <Project>{60798b82-b273-4d39-aa52-021c7228a0ad}</Project>
       <Name>ApiPort.VisualStudio.Common</Name>

--- a/src/ApiPort/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
+++ b/src/ApiPort/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
@@ -65,7 +65,10 @@
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
     <PackageReference Include="Microsoft.Tpl.Dataflow" Version="4.5.24" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.4.27004" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.6.170" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.3.2092">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="VSLangProj140" Version="14.0.25030" />
     <PackageReference Include="VSLangProj150" Version="15.0.26229" />
   </ItemGroup>

--- a/src/ApiPort/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
+++ b/src/ApiPort/ApiPort.VisualStudio/ApiPort.VisualStudio.csproj
@@ -72,6 +72,7 @@
   <ItemGroup>
     <Compile Include="AssemblyRedirectResolver.cs" />
     <Compile Include="AutofacComRegisterExtensions.cs" />
+    <Compile Include="DependencyBuilder.Offline.cs" />
     <Compile Include="Properties\Properties.cs" />
     <Compile Include="Reporting\ToolbarListReportViewer.cs" />
     <Compile Include="StatusBarProgressReporter.cs" />
@@ -122,6 +123,10 @@
     <None Include="Resources\Images.png" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\lib\Microsoft.Fx.Portability.Offline\Microsoft.Fx.Portability.Offline.csproj">
+      <Project>{f3d148ca-d49d-4315-9cd6-ae7b0eea9549}</Project>
+      <Name>Microsoft.Fx.Portability.Offline</Name>
+    </ProjectReference>
     <ProjectReference Include="..\ApiPort.VisualStudio.Common\ApiPort.VisualStudio.Common.csproj">
       <Project>{60798b82-b273-4d39-aa52-021c7228a0ad}</Project>
       <Name>ApiPort.VisualStudio.Common</Name>

--- a/src/ApiPort/ApiPort.VisualStudio/DependencyBuilder.Offline.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/DependencyBuilder.Offline.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Autofac;
+
+using Microsoft.Fx.Portability;
+using Microsoft.Fx.Portability.Analysis;
+using Microsoft.Fx.Portability.Analyzer;
+using Microsoft.Fx.Portability.Reporting;
+
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace ApiPort
+{
+    internal static class DependencyBuilder
+    {
+        internal const string DefaultOutputFormatInstanceName = "DefaultOutputFormat";
+
+        public static void RegisterOfflineModule(this ContainerBuilder builder)
+        {
+            builder.RegisterType<DependencyOrderer>()
+                .As<IDependencyOrderer>()
+                .SingleInstance();
+
+            builder.RegisterType<RequestAnalyzer>()
+                .As<IRequestAnalyzer>()
+                .SingleInstance();
+
+            builder.RegisterType<AnalysisEngine>()
+                .As<IAnalysisEngine>()
+                .SingleInstance();
+
+            builder.RegisterModule(new OfflineDataModule(DefaultOutputFormatInstanceName));
+            LoadReportWriters(builder);
+        }
+
+        private static void LoadReportWriters(ContainerBuilder builder)
+        {
+            foreach (var path in Directory.EnumerateFiles(GetApplicationDirectory(), "Microsoft.Fx.Portability.Reports.*.dll"))
+            {
+                try
+                {
+                    var name = new AssemblyName(Path.GetFileNameWithoutExtension(path));
+                    var assembly = Assembly.Load(name);
+
+                    builder.RegisterAssemblyTypes(assembly)
+                        .AssignableTo<IReportWriter>()
+                        .As<IReportWriter>()
+                        .SingleInstance();
+                }
+                catch (Exception)
+                {
+                }
+            }
+        }
+
+        private static string GetApplicationDirectory()
+        {
+            return Path.GetDirectoryName(typeof(DependencyBuilder).GetTypeInfo().Assembly.Location);
+        }
+    }
+}

--- a/src/ApiPort/ApiPort.VisualStudio/ServiceProvider.cs
+++ b/src/ApiPort/ApiPort.VisualStudio/ServiceProvider.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using ApiPort;
+
 using ApiPortVS.Analyze;
 using ApiPortVS.Contracts;
 using ApiPortVS.Models;
@@ -9,8 +11,11 @@ using ApiPortVS.Resources;
 using ApiPortVS.SourceMapping;
 using ApiPortVS.ViewModels;
 using ApiPortVS.Views;
+
 using Autofac;
+
 using EnvDTE;
+
 using Microsoft.Fx.Portability;
 using Microsoft.Fx.Portability.Analyzer;
 using Microsoft.Fx.Portability.Proxy;
@@ -19,13 +24,12 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-
-using static Microsoft.VisualStudio.VSConstants;
 
 using Tasks = System.Threading.Tasks;
 
@@ -66,10 +70,9 @@ namespace ApiPortVS
             builder.RegisterType<VisualStudioProxyProvider>()
                 .As<IProxyProvider>()
                 .SingleInstance();
-            builder.RegisterType<ApiPortService>()
-                .As<IApiPortService>()
-                .WithParameter(TypedParameter.From(DefaultEndpoint))
-                .SingleInstance();
+
+            builder.RegisterOfflineModule();
+
             builder.RegisterType<ApiPortClient>()
                 .AsSelf()
                 .SingleInstance();

--- a/src/ApiPort/ApiPort.Vsix/ApiPort.Vsix.csproj
+++ b/src/ApiPort/ApiPort.Vsix/ApiPort.Vsix.csproj
@@ -61,7 +61,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK.VsixSuppression" Version="14.1.33" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.6.170" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.3.2092">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ApiPort.VisualStudio.2017\ApiPort.VisualStudio.2017.csproj">

--- a/src/ApiPort/ApiPort.Vsix/source.extension.vsixmanifest
+++ b/src/ApiPort/ApiPort.Vsix/source.extension.vsixmanifest
@@ -3,7 +3,11 @@
     <Metadata>
         <Identity Id="55d15546-28ca-40dc-af23-dfa503e9c5fe" Version="1.4.0" Language="en-US" Publisher="Microsoft" />
         <DisplayName>.NET Portability Analyzer</DisplayName>
-        <Description xml:space="preserve">Evaluates portability of assemblies across .NET platforms</Description>
+        <Description xml:space="preserve">Evaluates portability of assemblies across .NET platforms
+
+[IMPORTANT]
+Due to an ongoing issue, this update is required to continue using Portability Analysis within Visual Studio while Engineering investigates.
+This version will execute in offline mode which removes capability for HTML report output and runs the entire analysis in-memory.</Description>
         <MoreInfo>https://aka.ms/dotnet-portabilityanalyzer</MoreInfo>
         <License>LICENSE.txt</License>
         <Icon>Resources\Package.ico</Icon>

--- a/src/ApiPort/ApiPort/ApiPort.props
+++ b/src/ApiPort/ApiPort/ApiPort.props
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e171125-2" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/src/lib/Microsoft.Fx.Portability.Reports.DGML/ReferenceGraph.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.DGML/ReferenceGraph.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Fx.Portability.Reports.DGML
                 }
 
                 // create nodes for all the references, if non platform.
-                if (userAsem.AssemblyReferences is not null)
+                if (userAsem.AssemblyReferences != null)
                 {
                     foreach (var reference in userAsem.AssemblyReferences)
                     {

--- a/src/lib/Microsoft.Fx.Portability.Reports.DGML/ReferenceGraph.cs
+++ b/src/lib/Microsoft.Fx.Portability.Reports.DGML/ReferenceGraph.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Fx.Portability.ObjectModel;
+
 using System.Collections.Generic;
 using System.Linq;
 
@@ -33,20 +34,23 @@ namespace Microsoft.Fx.Portability.Reports.DGML
                 }
 
                 // create nodes for all the references, if non platform.
-                foreach (var reference in userAsem.AssemblyReferences)
+                if (userAsem.AssemblyReferences is not null)
                 {
-                    if (!(assembliesWithData.ContainsKey(reference.ToString()) || unresolvedAssemblies.Contains(reference.ToString())))
+                    foreach (var reference in userAsem.AssemblyReferences)
                     {
-                        // platform reference (not in the user specified asssemblies and not an unresolved assembly.
-                        continue;
+                        if (!(assembliesWithData.ContainsKey(reference.ToString()) || unresolvedAssemblies.Contains(reference.ToString())))
+                        {
+                            // platform reference (not in the user specified asssemblies and not an unresolved assembly.
+                            continue;
+                        }
+
+                        var refNode = rg.GetOrAddNodeForAssembly(new ReferenceNode(reference.ToString()));
+
+                        // if the reference is missing, flag it as such.
+                        refNode.IsMissing = unresolvedAssemblies.Contains(reference.ToString());
+
+                        node.AddReferenceToNode(refNode);
                     }
-
-                    var refNode = rg.GetOrAddNodeForAssembly(new ReferenceNode(reference.ToString()));
-
-                    // if the reference is missing, flag it as such.
-                    refNode.IsMissing = unresolvedAssemblies.Contains(reference.ToString());
-
-                    node.AddReferenceToNode(refNode);
                 }
             }
 

--- a/src/lib/Microsoft.Fx.Portability.Reports.Json/Microsoft.Fx.Portability.Reports.Json.csproj
+++ b/src/lib/Microsoft.Fx.Portability.Reports.Json/Microsoft.Fx.Portability.Reports.Json.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/lib/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
+++ b/src/lib/Microsoft.Fx.Portability/Microsoft.Fx.Portability.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />

--- a/tests/ApiPort/ApiPortVS.Tests/ApiPortVS.Tests.csproj
+++ b/tests/ApiPort/ApiPortVS.Tests/ApiPortVS.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/tests/lib/Microsoft.Fx.Portability.Cci.Tests/Microsoft.Fx.Portability.Cci.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.Cci.Tests/Microsoft.Fx.Portability.Cci.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.MetadataReader.Tests/Microsoft.Fx.Portability.MetadataReader.Tests.csproj
@@ -24,7 +24,7 @@
     <!--Reference to Microsoft.NETCore.Platforms to workaround https://github.com/dotnet/cli/issues/12341. Remove the reference once build machine moves to .NET Core 3.0-->
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="3.0.0" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="System.Diagnostics.FileVersionInfo " Version="4.3.0" />

--- a/tests/lib/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
+++ b/tests/lib/Microsoft.Fx.Portability.Tests/Microsoft.Fx.Portability.Tests.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="System.Diagnostics.FileVersionInfo " Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
In line w/ [our plans for deprecation](https://github.com/microsoft/dotnet-apiport#net-api-portability), the VSIX needs to utilize offline mode for its execution instead of talking to the backend service.

closes #1019 
closes #1020 